### PR TITLE
fix: show all software updates instead of only 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Software Versions**: Show all software updates instead of only the first 100
+
 ## [0.6.1] - 2025-12-22
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/data/api/TeslamateApi.kt
+++ b/app/src/main/java/com/matedroid/data/api/TeslamateApi.kt
@@ -69,6 +69,8 @@ interface TeslamateApi {
 
     @GET("api/v1/cars/{carId}/updates")
     suspend fun getUpdates(
-        @Path("carId") carId: Int
+        @Path("carId") carId: Int,
+        @Query("page") page: Int? = null,
+        @Query("show") show: Int? = null
     ): Response<UpdatesResponse>
 }

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -187,7 +187,7 @@ class TeslamateRepository @Inject constructor(
     suspend fun getUpdates(carId: Int): ApiResult<List<UpdateData>> {
         return try {
             val api = getApi() ?: return ApiResult.Error("Server not configured")
-            val response = api.getUpdates(carId)
+            val response = api.getUpdates(carId, page = 1, show = 50000)
             if (response.isSuccessful) {
                 val updates = response.body()?.data?.updates ?: emptyList()
                 ApiResult.Success(updates)


### PR DESCRIPTION
## Summary
- Adds `page` and `show` pagination parameters to the updates API endpoint
- Passes `show=50000` to fetch all updates (matching the pattern used for charges and drives)
- Fixes the 100-update limit caused by TeslaMateAPI's default pagination

## Root Cause
The TeslaMateAPI `/api/v1/cars/{id}/updates` endpoint supports pagination with:
- `page` parameter (default: 1)
- `show` parameter (default: **100**)

The app was not passing these parameters, so users with more than 100 software updates could only see the first 100.

## Test plan
- [ ] User with >100 software updates confirms all updates now appear
- [ ] Verify the Software Versions screen loads correctly
- [ ] Check that filtering and statistics work with the full dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)