### PR TITLE
fix(#103): use locale-aware date formatting in drive details

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -83,6 +83,7 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -769,7 +770,8 @@ private fun formatDateTime(dateStr: String?): String {
         } catch (e: DateTimeParseException) {
             LocalDateTime.parse(dateStr.replace("Z", ""))
         }
-        val formatter = DateTimeFormatter.ofPattern("EEEE, MMM d, yyyy 'at' HH:mm")
+        // Use locale-aware formatter for proper date/time localization
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
         dateTime.format(formatter)
     } catch (e: Exception) {
         dateStr


### PR DESCRIPTION
## Summary
- Replaced hardcoded English date pattern (`EEEE, MMM d, yyyy 'at' HH:mm`) with `DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)`
- Dates in drive details screen now display properly according to device locale

## Test plan
- [ ] Test on device with Spanish locale - verify dates show in Spanish format
- [ ] Test on device with English locale - verify dates show in English format
- [ ] Test on device with other locales (Italian, Catalan) - verify proper formatting

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)