### PR TITLE
fix(mileage): calculate avg/year using actual elapsed time since first drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Background sync of drive/charge details for Deep Stats computation
 - **Charges**: Tap the Cost card to edit the charge cost directly in Teslamate (requires Teslamate Base URL in Settings)
 - **Settings**: New "Teslamate Settings" section with Base URL for direct Teslamate integration
+- **Mileage**: Info icon next to "Avg/Year" explaining how the calculation works
+
+### Fixed
+- **Mileage**: Fixed incorrect Avg/Year calculation that counted calendar years instead of actual elapsed time since first drive (fixes #10)
 
 ## [0.7.1] - 2025-12-25
 


### PR DESCRIPTION
## Summary

Fixes #10 - The Avg/Year calculation was incorrectly counting calendar years instead of actual elapsed time.

**Before:** A car registered in November 2023 with 44,000 km would show:
- 2023, 2024, 2025, 2026 = 4 calendar years
- 44,000 / 4 = **11,000 km/year** (incorrect)

**After:** Using actual elapsed time (~2.17 years from Nov 2023 to Jan 2026):
- (44,000 / 791 days) × 365 = **~20,300 km/year** (correct)

### Changes

1. **MileageViewModel.kt**: 
   - Find the earliest drive date from recorded drives
   - Calculate `avgYearlyDistance = (totalDistance / daysSinceFirstDrive) × 365`
   - Store `firstDriveDate` in UI state for display

2. **MileageScreen.kt**:
   - Add info icon (i) next to "Avg/Year" label
   - Tapping shows a dialog explaining the calculation method and first drive date

## Test plan

- [x] Build and install on device
- [x] Open Mileage screen and verify Avg/Year shows correct value
- [x] Tap the info icon next to Avg/Year and verify dialog appears
- [x] Dialog should show first drive date and days since then

🤖 Generated with [Claude Code](https://claude.com/claude-code)