### PR TITLE
chore: remove unnecessary moshi-kotlin reflection dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,7 +109,6 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
     implementation(libs.moshi)
-    implementation(libs.moshi.kotlin)
     ksp(libs.moshi.codegen)
 
     // DataStore

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -5,7 +5,6 @@ import com.matedroid.data.api.NominatimApi
 import com.matedroid.data.api.TeslamateApi
 import com.matedroid.data.local.SettingsDataStore
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -32,7 +31,6 @@ object NetworkModule {
     @Singleton
     fun provideMoshi(): Moshi {
         return Moshi.Builder()
-            .addLast(KotlinJsonAdapterFactory())
             .build()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,6 @@ retrofit-converter-moshi = { group = "com.squareup.retrofit2", name = "converter
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
-moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 moshi-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 
 # DataStore


### PR DESCRIPTION
## Summary
- Remove `moshi-kotlin` reflection-based adapter since the project uses KSP code generation
- Remove `KotlinJsonAdapterFactory()` from Moshi builder (no longer needed with codegen)
- Clean up unused dependency from version catalog

## Benefits
- Smaller APK size (no reflection library bundled)
- Faster JSON parsing (generated code vs runtime reflection)
- Cleaner dependency tree

## Note
The Moshi kapt deprecation warning during `hiltJavaCompileDebug` is a [known Hilt bug](https://github.com/square/moshi/discussions/1752) where Hilt incorrectly loads KSP dependencies into its APT classpath. This warning will persist until Hilt fixes it or Moshi 2.0 removes kapt support entirely.

🤖 Generated with [Claude Code](https://claude.ai/code)