### PR TITLE
Add F-Droid badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MateDroid
 
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/com.matedroid/)
+
 A native Android application for viewing Tesla vehicle data from your self-hosted [Teslamate](https://github.com/adriankumpf/teslamate) instance via the [TeslamateApi](https://github.com/tobiasehlert/teslamateapi).
 
 **DISCLAIMER**: This app has been *vibe-coded*


### PR DESCRIPTION
## Summary
- Add "Get it on F-Droid" badge at the top of README
- Links to the F-Droid package page: https://f-droid.org/packages/com.matedroid/

Closes #25