### PR TITLE
feat: add navigation arrow hints to mileage cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Software Versions**: Tap the external link icon next to any version to view release notes on NotATeslaApp
 
 ### Changed
-- **Mileage**: Round Total and Avg/Year values to whole numbers for cleaner display
+- **Mileage**: Round all distance values to whole numbers for cleaner display (Total, Avg/Year, year cards, month cards)
+- **Mileage**: Add arrow icon to year and month cards to indicate they are navigable
 
 ### Fixed
 - **Software Versions**: Show all software updates instead of only the first 100

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.ElectricBolt
@@ -320,7 +321,7 @@ private fun YearRow(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "%.1f km".format(yearData.totalDistance),
+                        text = "%.0f km".format(yearData.totalDistance),
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -338,6 +339,13 @@ private fun YearRow(
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
+
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = "View details",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp)
+                )
             }
         }
     }
@@ -517,7 +525,7 @@ private fun MonthRow(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "%.1f km".format(monthData.totalDistance),
+                        text = "%.0f km".format(monthData.totalDistance),
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -535,6 +543,13 @@ private fun MonthRow(
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
+
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = "View details",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp)
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add right arrow icon to year cards in the Mileage screen to indicate they navigate to monthly details
- Add right arrow icon to month cards to indicate they navigate to daily details

This improves discoverability by making it clearer that these cards are tappable and lead to more detailed views.

## Test plan
- [ ] Open Mileage screen
- [ ] Verify year cards show arrow icon on the right
- [ ] Tap a year card to navigate to monthly view
- [ ] Verify month cards show arrow icon on the right
- [ ] Tap a month card to navigate to daily view

🤖 Generated with [Claude Code](https://claude.com/claude-code)