### PR TITLE
feat: show total kWh instead of charge count in histograms

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -606,9 +606,9 @@ private fun ChargesChart(
     palette: CarColorPalette
 ) {
     val title = when (granularity) {
-        ChartGranularity.DAILY -> "Charges per Day"
-        ChartGranularity.WEEKLY -> "Charges per Week"
-        ChartGranularity.MONTHLY -> "Charges per Month"
+        ChartGranularity.DAILY -> "Energy per Day"
+        ChartGranularity.WEEKLY -> "Energy per Week"
+        ChartGranularity.MONTHLY -> "Energy per Month"
     }
 
     Card(
@@ -641,8 +641,8 @@ private fun ChargesChart(
             val barData = chartData.map { data ->
                 BarChartData(
                     label = data.label,
-                    value = data.count.toDouble(),
-                    displayValue = "${data.count} charges"
+                    value = data.totalEnergy,
+                    displayValue = "%.1f kWh".format(data.totalEnergy)
                 )
             }
 
@@ -655,7 +655,7 @@ private fun ChargesChart(
                 barColor = palette.accent,
                 labelColor = palette.onSurfaceVariant,
                 showEveryNthLabel = labelInterval,
-                valueFormatter = { "%.0f charges".format(it) }
+                valueFormatter = { "%.1f kWh".format(it) }
             )
         }
     }


### PR DESCRIPTION
## Summary
- Changed the charges screen histograms to display **total energy charged (kWh)** per day/week/month instead of the number of charging sessions
- Updated chart titles from "Charges per Day/Week/Month" to "Energy per Day/Week/Month"
- Updated value formatting from "X charges" to "X.X kWh"

## Rationale
This is more useful for users with smart charging systems (like Octopus) that optimize electricity costs by splitting charging into multiple partial sessions. Showing total kWh charged per period gives a clearer picture of actual energy consumption.

Fixes #18

## Test plan
- [ ] Open the Charges screen
- [ ] Verify the histogram chart titles now say "Energy per Day/Week/Month"
- [ ] Verify the bars represent total kWh charged (not count)
- [ ] Tap on bars to see tooltip showing "X.X kWh" format
- [ ] Test different date filters (7 days, 30 days, 90 days, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)