### PR TITLE
feat: show sleep duration and bedtime icon when car is asleep

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -690,14 +690,25 @@ private fun formatDurationSince(isoTimestamp: String?): String? {
 }
 
 /**
- * Formats an ISO timestamp to local time as "HH:mm"
+ * Formats an ISO timestamp to a human-readable format:
+ * - Today: "HH:mm"
+ * - Yesterday: "yesterday HH:mm"
+ * - Older: "DD/MM HH:mm"
  */
-private fun formatTimeFromTimestamp(isoTimestamp: String?): String? {
+private fun formatTimeFromTimestamp(isoTimestamp: String?, yesterdayStr: String): String? {
     if (isoTimestamp == null) return null
     return try {
         val dateTime = java.time.OffsetDateTime.parse(isoTimestamp)
-        val localTime = dateTime.toLocalTime()
-        String.format("%02d:%02d", localTime.hour, localTime.minute)
+        val localDateTime = dateTime.toLocalDateTime()
+        val today = java.time.LocalDate.now()
+        val yesterday = today.minusDays(1)
+        val timeStr = String.format("%02d:%02d", localDateTime.hour, localDateTime.minute)
+
+        when (localDateTime.toLocalDate()) {
+            today -> timeStr
+            yesterday -> "$yesterdayStr $timeStr"
+            else -> String.format("%02d/%02d %s", localDateTime.dayOfMonth, localDateTime.monthValue, timeStr)
+        }
     } catch (e: Exception) {
         null
     }
@@ -729,8 +740,9 @@ private fun StatusIndicatorsRow(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // State icon - bedtime when asleep, power icon otherwise
+                val yesterdayStr = stringResource(R.string.yesterday)
                 val stateTooltip = if (isAsleep) {
-                    val sleepTime = formatTimeFromTimestamp(status.stateSince)
+                    val sleepTime = formatTimeFromTimestamp(status.stateSince, yesterdayStr)
                     if (sleepTime != null) {
                         stringResource(R.string.asleep_since, sleepTime)
                     } else {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -75,6 +75,9 @@
     <!-- Tooltip shown when car is asleep, %s is the time when it went to sleep -->
     <string name="asleep_since">Adormit des de %s</string>
 
+    <!-- Word for yesterday used in timestamps -->
+    <string name="yesterday">ahir</string>
+
     <!-- Content description for the car image, indicates it's tappable -->
     <string name="car_image_tap_for_stats">Imatge del cotxe - toca per estadístiques</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,9 @@
     <!-- Tooltip shown when car is asleep, %s is the time when it went to sleep -->
     <string name="asleep_since">Asleep since %s</string>
 
+    <!-- Word for yesterday used in timestamps -->
+    <string name="yesterday">yesterday</string>
+
     <!-- Content description for the car image, indicates it's tappable -->
     <string name="car_image_tap_for_stats">Car image - tap for stats</string>
 


### PR DESCRIPTION
## Summary
- Show bedtime/moon icon instead of power icon when car is asleep
- Display duration since car went to sleep (e.g., "45m" or "2h 15m")
- Tooltip shows "Asleep since HH:mm" with smart date handling:
  - Today: "Asleep since 21:09"
  - Yesterday: "Asleep since yesterday 21:09"
  - Older: "Asleep since 15/01 21:09"

## Test plan
- [ ] Verify bedtime icon shows when car state is "asleep" or "suspended"
- [ ] Verify duration text appears below status row
- [ ] Verify tooltip shows correct time format based on date

🤖 Generated with [Claude Code](https://claude.com/claude-code)