### PR TITLE
feat: add release notes link to software version cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Software Versions**: Tap the external link icon next to any version to view release notes on NotATeslaApp
+
 ### Fixed
 - **Software Versions**: Show all software updates instead of only the first 100
 

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.Timer
@@ -49,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -413,6 +415,8 @@ private fun SoftwareVersionCard(
     palette: CarColorPalette
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
+    val uriHandler = LocalUriHandler.current
+    val releaseNotesUrl = "https://www.notateslaapp.com/software-updates/version/${update.version}/release-notes"
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -435,7 +439,8 @@ private fun SoftwareVersionCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Row(
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f)
                 ) {
                     Icon(
                         imageVector = Icons.Default.SystemUpdate,
@@ -445,12 +450,26 @@ private fun SoftwareVersionCard(
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     Column {
-                        Text(
-                            text = update.version,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = if (update.isCurrent) palette.onSurface else MaterialTheme.colorScheme.onSurface
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = update.version,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = if (update.isCurrent) palette.onSurface else MaterialTheme.colorScheme.onSurface
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            IconButton(
+                                onClick = { uriHandler.openUri(releaseNotesUrl) },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                                    contentDescription = "View release notes",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = if (update.isCurrent) palette.accent.copy(alpha = 0.7f) else MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                                )
+                            }
+                        }
                         if (update.isCurrent) {
                             Text(
                                 text = "Current version",


### PR DESCRIPTION
## Summary
- Adds an external link icon (↗) next to each software version number
- Tapping the icon opens NotATeslaApp release notes for that version
- URL pattern: `https://www.notateslaapp.com/software-updates/version/{version}/release-notes`

## Test plan
- [x] Tap the external link icon on any software version card
- [x] Verify it opens the correct NotATeslaApp release notes page in browser
- [x] Check the icon is visible and appropriately styled for both current and past versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)