### PR TITLE
fix(dashboard): don't double-convert tire pressure when unit is PSI

### DIFF
--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -11,7 +11,6 @@ object UnitFormatter {
     // Conversion constants
     private const val KM_TO_MI = 0.621371
     private const val MI_TO_KM = 1.60934
-    private const val BAR_TO_PSI = 14.5038
     private const val WH_PER_KM_TO_WH_PER_MI = 1.60934
 
     /**
@@ -75,15 +74,13 @@ object UnitFormatter {
     }
 
     /**
-     * Format pressure value with appropriate unit label
+     * Format pressure value with appropriate unit label.
+     * Note: TeslamateAPI returns pressure already in the user's preferred unit,
+     * so no conversion is needed - just format and add the label.
      */
-    fun formatPressure(bar: Double, units: Units?, decimals: Int = 1): String {
-        return if (units?.unitOfPressure == "psi") {
-            val psi = bar * BAR_TO_PSI
-            "%.${decimals}f psi".format(psi)
-        } else {
-            "%.${decimals}f bar".format(bar)
-        }
+    fun formatPressure(value: Double, units: Units?, decimals: Int = 1): String {
+        val unit = if (units?.unitOfPressure == "psi") "psi" else "bar"
+        return "%.${decimals}f %s".format(value, unit)
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes tire pressure showing ~610 PSI instead of the correct ~42 PSI

## Root Cause Analysis
The `formatPressure()` function assumed input was **always in bar** and converted to PSI when needed:

```kotlin
fun formatPressure(bar: Double, units: Units?, decimals: Int = 1): String {
    return if (units?.unitOfPressure == "psi") {
        val psi = bar * BAR_TO_PSI  // Multiplies by 14.5!
        ...
    }
}
```

But **TeslamateAPI returns pressure already in the user's preferred unit**. When the user has PSI configured, the API returns `42.06` (PSI), not `2.9` (bar). The function was incorrectly multiplying by 14.5, resulting in `42 × 14.5 = 610 PSI`.

## The Fix
Remove the conversion since the API already returns values in the correct unit:

```kotlin
fun formatPressure(value: Double, units: Units?, decimals: Int = 1): String {
    val unit = if (units?.unitOfPressure == "psi") "psi" else "bar"
    return "%.${decimals}f %s".format(value, unit)
}
```

Fixes #46

## Test plan
- [ ] Configure TeslamateAPI with `unit_of_pressure: "psi"`
- [ ] Verify tire pressure displays correctly (~30-45 PSI for normal tires)
- [ ] Configure TeslamateAPI with `unit_of_pressure: "bar"` 
- [ ] Verify tire pressure displays correctly (~2.0-3.1 bar for normal tires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)