### PR TITLE
Calculation actual # of AC phases

### DIFF
--- a/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
+++ b/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
@@ -97,7 +97,8 @@ data class CarStatus(
     val chargeEnergyAdded: Double? get() = chargingDetails?.chargeEnergyAdded
     val chargeLimitSoc: Int? get() = chargingDetails?.chargeLimitSoc
     val chargerPower: Int? get() = chargingDetails?.chargerPower
-    val chargerPhases: Int? get() = chargingDetails?.chargerPhases
+    //val chargerPhases: Int? get() = chargingDetails?.chargerPhases
+    val acPhases: Int? get() = chargingDetails?.acPhases
     val chargerActualCurrent: Int? get() = chargingDetails?.chargerActualCurrent
     val chargeCurrentRequestMax: Int? get() = chargingDetails?.chargeCurrentRequestMax
     val isDcCharging: Boolean get() = chargingDetails?.isDcCharging ?: false
@@ -193,10 +194,20 @@ data class ChargingDetails(
     /**
      * Detect if this is DC charging using Teslamate's logic:
      * DC charging has charger_phases = 0 or null (bypasses onboard charger)
-     * AC charging has charger_phases = 1, 2, or 3
      */
     val isDcCharging: Boolean
         get() = chargerPhases == null || chargerPhases == 0
+    /**
+     * Actual number of AC phases:
+     * 1 -> monophase
+     * 2 -> triphase
+     */
+    val acPhases: Int?
+        get() = when (chargerPhases) {
+            1 -> 1
+            2, 3 -> 3
+            else -> null
+        }
 }
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
@@ -191,7 +191,7 @@ class ChargeDetailViewModel @Inject constructor(
     /**
      * Detect if this is a DC charge using Teslamate's logic:
      * DC charging has charger_phases = 0 or null (bypasses onboard charger)
-     * AC charging has charger_phases = 1, 2, or 3
+     * AC charging has charger_phases = 1 or 2 (for triphasic line)
      */
     private fun detectDcCharge(detail: ChargeDetail): Boolean {
         val points = detail.chargePoints ?: return false

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1312,7 +1312,7 @@ private fun ChargingDetailsRow(
                     color = palette.onSurfaceVariant
                 )
                 // Phases badge
-                val phases = status.chargerPhases
+                val phases = status.acPhases
                 if (phases != null && phases > 0) {
                     Box(
                         modifier = Modifier


### PR DESCRIPTION
### Summary
Add `acPhases` to show the correct number of AC phases (1 = monophase, 3 = triphase) in the UI.

### Changes
New property `acPhases` in `CarModels.kt`
Updated `DashboardScreen.kt` to use `status.acPhases`

### Notes
Preserves original `chargerPhases` from the API
Handles possible future 3 value for triphase