### PR TITLE
fix(#104): standardize duration format to HH:MM

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -863,5 +863,5 @@ private fun formatDateTime(dateStr: String?, unknownLabel: String = "Unknown"): 
 private fun formatDuration(minutes: Int): String {
     val hours = minutes / 60
     val mins = minutes % 60
-    return if (hours > 0) "${hours}h ${mins}m" else "${mins}m"
+    return "%d:%02d".format(hours, mins)
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -781,5 +781,5 @@ private fun formatDateTime(dateStr: String?): String {
 private fun formatDuration(minutes: Int): String {
     val hours = minutes / 60
     val mins = minutes % 60
-    return if (hours > 0) "${hours}h ${mins}m" else "${mins}m"
+    return "%d:%02d".format(hours, mins)
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -614,7 +614,7 @@ private fun formatDate(dateStr: String): String {
 private fun formatDuration(minutes: Int): String {
     val hours = minutes / 60
     val mins = minutes % 60
-    return if (hours > 0) "${hours}h ${mins}m" else "${mins}m"
+    return "%d:%02d".format(hours, mins)
 }
 
 /**
@@ -799,5 +799,5 @@ private fun DrivesChartPage(
 private fun formatDurationChart(minutes: Int): String {
     val hours = minutes / 60
     val mins = minutes % 60
-    return if (hours > 0) "${hours}h ${mins}m" else "${mins}m"
+    return "%d:%02d".format(hours, mins)
 }


### PR DESCRIPTION
## Summary
- Changed duration format from "xh ym" (e.g., "1h 30m") to "H:MM" (e.g., "1:30") for consistency
- Updated all duration formatters across drives and charges screens

**Before:** `1h 30m`
**After:** `1:30`

## Files changed
- `DriveDetailScreen.kt` - drive detail duration
- `ChargeDetailScreen.kt` - charge detail duration
- `DrivesScreen.kt` - drives list and chart tooltip formatters

## Test plan
- [ ] Check Drive Details screen - verify duration shows as "H:MM"
- [ ] Check Charge Details screen - verify duration shows as "H:MM"
- [ ] Check Drives list screen - verify duration shows as "H:MM"
- [ ] Check Drives chart tooltip - verify duration shows as "H:MM"

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)