### PR TITLE
fix: add error details dialog for API parsing errors

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -299,7 +299,10 @@ fun DashboardScreen(
                     EmptyContent()
                 }
                 uiState.error != null -> {
-                    ErrorContent(message = uiState.error!!)
+                    ErrorContent(
+                        message = uiState.error!!,
+                        details = uiState.errorDetails
+                    )
                 }
                 else -> {
                     // Car status still loading after cars loaded
@@ -352,23 +355,60 @@ private fun EmptyContent() {
 }
 
 @Composable
-private fun ErrorContent(message: String) {
+private fun ErrorContent(
+    message: String,
+    details: String? = null
+) {
+    var showDetailsDialog by remember { mutableStateOf(false) }
+
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        ) {
             Text(
                 text = stringResource(R.string.error_loading_data),
                 style = MaterialTheme.typography.titleMedium,
                 color = StatusError
             )
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            if (details != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                TextButton(onClick = { showDetailsDialog = true }) {
+                    Text(stringResource(R.string.error_show_details))
+                }
+            }
         }
+    }
+
+    if (showDetailsDialog && details != null) {
+        AlertDialog(
+            onDismissRequest = { showDetailsDialog = false },
+            title = { Text(stringResource(R.string.error_details_title)) },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = details,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showDetailsDialog = false }) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -32,7 +32,8 @@ data class DashboardUiState(
     val resolvedAddress: String? = null,
     val totalCharges: Int? = null,
     val totalDrives: Int? = null,
-    val error: String? = null
+    val error: String? = null,
+    val errorDetails: String? = null
 ) {
     private val selectedCar: CarData?
         get() = cars.find { it.carId == selectedCarId }
@@ -79,7 +80,7 @@ class DashboardViewModel @Inject constructor(
 
     fun loadCars() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update { it.copy(isLoading = true, error = null, errorDetails = null) }
 
             when (val result = repository.getCars()) {
                 is ApiResult.Success -> {
@@ -104,7 +105,8 @@ class DashboardViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            error = result.message
+                            error = result.message,
+                            errorDetails = result.details
                         )
                     }
                 }
@@ -248,6 +250,6 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun clearError() {
-        _uiState.update { it.copy(error = null) }
+        _uiState.update { it.copy(error = null, errorDetails = null) }
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -39,6 +39,12 @@
     <!-- Error state: title when data loading fails -->
     <string name="error_loading_data">Error en carregar les dades</string>
 
+    <!-- Error details: button to show technical error details -->
+    <string name="error_show_details">Mostra detalls</string>
+
+    <!-- Error details: dialog title -->
+    <string name="error_details_title">Detalls de l\'Error</string>
+
     <!-- Vehicle state shown when locked -->
     <string name="locked">Bloquejat</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -39,6 +39,12 @@
     <!-- Error state: title when data loading fails -->
     <string name="error_loading_data">Error al cargar datos</string>
 
+    <!-- Error details: button to show technical error details -->
+    <string name="error_show_details">Mostrar detalles</string>
+
+    <!-- Error details: dialog title -->
+    <string name="error_details_title">Detalles del Error</string>
+
     <!-- Vehicle state shown when locked -->
     <string name="locked">Bloqueado</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,6 +39,12 @@
     <!-- Error state: title when data loading fails -->
     <string name="error_loading_data">Errore nel caricamento dati</string>
 
+    <!-- Error details: button to show technical error details -->
+    <string name="error_show_details">Mostra dettagli</string>
+
+    <!-- Error details: dialog title -->
+    <string name="error_details_title">Dettagli Errore</string>
+
     <!-- Vehicle state shown when locked -->
     <string name="locked">Chiusa</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,12 @@
     <!-- Error state: title when data loading fails -->
     <string name="error_loading_data">Error loading data</string>
 
+    <!-- Error details: button to show technical error details -->
+    <string name="error_show_details">Show details</string>
+
+    <!-- Error details: dialog title -->
+    <string name="error_details_title">Error Details</string>
+
     <!-- Vehicle state shown when locked -->
     <string name="locked">Locked</string>
 


### PR DESCRIPTION
## Summary
- Add "Show details" button to error messages when API parsing fails
- Display a dialog with diagnostic information to help users troubleshoot TeslaMate API configuration issues
- Add translations for error dialog UI in all 4 locales (EN, IT, ES, CA)

Closes #72

## Changes
- **TeslamateRepository.kt**: Add `details` field to `ApiResult.Error`, detect JSON parsing errors and provide contextual guidance
- **DashboardViewModel.kt**: Pass error details to UI state  
- **DashboardScreen.kt**: Add "Show details" button and `AlertDialog` for viewing error details
- **strings.xml** (all locales): Add `error_show_details` and `error_details_title` strings

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Trigger a JSON parsing error (e.g., incorrect API URL returning HTML) and verify the "Show details" button appears
- [ ] Tap "Show details" and verify the dialog shows helpful diagnostic information

🤖 Generated with [Claude Code](https://claude.com/claude-code)