### PR TITLE
fix(#102): remove duplicate % symbol in battery loss label

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -438,7 +438,7 @@
     <!-- Degradation section -->
     <string name="estimated_degradation">Degradació estimada</string>
     <string name="loss_kwh">Pèrdua (kWh)</string>
-    <string name="loss_percent">Pèrdua (%%)</string>
+    <string name="loss_percent">Pèrdua (%)</string>
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degradació Estimada</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -438,7 +438,7 @@
     <!-- Degradation section -->
     <string name="estimated_degradation">Degradación estimada</string>
     <string name="loss_kwh">Pérdida (kWh)</string>
-    <string name="loss_percent">Pérdida (%%)</string>
+    <string name="loss_percent">Pérdida (%)</string>
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degradación Estimada</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -438,7 +438,7 @@
     <!-- Degradation section -->
     <string name="estimated_degradation">Degrado stimato</string>
     <string name="loss_kwh">Perdita (kWh)</string>
-    <string name="loss_percent">Perdita (%%)</string>
+    <string name="loss_percent">Perdita (%)</string>
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degrado Stimato</string>


### PR DESCRIPTION
## Summary
- Fixed `loss_percent` string in ES/IT/CA locales that incorrectly used `%%` instead of `%`
- The escape sequence `%%` is only needed when format placeholders are present; this static label doesn't need it

**Before:** "Pérdida (%%)"
**After:** "Pérdida (%)"

## Test plan
- [ ] Check Battery Health screen in Spanish locale - verify "Pérdida (%)" shows correctly
- [ ] Check Battery Health screen in Italian locale - verify "Perdita (%)" shows correctly
- [ ] Check Battery Health screen in Catalan locale - verify "Pèrdua (%)" shows correctly

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)