### PR TITLE
feat: remember last selected car and add GitHub issues link

### DIFF
--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,7 +23,8 @@ data class AppSettings(
     val acceptInvalidCerts: Boolean = false,
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
-    val teslamateBaseUrl: String = ""
+    val teslamateBaseUrl: String = "",
+    val lastSelectedCarId: Int? = null
 ) {
     val isConfigured: Boolean
         get() = serverUrl.isNotBlank()
@@ -42,6 +44,7 @@ class SettingsDataStore @Inject constructor(
     private val currencyCodeKey = stringPreferencesKey("currency_code")
     private val showShortDrivesChargesKey = booleanPreferencesKey("show_short_drives_charges")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
+    private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
 
     val settings: Flow<AppSettings> = context.dataStore.data.map { preferences ->
         AppSettings(
@@ -51,7 +54,8 @@ class SettingsDataStore @Inject constructor(
             acceptInvalidCerts = preferences[acceptInvalidCertsKey] ?: false,
             currencyCode = preferences[currencyCodeKey] ?: "EUR",
             showShortDrivesCharges = preferences[showShortDrivesChargesKey] ?: false,
-            teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: ""
+            teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
+            lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
     }
 
@@ -90,6 +94,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveTeslamateBaseUrl(url: String) {
         context.dataStore.edit { preferences ->
             preferences[teslamateBaseUrlKey] = url
+        }
+    }
+
+    suspend fun saveLastSelectedCarId(carId: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[lastSelectedCarIdKey] = carId
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -638,13 +639,23 @@ private fun SettingsContent(
             }
         }
 
-        // Version number at bottom
+        // Version number and issue link at bottom
         Spacer(modifier = Modifier.height(48.dp))
         Text(
             text = "v${com.matedroid.BuildConfig.VERSION_NAME}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
             modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        val uriHandler = LocalUriHandler.current
+        Text(
+            text = stringResource(R.string.settings_report_issue),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .clickable { uriHandler.openUri("https://github.com/vide/matedroid/issues") }
         )
         Spacer(modifier = Modifier.height(16.dp))
     }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -225,6 +225,9 @@
     <string name="settings_secondary_server">Servidor secundari</string>
     <string name="settings_connected">Connectat</string>
 
+    <!-- Link to GitHub issues page shown below version number -->
+    <string name="settings_report_issue">Informa d\'un problema</string>
+
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
     <string name="drives_title">Viatges</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -225,6 +225,9 @@
     <string name="settings_secondary_server">Servidor secundario</string>
     <string name="settings_connected">Conectado</string>
 
+    <!-- Link to GitHub issues page shown below version number -->
+    <string name="settings_report_issue">Reportar un problema</string>
+
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
     <string name="drives_title">Viajes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -225,6 +225,9 @@
     <string name="settings_secondary_server">Server secondario</string>
     <string name="settings_connected">Connesso</string>
 
+    <!-- Link to GitHub issues page shown below version number -->
+    <string name="settings_report_issue">Segnala un problema</string>
+
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
     <string name="drives_title">Viaggi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,9 @@
     <string name="settings_secondary_server">Secondary server</string>
     <string name="settings_connected">Connected</string>
 
+    <!-- Link to GitHub issues page shown below version number -->
+    <string name="settings_report_issue">Report an issue</string>
+
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
     <string name="drives_title">Drives</string>

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -7,13 +7,17 @@ import com.matedroid.data.api.models.CarStatus
 import com.matedroid.data.api.models.CarStatusDetails
 import com.matedroid.data.api.models.ChargingDetails
 import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.AppSettings
+import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.CarStatusWithUnits
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.TeslamateRepository
+import kotlinx.coroutines.flow.flowOf
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -37,6 +41,7 @@ class DashboardViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var repository: TeslamateRepository
     private lateinit var geocodingRepository: GeocodingRepository
+    private lateinit var settingsDataStore: SettingsDataStore
     private var viewModel: DashboardViewModel? = null
 
     private val testCar = CarData(
@@ -68,6 +73,10 @@ class DashboardViewModelTest {
         Dispatchers.setMain(testDispatcher)
         repository = mockk()
         geocodingRepository = mockk()
+        settingsDataStore = mockk()
+        // Default: no previously selected car
+        every { settingsDataStore.settings } returns flowOf(AppSettings())
+        coEvery { settingsDataStore.saveLastSelectedCarId(any()) } returns Unit
     }
 
     @After
@@ -79,7 +88,7 @@ class DashboardViewModelTest {
     }
 
     private fun createViewModel(): DashboardViewModel {
-        return DashboardViewModel(repository, geocodingRepository)
+        return DashboardViewModel(repository, geocodingRepository, settingsDataStore)
     }
 
     /**


### PR DESCRIPTION
## Summary
- Remembers the last selected car for users with multiple vehicles
- Adds "Report an issue" link below version number in Settings

## Changes

### Remember Last Car
Users with multiple cars will now return to their last selected car when reopening the app, instead of always starting with the first car.

- Added `lastSelectedCarId` to `AppSettings` and `SettingsDataStore`
- `DashboardViewModel` now saves the car ID when user switches cars
- On app launch, restores last selected car (falls back to first car if saved ID is no longer valid)

### GitHub Issues Link
Added a clickable "Report an issue" link below the version number in Settings screen that opens the GitHub issues page.

- Added translations for all 4 locales (EN, IT, ES, CA)

Fixes #76

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Manual: With multiple cars, select car 2, close app, reopen → should start with car 2
- [x] Manual: Tap "Report an issue" in Settings → opens GitHub issues page

🤖 Generated with [Claude Code](https://claude.com/claude-code)