### PR TITLE
fix: round mileage totals to whole numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Software Versions**: Tap the external link icon next to any version to view release notes on NotATeslaApp
 
+### Changed
+- **Mileage**: Round Total and Avg/Year values to whole numbers for cleaner display
+
 ### Fixed
 - **Software Versions**: Show all software updates instead of only the first 100
 

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -744,7 +744,7 @@ private fun SummaryRow(
         ) {
             SummaryItem(
                 icon = Icons.Outlined.AllInclusive,
-                value = "%.1f km".format(totalDistance),
+                value = "%.0f km".format(totalDistance),
                 label = "Total",
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -752,7 +752,7 @@ private fun SummaryRow(
             )
             SummaryItem(
                 icon = Icons.Filled.Speed,
-                value = "%.1f km".format(avgDistance),
+                value = "%.0f km".format(avgDistance),
                 label = avgLabel,
                 iconColor = iconColor,
                 valueColor = valueColor,


### PR DESCRIPTION
## Summary
Removes unnecessary decimal precision from Total and Avg/Year mileage values in the Mileage screen.

Before: `12345.7 km`
After: `12346 km`

Closes #4

## Test plan
- [x] Verify Total mileage shows as whole number
- [x] Verify Avg/Year shows as whole number

🤖 Generated with [Claude Code](https://claude.com/claude-code)