### PR TITLE
fix: reduce connect timeout from 30s to 1s

### DIFF
--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -164,7 +164,7 @@ class TeslamateApiFactory(
                 chain.proceed(request)
             }
             .addInterceptor(loggingInterceptor)
-            .connectTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(1, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
 


### PR DESCRIPTION
## Summary
- Reduces HTTP connect timeout from 30 seconds to 1 second
- Fixes slow fallback when primary server is unreachable (e.g., when using VPN)
- Read and write timeouts remain at 30s for data transfers

## Context
Users reported that when using the secondary server feature with the primary server unavailable (VPN scenario), data retrieval was very slow. The root cause was a 30-second connect timeout before fallback would trigger.

## Test plan
- [ ] Configure primary and secondary servers
- [ ] Disconnect from network that has access to primary (simulate VPN scenario)
- [ ] Verify fallback to secondary server happens within ~1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)