### PR TITLE
fix: enable lenient JSON parsing to handle malformed API responses

### DIFF
--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -55,7 +55,7 @@ object NetworkModule {
         return Retrofit.Builder()
             .baseUrl("https://nominatim.openstreetmap.org/")
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
             .build()
             .create(NominatimApi::class.java)
     }
@@ -71,7 +71,7 @@ object NetworkModule {
         return Retrofit.Builder()
             .baseUrl("https://archive-api.open-meteo.com/")
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
             .build()
             .create(OpenMeteoApi::class.java)
     }
@@ -123,7 +123,7 @@ class TeslamateApiFactory(
         val api = Retrofit.Builder()
             .baseUrl(normalizedUrl)
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
             .build()
             .create(TeslamateApi::class.java)
 


### PR DESCRIPTION
## Summary
- Enables lenient JSON parsing for all Retrofit API clients
- Fixes intermittent "JsonReader.setLenient(true)" crash

## Problem
The app was crashing with `Use JsonReader.setLenient(true) to accept malformed JSON` errors when the TeslaMate API returned unexpected responses. This happened intermittently when:
- The server returned error pages or status messages
- The JSON contained non-standard formatting
- There were encoding issues in the response

## Solution
Use `MoshiConverterFactory.create(moshi).asLenient()` for all Retrofit API clients:
- TeslaMate API (primary)
- Nominatim geocoding API
- OpenMeteo weather API

Lenient mode makes the JSON parser more tolerant of edge cases like:
- Multiple top-level values
- Comments in JSON
- Single quotes
- Trailing commas

Fixes #72

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Manual: Open app multiple times to verify no JSON parsing crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)