### PR TITLE
fix: resolve race condition in dashboard counts display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Software Versions**: Tap the external link icon next to any version to view release notes on NotATeslaApp
 
 ### Fixed
+- **Dashboard**: Fix race condition where drive/charge counts could fail to display for users with large datasets
 - **Software Versions**: Show all software updates instead of only the first 100
 
 ## [0.6.1] - 2025-12-22


### PR DESCRIPTION
## Summary
Fixes a race condition in `DashboardViewModel` that caused drive/charge counts to intermittently fail to display, especially for users with large datasets.

## Root Cause
The ViewModel was using non-atomic state updates:
```kotlin
_uiState.value = _uiState.value.copy(totalCharges = x)
```

When `loadCounts()` launches two parallel coroutines (one for charges, one for drives), both could:
1. Read the same state snapshot (both see `totalCharges=null, totalDrives=null`)
2. Perform async API calls
3. Write back with `.copy()` - the second write overwrites the first's changes

With large datasets, the API calls take longer, widening the race window and making this bug more likely to occur.

## Fix
Replaced all `_uiState.value = _uiState.value.copy(...)` with `_uiState.update { it.copy(...) }` throughout the ViewModel. The `update` function provides atomic state updates that properly handle concurrent modifications.

## Test plan
- [ ] User with many drives/charges confirms both counts now appear on dashboard
- [ ] Pull-to-refresh still works correctly
- [ ] Switching between multiple cars updates counts properly
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)