### PR TITLE
Fix translations

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -652,7 +652,7 @@ private fun RecordsCard(
     val categoryDrives = stringResource(R.string.stats_category_drives)
     val categoryBattery = stringResource(R.string.stats_category_battery)
     val categoryWeather = stringResource(R.string.stats_category_weather)
-    val categoryOthers = stringResource(R.string.stats_category_others)
+    val categoryMisc = stringResource(R.string.stats_category_misc)
     val gapTypeCharging = stringResource(R.string.gap_type_charging)
     val gapTypeDriving = stringResource(R.string.gap_type_driving)
 
@@ -722,19 +722,19 @@ private fun RecordsCard(
         weatherRecords.add(RecordData("❄️", labelColdestCharge, "%.1f°C".format(record.tempC), record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
     }
 
-    // Category 4: Other
-    val otherRecords = mutableListOf<RecordData>()
+    // Category 4: Miscelaneous
+    val miscRecords = mutableListOf<RecordData>()
     quickStats.maxDistanceBetweenCharges?.let { record ->
-        otherRecords.add(RecordData("🔋", labelLongestRange, "%.1f km".format(record.distance), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
+        miscRecords.add(RecordData("🔋", labelLongestRange, "%.1f km".format(record.distance), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
     }
     quickStats.longestGapWithoutCharging?.let { gap ->
-        otherRecords.add(RecordData("⏰", labelNoCharging, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeCharging) })
+        miscRecords.add(RecordData("⏰", labelNoCharging, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeCharging) })
     }
     quickStats.longestGapWithoutDriving?.let { gap ->
-        otherRecords.add(RecordData("🅿️", labelNoDriving, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeDriving) })
+        miscRecords.add(RecordData("🅿️", labelNoDriving, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeDriving) })
     }
     quickStats.mostDistanceDay?.let { day ->
-        otherRecords.add(RecordData("🛣️", labelMostDistanceDay, "%.1f km".format(day.totalDistance), day.day) { onDayClick(day.day) })
+        miscRecords.add(RecordData("🛣️", labelMostDistanceDay, "%.1f km".format(day.totalDistance), day.day) { onDayClick(day.day) })
     }
 
     // Build list of all categories with their records
@@ -743,7 +743,7 @@ private fun RecordsCard(
     if (driveRecords.isNotEmpty()) allCategories.add(CategoryData(categoryDrives, "🚗", driveRecords))
     if (batteryRecords.isNotEmpty()) allCategories.add(CategoryData(categoryBattery, "🔋", batteryRecords))
     if (weatherRecords.isNotEmpty()) allCategories.add(CategoryData(categoryWeather, "🌡️", weatherRecords))
-    if (otherRecords.isNotEmpty()) allCategories.add(CategoryData(categoryOthers, "📍", otherRecords))
+    if (miscRecords.isNotEmpty()) allCategories.add(CategoryData(categoryMisc, "📍", miscRecords))
 
     // Don't render anything if no categories
     if (allCategories.isEmpty()) return

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -549,7 +549,7 @@
     <string name="stats_category_weather">Temps i Altitud</string>
 
     <!-- Record category: distance and gap records -->
-    <string name="stats_category_others">Altres</string>
+    <string name="stats_category_misc">Altres</string>
 
     <!-- Record: longest single drive by distance -->
     <string name="record_longest_drive">Viatge més llarg</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -549,7 +549,7 @@
     <string name="stats_category_weather">Clima y Altitud</string>
 
     <!-- Record category: distance and gap records -->
-    <string name="stats_category_others">Otros</string>
+    <string name="stats_category_misc">Otros</string>
 
     <!-- Record: longest single drive by distance -->
     <string name="record_longest_drive">Viaje más largo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -549,7 +549,7 @@
     <string name="stats_category_weather">Meteo e Altitudine</string>
 
     <!-- Record category: distance and gap records -->
-    <string name="stats_category_others">Altri</string>
+    <string name="stats_category_misc">Altri</string>
 
     <!-- Record: longest single drive by distance -->
     <string name="record_longest_drive">Viaggio più lungo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,7 +549,7 @@
     <string name="stats_category_weather">Weather &amp; Altitude</string>
 
     <!-- Record category: distance and gap records -->
-    <string name="stats_category_others">Others</string>
+    <string name="stats_category_misc">Misc</string>
 
     <!-- Record: longest single drive by distance -->
     <string name="record_longest_drive">Longest Drive</string>


### PR DESCRIPTION
## Summary
- Add translations for "days" in Records view.  Fix #77
- Rename "Distance" for "Misc" (IT: Altri, CA: Altres, ES: Otros).  Resolves #78 

## Changes:
- **Internationalization**: Replaced hardcoded "days" strings with `R.string.format_days` in _StatsScreen.kt_.
- **Updated**: `format_days` in _strings.xml_ to use `%.1f` (float) instead of `%d` (integer) to correctly handle decimal values from `gap.gapDays`.
- **Refactor**: 
     - Use `format_days_count` when gapDays value is integer.
     - `distanceRecords` for `miscRecords` and `categoryDistance` for `categoryMisc` in _StatsScreen.kt_
     - `stats_category_distances` for `stats_category_misc` in _strings.xml_
