### PR TITLE
fix(drives): preserve filters and scroll position on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Over 150 km: shows weather every 35 km
   - Weather icons for: Clear, Partly Cloudy, Fog, Drizzle, Rain, Snow, Thunderstorm
 
+### Fixed
+- **Drives**: Date and distance filters now persist when navigating to drive details and back
+- **Drives**: Scroll position is now preserved when returning from drive details
+
 ## [0.9.4] - 2026-01-14
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fixes issue where date and distance filters were reset to defaults when navigating back from drive details
- Preserves scroll position in the drives list when returning from drive details

## Root Cause
The date filter state was stored locally in the composable with `remember { mutableStateOf() }`, which gets reset when the composable is destroyed. Additionally, `LaunchedEffect(carId)` always applied the default 7-day filter on every load.

## Changes
- Moved `DriveDateFilter` enum from `DrivesScreen.kt` to `DrivesViewModel.kt`
- Added `dateFilter`, `scrollPosition`, and `scrollOffset` to `DrivesUiState`
- Added `isInitialized` flag in ViewModel to only apply default filter on first load
- Added `saveScrollPosition()` function to persist scroll state
- Updated `DrivesScreen` to use `rememberLazyListState()` with ViewModel's saved position
- Removed local filter state from composable

## Test plan
- [x] Open Drives screen - default is "Last 7 days"
- [x] Change date filter to "Last 90 days" and distance filter to "Road trip"
- [x] Scroll down to a drive and tap to open details
- [x] Press back arrow to return to drives list
- [x] Verify filters are still "Last 90 days" and "Road trip"
- [x] Verify scroll position is preserved (same drive visible)
- [x] Repeat test with different filter combinations


🤖 Generated with [Claude Code](https://claude.com/claude-code)