### PR TITLE
feat(drives): add distance filter for drives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Software Versions**: Tap the external link icon next to any version to view release notes on NotATeslaApp
+- **Drives**: Filter drives by distance - Commute (< 10 km), Day trip (10-100 km), Road trip (> 100 km). Labels adapt to metric/imperial units.
 
 ### Changed
 - **Mileage**: Round all distance values to whole numbers for cleaner display (Total, Avg/Year, year cards, month cards)

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.matedroid.data.api.models.DriveData
+import com.matedroid.data.api.models.Units
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.InteractiveBarChart
 import com.matedroid.ui.theme.CarColorPalette
@@ -154,9 +155,12 @@ fun DrivesScreen(
                     chartData = uiState.chartData,
                     chartGranularity = uiState.chartGranularity,
                     summary = uiState.summary,
-                    selectedFilter = selectedFilter,
+                    selectedDateFilter = selectedFilter,
+                    selectedDistanceFilter = uiState.distanceFilter,
+                    units = uiState.units,
                     palette = palette,
-                    onFilterSelected = { applyDateFilter(it) },
+                    onDateFilterSelected = { applyDateFilter(it) },
+                    onDistanceFilterSelected = { viewModel.setDistanceFilter(it) },
                     onDriveClick = onNavigateToDriveDetail
                 )
             }
@@ -171,9 +175,12 @@ private fun DrivesContent(
     chartData: List<DriveChartData>,
     chartGranularity: DriveChartGranularity,
     summary: DrivesSummary,
-    selectedFilter: DriveDateFilter,
+    selectedDateFilter: DriveDateFilter,
+    selectedDistanceFilter: DriveDistanceFilter,
+    units: Units?,
     palette: CarColorPalette,
-    onFilterSelected: (DriveDateFilter) -> Unit,
+    onDateFilterSelected: (DriveDateFilter) -> Unit,
+    onDistanceFilterSelected: (DriveDistanceFilter) -> Unit,
     onDriveClick: (driveId: Int) -> Unit
 ) {
     LazyColumn(
@@ -183,9 +190,18 @@ private fun DrivesContent(
     ) {
         item {
             DateFilterChips(
-                selectedFilter = selectedFilter,
+                selectedFilter = selectedDateFilter,
                 palette = palette,
-                onFilterSelected = onFilterSelected
+                onFilterSelected = onDateFilterSelected
+            )
+        }
+
+        item {
+            DistanceFilterChips(
+                selectedFilter = selectedDistanceFilter,
+                units = units,
+                palette = palette,
+                onFilterSelected = onDistanceFilterSelected
             )
         }
 
@@ -257,6 +273,31 @@ private fun DateFilterChips(
                 selected = filter == selectedFilter,
                 onClick = { onFilterSelected(filter) },
                 label = { Text(filter.label) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = palette.surface,
+                    selectedLabelColor = palette.onSurface
+                )
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DistanceFilterChips(
+    selectedFilter: DriveDistanceFilter,
+    units: Units?,
+    palette: CarColorPalette,
+    onFilterSelected: (DriveDistanceFilter) -> Unit
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(DriveDistanceFilter.entries.toList()) { filter ->
+            FilterChip(
+                selected = filter == selectedFilter,
+                onClick = { onFilterSelected(filter) },
+                label = { Text(filter.getLabel(units)) },
                 colors = FilterChipDefaults.filterChipColors(
                     selectedContainerColor = palette.surface,
                     selectedLabelColor = palette.onSurface


### PR DESCRIPTION
## Summary
- Add a new filter row in Drives screen to filter by drive length
- Three filter options:
  - **Commute** (< 10 km / 6 mi) - short trips
  - **Day trip** (10-100 km / 6-60 mi) - medium range drives
  - **Road trip** (> 100 km / 60 mi) - long journeys
- Filter labels automatically adapt to user's metric/imperial unit setting
- "All" option to show all drives (default)

## Test plan
- [ ] Open Drives screen
- [ ] Verify distance filter row appears below date filter
- [ ] Test each filter option shows correct subset of drives
- [ ] Verify filter labels show km for metric users, mi for imperial users
- [ ] Combine with date filter to verify both work together

🤖 Generated with [Claude Code](https://claude.com/claude-code)