### PR TITLE
fix: add changelog to Google Play releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,10 @@ jobs:
             app/build/outputs/apk/release/${{ env.APK_NAME }}
             app/build/outputs/apk/debug/${{ env.APK_NAME_DEBUG }}
 
+      - name: Prepare changelog for Google Play
+        if: github.event_name == 'release'
+        run: ./scripts/prepare-play-store-changelog.sh
+
       - name: Upload to Google Play (Closed Testing)
         if: github.event_name == 'release' && env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != ''
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+fastlane/metadata/android/whatsnew-*
 
 # Version control
 vcs.xml

--- a/scripts/prepare-play-store-changelog.sh
+++ b/scripts/prepare-play-store-changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Prepares changelog files for Google Play upload.
+# Converts Fastlane-style changelogs to the whatsnew-<LOCALE> format
+# expected by the r0adkll/upload-google-play action.
+#
+# Usage: ./scripts/prepare-play-store-changelog.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+METADATA_DIR="$PROJECT_ROOT/fastlane/metadata/android"
+
+# Extract versionCode from build.gradle.kts
+VERSION_CODE=$(grep 'versionCode' "$PROJECT_ROOT/app/build.gradle.kts" | sed 's/[^0-9]*//g')
+
+if [ -z "$VERSION_CODE" ]; then
+    echo "Error: Could not extract versionCode from build.gradle.kts"
+    exit 1
+fi
+
+echo "Preparing changelogs for versionCode: $VERSION_CODE"
+
+FOUND_ANY=false
+
+# Loop through all locale directories
+for locale_dir in "$METADATA_DIR"/*/; do
+    locale=$(basename "$locale_dir")
+
+    # Skip if not a locale directory (e.g., if there are other files)
+    if [[ ! "$locale" =~ ^[a-z]{2}-[A-Z]{2}$ ]]; then
+        continue
+    fi
+
+    changelog_file="$locale_dir/changelogs/${VERSION_CODE}.txt"
+    whatsnew_file="$METADATA_DIR/whatsnew-${locale}"
+
+    if [ -f "$changelog_file" ]; then
+        cp "$changelog_file" "$whatsnew_file"
+        echo "Created $whatsnew_file"
+        FOUND_ANY=true
+    else
+        echo "Warning: No changelog found at $changelog_file"
+    fi
+done
+
+if [ "$FOUND_ANY" = false ]; then
+    echo "Error: No changelog files found for versionCode $VERSION_CODE"
+    exit 1
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary

- The `r0adkll/upload-google-play` action expects `whatsnew-<LOCALE>` files, but we have Fastlane-style changelogs (`en-US/changelogs/<versionCode>.txt`)
- This means **changelogs were not being uploaded to Google Play** - the "What's New" section was empty
- Add a script that converts Fastlane changelogs to the expected format during CI

## Changes

- Add `scripts/prepare-play-store-changelog.sh` - converts changelogs to whatsnew format
- Update release workflow to call the script before Google Play upload
- Add generated `whatsnew-*` files to `.gitignore`

## Test plan

- [x] Script tested locally - correctly generates `whatsnew-en-US` from `en-US/changelogs/21.txt`
- [ ] Verify on next release that Google Play shows the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)