### PR TITLE
fix(dashboard): use API counts for drives/charges totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dashboard**: Use pre-computed drive/charge counts from API instead of fetching all records
+
 ## [0.7.0] - 2025-12-24
 
 ### Added

--- a/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
+++ b/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
@@ -18,13 +18,20 @@ data class CarData(
     @Json(name = "car_id") val carId: Int,
     @Json(name = "name") val name: String? = null,
     @Json(name = "car_details") val carDetails: CarDetails? = null,
-    @Json(name = "car_exterior") val carExterior: CarExterior? = null
+    @Json(name = "car_exterior") val carExterior: CarExterior? = null,
+    @Json(name = "teslamate_stats") val teslamateStats: TeslamateStats? = null
 ) {
     val displayName: String
         get() = name?.takeIf { it.isNotBlank() }
             ?: carDetails?.model?.let { "Model $it" }
             ?: "Tesla"
 }
+
+@JsonClass(generateAdapter = true)
+data class TeslamateStats(
+    @Json(name = "total_charges") val totalCharges: Int? = null,
+    @Json(name = "total_drives") val totalDrives: Int? = null
+)
 
 @JsonClass(generateAdapter = true)
 data class CarExterior(

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -170,23 +170,13 @@ class DashboardViewModel @Inject constructor(
     }
 
     private fun loadCounts(carId: Int) {
-        viewModelScope.launch {
-            // Load charges count
-            when (val result = repository.getCharges(carId, null, null)) {
-                is ApiResult.Success -> {
-                    _uiState.update { it.copy(totalCharges = result.data.size) }
-                }
-                is ApiResult.Error -> { /* ignore */ }
-            }
-        }
-        viewModelScope.launch {
-            // Load drives count
-            when (val result = repository.getDrives(carId, null, null)) {
-                is ApiResult.Success -> {
-                    _uiState.update { it.copy(totalDrives = result.data.size) }
-                }
-                is ApiResult.Error -> { /* ignore */ }
-            }
+        // Use counts from the cars API response instead of fetching all drives/charges
+        val selectedCar = _uiState.value.cars.find { it.carId == carId }
+        _uiState.update {
+            it.copy(
+                totalCharges = selectedCar?.teslamateStats?.totalCharges,
+                totalDrives = selectedCar?.teslamateStats?.totalDrives
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
Use `total_charges` and `total_drives` fields from the `/api/v1/cars` endpoint instead of fetching and counting all individual drives/charges.

## Changes
- Added `total_charges` and `total_drives` fields to `CarData` model
- Updated `DashboardViewModel.loadCounts()` to use these pre-computed values from the API

## Benefits
- More efficient - no need to fetch all records just to count them
- Faster dashboard loading, especially for users with many drives/charges
- Avoids potential issues with large datasets

## Test plan
- [ ] Open dashboard
- [ ] Verify drive/charge counts display correctly
- [ ] Compare counts with values shown on Drives/Charges screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)