### PR TITLE
fix: show total battery consumed instead of average per drive

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -686,7 +686,7 @@ private fun MonthSummaryCard(
     val totalDistance = monthData?.totalDistance ?: 0.0
     val driveCount = monthData?.driveCount ?: 0
     val avgDistance = if (driveCount > 0) totalDistance / driveCount else 0.0
-    val avgBatteryUsage = monthData?.avgBatteryUsage ?: 0.0
+    val totalBatteryUsage = monthData?.totalBatteryUsage ?: 0.0
     val totalEnergy = monthData?.totalEnergy ?: 0.0
     val avgEnergy = if (driveCount > 0) totalEnergy / driveCount else 0.0
 
@@ -759,9 +759,8 @@ private fun MonthSummaryCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 StatChip(
-                    prefix = "Ø",
                     iconText = "🔋",
-                    value = "%.0f%%".format(avgBatteryUsage),
+                    value = "%.0f%%".format(totalBatteryUsage),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
@@ -1140,7 +1139,7 @@ private fun DayTripRow(
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(
-                        text = "%.0f%%".format(dayData.avgBatteryUsage),
+                        text = "%.0f%%".format(dayData.totalBatteryUsage),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
@@ -1317,9 +1316,8 @@ private fun DaySummaryCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 StatChip(
-                    prefix = "Ø",
                     iconText = "🔋",
-                    value = "%.0f%%".format(dayData.avgBatteryUsage),
+                    value = "%.0f%%".format(dayData.totalBatteryUsage),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
@@ -23,7 +23,7 @@ data class YearlyMileage(
     val totalDistance: Double,
     val driveCount: Int,
     val totalEnergy: Double,
-    val avgBatteryUsage: Double,
+    val totalBatteryUsage: Double,
     val drives: List<DriveData>
 )
 
@@ -32,7 +32,7 @@ data class MonthlyMileage(
     val totalDistance: Double,
     val driveCount: Int,
     val totalEnergy: Double,
-    val avgBatteryUsage: Double,
+    val totalBatteryUsage: Double,
     val drives: List<DriveData>
 )
 
@@ -41,7 +41,7 @@ data class DailyMileage(
     val totalDistance: Double,
     val driveCount: Int,
     val totalEnergy: Double,
-    val avgBatteryUsage: Double,
+    val totalBatteryUsage: Double,
     val drives: List<DriveData>
 )
 
@@ -202,14 +202,14 @@ class MileageViewModel @Inject constructor(
                 val end = drive.endBatteryLevel
                 if (start != null && end != null) (start - end).toDouble() else null
             }
-            val avgBatteryUsage = if (batteryUsages.isNotEmpty()) batteryUsages.average() else 0.0
+            val totalBatteryUsage = batteryUsages.sum()
 
             YearlyMileage(
                 year = year!!,
                 totalDistance = totalDistance,
                 driveCount = yearDrives.size,
                 totalEnergy = totalEnergy,
-                avgBatteryUsage = avgBatteryUsage,
+                totalBatteryUsage = totalBatteryUsage,
                 drives = yearDrives
             )
         }.sortedByDescending { it.year }
@@ -272,14 +272,14 @@ class MileageViewModel @Inject constructor(
                 val end = drive.endBatteryLevel
                 if (start != null && end != null) (start - end).toDouble() else null
             }
-            val avgBatteryUsage = if (batteryUsages.isNotEmpty()) batteryUsages.average() else 0.0
+            val totalBatteryUsage = batteryUsages.sum()
 
             MonthlyMileage(
                 yearMonth = yearMonth!!,
                 totalDistance = totalDistance,
                 driveCount = monthDrives.size,
                 totalEnergy = totalEnergy,
-                avgBatteryUsage = avgBatteryUsage,
+                totalBatteryUsage = totalBatteryUsage,
                 drives = monthDrives
             )
         }.sortedByDescending { it.yearMonth }
@@ -323,14 +323,14 @@ class MileageViewModel @Inject constructor(
                 val end = drive.endBatteryLevel
                 if (start != null && end != null) (start - end).toDouble() else null
             }
-            val avgBatteryUsage = if (batteryUsages.isNotEmpty()) batteryUsages.average() else 0.0
+            val totalBatteryUsage = batteryUsages.sum()
 
             DailyMileage(
                 date = date!!,
                 totalDistance = totalDistance,
                 driveCount = dayDrives.size,
                 totalEnergy = totalEnergy,
-                avgBatteryUsage = avgBatteryUsage,
+                totalBatteryUsage = totalBatteryUsage,
                 drives = dayDrives.sortedByDescending { it.startDate }
             )
         }.sortedByDescending { it.date }


### PR DESCRIPTION
## Summary
- Battery percentage in daily mileage cards now shows the **sum** of battery consumed across all drives, rather than the average per drive
- This is more intuitive and correctly shows values over 100% for long journeys with multiple drives
- Removed the "Ø" (average) prefix from battery stat chips since it's now a total value

## Example
Before: 3 drives consuming 15%, 15%, 20% → showed **16.7%** (average)
After: 3 drives consuming 15%, 15%, 20% → shows **50%** (total)

🤖 Generated with [Claude Code](https://claude.com/code)