### PR TITLE
fix(settings): Force Full Resync now properly clears all cached data

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -52,9 +52,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -456,11 +460,25 @@ private fun SettingsContent(
         if (showResyncConfirmDialog) {
             AlertDialog(
                 onDismissRequest = { showResyncConfirmDialog = false },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = StatusWarning,
+                        modifier = Modifier.size(32.dp)
+                    )
+                },
                 title = { Text("Force Full Resync?") },
                 text = {
                     Text(
-                        "This will reset the sync progress and re-download all drive and charge details from the server.\n\n" +
-                        "The process may take several minutes depending on how much data you have."
+                        buildAnnotatedString {
+                            append("This will ")
+                            withStyle(SpanStyle(color = StatusError, fontWeight = FontWeight.Bold)) {
+                                append("DELETE")
+                            }
+                            append(" all cached drives, charges, and statistics, then re-download everything from the server.\n\n")
+                            append("The process may take several minutes depending on how much data you have.")
+                        }
                     )
                 },
                 confirmButton = {

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -208,17 +208,17 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isResyncing = true, error = null)
             try {
-                // Get all cars and reset sync for each
+                // Get all cars and do a full reset (delete all cached data) for each
                 when (val result = repository.getCars()) {
                     is ApiResult.Success -> {
                         for (car in result.data) {
-                            syncManager.resetSync(car.carId)
+                            syncManager.fullResetSync(car.carId)
                         }
                         // Trigger immediate sync via WorkManager
                         triggerImmediateSync()
                         _uiState.value = _uiState.value.copy(
                             isResyncing = false,
-                            successMessage = "Resync started. Check the Stats screen for progress."
+                            successMessage = "Full resync started. All cached data cleared. Check the Stats screen for progress."
                         )
                     }
                     is ApiResult.Error -> {


### PR DESCRIPTION
## Summary

- Fix Force Full Resync button to actually delete all cached data before resyncing
- The previous implementation only reset sync state flags, causing it to retry missing items instead of fetching everything fresh
- Add warning icon and red "DELETE" text to the confirmation dialog to make the destructive nature clear

## Problem

The "Force Full Resync" button in Settings was not actually forcing a full resync. It only called `syncManager.resetSync(carId)` which resets sync state flags (`summariesSynced`, `detailsSynced`, etc.) but does **not** delete the cached data from:
- `drives_summary` table
- `charges_summary` table
- `drive_detail_aggregates` table
- `charge_detail_aggregates` table

As a result, when syncing resumed, it would only process items that were unprocessed or had outdated schema versions - not refetch everything from scratch.

## Solution

- Added `AggregateDao` to `SyncManager`
- Created new `fullResetSync()` method that:
  1. Deletes all cached drives for the car
  2. Deletes all cached charges for the car
  3. Deletes all drive detail aggregates for the car
  4. Deletes all charge detail aggregates for the car
  5. Resets sync state flags
- Updated `SettingsViewModel.forceResync()` to call `fullResetSync()` instead of `resetSync()`
- Improved confirmation dialog with warning icon and red "DELETE" text

## Test plan

- [ ] Tap "Force Full Resync" button
- [ ] Verify the confirmation dialog shows warning icon and red "DELETE" text
- [ ] Confirm the resync
- [ ] Verify all data is cleared (stats show as empty/syncing)
- [ ] Wait for sync to complete
- [ ] Verify all data is restored from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)