### PR TITLE
fix(#105): add locale-aware thousands separator to distance formatting

### DIFF
--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -19,9 +19,9 @@ object UnitFormatter {
     fun formatDistance(value: Double, units: Units?, decimals: Int = 1): String {
         return if (units?.isImperial == true) {
             val miles = value * KM_TO_MI
-            "%.${decimals}f mi".format(miles)
+            "%,.${decimals}f mi".format(miles)
         } else {
-            "%.${decimals}f km".format(value)
+            "%,.${decimals}f km".format(value)
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
@@ -550,13 +550,13 @@ private fun RangeCard(stats: BatteryStats, palette: CarColorPalette, onClick: ()
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 RangeValueCard(
-                    value = "%.1f km".format(stats.maxRangeNew),
+                    value = "%,.1f km".format(stats.maxRangeNew),
                     label = maxRangeNewLabel,
                     iconColor = CapacityGreen,
                     modifier = Modifier.weight(1f)
                 )
                 RangeValueCard(
-                    value = "%.1f km".format(stats.maxRangeNow),
+                    value = "%,.1f km".format(stats.maxRangeNow),
                     label = maxRangeNowLabel,
                     iconColor = CapacityYellow,
                     modifier = Modifier.weight(1f)
@@ -580,7 +580,7 @@ private fun RangeCard(stats: BatteryStats, palette: CarColorPalette, onClick: ()
                 Spacer(modifier = Modifier.width(8.dp))
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        text = "%.1f km".format(stats.rangeLoss),
+                        text = "%,.1f km".format(stats.rangeLoss),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = palette.onSurface
@@ -841,7 +841,7 @@ private fun RangeInformationCard(stats: BatteryStats) {
             RangeInfoRow(
                 title = estimatedRangeLabel,
                 subtitle = estimatedRangeSubtitle,
-                value = "%.1f km".format(stats.estimatedRange),
+                value = "%,.1f km".format(stats.estimatedRange),
                 valueColor = RangeBlue
             )
 
@@ -850,7 +850,7 @@ private fun RangeInformationCard(stats: BatteryStats) {
             RangeInfoRow(
                 title = ratedRangeLabel,
                 subtitle = ratedRangeSubtitle,
-                value = "%.1f km".format(stats.ratedRange),
+                value = "%,.1f km".format(stats.ratedRange),
                 valueColor = RangeBlue
             )
 
@@ -859,7 +859,7 @@ private fun RangeInformationCard(stats: BatteryStats) {
             RangeInfoRow(
                 title = idealRangeLabel,
                 subtitle = idealRangeSubtitle,
-                value = "%.1f km".format(stats.idealRange),
+                value = "%,.1f km".format(stats.idealRange),
                 valueColor = RangeBlue
             )
         }
@@ -993,7 +993,7 @@ private fun EstimatedCapacityCard(stats: BatteryStats) {
                 }
 
                 Text(
-                    text = "%.1f km".format(stats.rangeAt100),
+                    text = "%,.1f km".format(stats.rangeAt100),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = StatusSuccess

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -357,7 +357,7 @@ private fun SummaryCard(summary: DrivesSummary, palette: CarColorPalette) {
                 SummaryItem(
                     icon = CustomIcons.SteeringWheel,
                     label = stringResource(R.string.total_distance),
-                    value = "%.1f km".format(summary.totalDistanceKm),
+                    value = "%,.1f km".format(summary.totalDistanceKm),
                     palette = palette,
                     modifier = Modifier.weight(0.8f)
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/drives/WeatherAlongTheWayCard.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/WeatherAlongTheWayCard.kt
@@ -293,8 +293,8 @@ private fun formatWeatherDistance(distanceKm: Double, units: Units?, isLastPoint
     val isImperial = units?.isImperial == true
     return if (isImperial) {
         val miles = distanceKm * 0.621371
-        "%.1f mi".format(miles)
+        "%,.1f mi".format(miles)
     } else {
-        "%.1f km".format(distanceKm)
+        "%,.1f km".format(distanceKm)
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -307,7 +307,7 @@ private fun YearlyChartCard(chartData: List<Pair<Int, Double>>, palette: CarColo
                 BarChartData(
                     label = year.toString(),
                     value = distance,
-                    displayValue = "%.1f km".format(distance)
+                    displayValue = "%,.1f km".format(distance)
                 )
             }
 
@@ -316,7 +316,7 @@ private fun YearlyChartCard(chartData: List<Pair<Int, Double>>, palette: CarColo
                 modifier = Modifier.fillMaxWidth(),
                 barColor = palette.accent,
                 labelColor = palette.onSurfaceVariant,
-                valueFormatter = { "%.1f km".format(it) },
+                valueFormatter = { "%,.1f km".format(it) },
                 yAxisFormatter = { if (it >= 1000) "%.0fk".format(it / 1000) else "%.0f".format(it) }
             )
         }
@@ -362,7 +362,7 @@ private fun YearRow(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "%.0f km".format(yearData.totalDistance),
+                        text = "%,.0f km".format(yearData.totalDistance),
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -504,7 +504,7 @@ private fun MonthlyChartCard(chartData: List<Pair<Int, Double>>, palette: CarCol
                 BarChartData(
                     label = month.toString(),
                     value = distance,
-                    displayValue = "%.1f km".format(distance)
+                    displayValue = "%,.1f km".format(distance)
                 )
             }
 
@@ -513,7 +513,7 @@ private fun MonthlyChartCard(chartData: List<Pair<Int, Double>>, palette: CarCol
                 modifier = Modifier.fillMaxWidth(),
                 barColor = palette.accent,
                 labelColor = palette.onSurfaceVariant,
-                valueFormatter = { "%.1f km".format(it) },
+                valueFormatter = { "%,.1f km".format(it) },
                 yAxisFormatter = { if (it >= 1000) "%.0fk".format(it / 1000) else "%.0f".format(it) }
             )
         }
@@ -566,7 +566,7 @@ private fun MonthRow(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "%.0f km".format(monthData.totalDistance),
+                        text = "%,.0f km".format(monthData.totalDistance),
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -741,13 +741,13 @@ private fun MonthSummaryCard(
             ) {
                 StatChip(
                     icon = CustomIcons.Road,
-                    value = "%.1f km".format(totalDistance),
+                    value = "%,.1f km".format(totalDistance),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     prefix = "Ø",
                     icon = CustomIcons.Road,
-                    value = "%.1f km".format(avgDistance),
+                    value = "%,.1f km".format(avgDistance),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -831,7 +831,7 @@ private fun SummaryRow(
         ) {
             SummaryItem(
                 icon = Icons.Outlined.AllInclusive,
-                value = "%.0f km".format(totalDistance),
+                value = "%,.0f km".format(totalDistance),
                 label = stringResource(R.string.mileage_total),
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -839,7 +839,7 @@ private fun SummaryRow(
             )
             SummaryItemWithInfo(
                 icon = Icons.Filled.Speed,
-                value = "%.0f km".format(avgDistance),
+                value = "%,.0f km".format(avgDistance),
                 label = avgLabel,
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -1038,7 +1038,7 @@ private fun DailyChartCard(
                 BarChartData(
                     label = day.toString(),
                     value = distance,
-                    displayValue = "%.1f km".format(distance)
+                    displayValue = "%,.1f km".format(distance)
                 )
             }
 
@@ -1047,7 +1047,7 @@ private fun DailyChartCard(
                 modifier = Modifier.fillMaxWidth(),
                 barColor = palette.accent,
                 labelColor = palette.onSurfaceVariant,
-                valueFormatter = { "%.1f km".format(it) },
+                valueFormatter = { "%,.1f km".format(it) },
                 yAxisFormatter = { if (it >= 1000) "%.0fk".format(it / 1000) else "%.0f".format(it) }
             )
         }
@@ -1111,7 +1111,7 @@ private fun DayTripRow(
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(
-                        text = "%.1f km".format(dayData.totalDistance),
+                        text = "%,.1f km".format(dayData.totalDistance),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
@@ -1298,13 +1298,13 @@ private fun DaySummaryCard(
             ) {
                 StatChip(
                     icon = CustomIcons.Road,
-                    value = "%.1f km".format(dayData.totalDistance),
+                    value = "%,.1f km".format(dayData.totalDistance),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     prefix = "Ø",
                     icon = CustomIcons.Road,
-                    value = "%.1f km".format(avgDistance),
+                    value = "%,.1f km".format(avgDistance),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -1388,7 +1388,7 @@ private fun DriveRow(
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(
-                        text = "%.1f km".format(distance),
+                        text = "%,.1f km".format(distance),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
@@ -297,7 +297,7 @@ private fun CountryCard(
                 // Distance chip
                 StatChip(
                     icon = Icons.Default.Route,
-                    value = "%.0f km".format(country.totalDistanceKm),
+                    value = "%,.0f km".format(country.totalDistanceKm),
                     palette = palette,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -392,7 +392,7 @@ private fun CountrySummaryCard(
             ) {
                 StatChip(
                     icon = Icons.Default.Route,
-                    value = "%.0f km".format(country.totalDistanceKm),
+                    value = "%,.0f km".format(country.totalDistanceKm),
                     palette = palette,
                     modifier = Modifier.weight(1f)
                 )
@@ -624,7 +624,7 @@ private fun CountryMapCard(
                                         position = geoPoint
                                         setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                                         title = drive.address
-                                        snippet = "%.1f km".format(drive.distanceKm)
+                                        snippet = "%,.1f km".format(drive.distanceKm)
 
                                         val dotDrawable = GradientDrawable().apply {
                                             shape = GradientDrawable.OVAL
@@ -1017,7 +1017,7 @@ private fun RegionCard(
             ) {
                 StatChip(
                     icon = Icons.Default.Route,
-                    value = "%.0f km".format(region.totalDistanceKm),
+                    value = "%,.0f km".format(region.totalDistanceKm),
                     palette = palette,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -609,7 +609,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
         Row(modifier = Modifier.fillMaxWidth()) {
             StatItem(
                 label = stringResource(R.string.total_distance),
-                value = "%.0f km".format(quickStats.totalDistanceKm),
+                value = "%,.0f km".format(quickStats.totalDistanceKm),
                 modifier = Modifier.weight(1f)
             )
             StatItem(
@@ -742,7 +742,7 @@ private fun RecordsCard(
     // Category 1: Drives
     val driveRecords = mutableListOf<RecordData>()
     quickStats.longestDrive?.let { drive ->
-        driveRecords.add(RecordData("📏", labelLongestDrive, "%.1f km".format(drive.distance), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
+        driveRecords.add(RecordData("📏", labelLongestDrive, "%,.1f km".format(drive.distance), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
     }
     quickStats.fastestDrive?.let { drive ->
         driveRecords.add(RecordData("🏎️", labelTopSpeed, "${drive.speedMax} km/h", drive.startDate.take(10)) { onDriveClick(drive.driveId) })
@@ -811,7 +811,7 @@ private fun RecordsCard(
     // Category 4: Miscelaneous
     val miscRecords = mutableListOf<RecordData>()
     quickStats.maxDistanceBetweenCharges?.let { record ->
-        miscRecords.add(RecordData("🔋", labelLongestRange, "%.1f km".format(record.distance), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
+        miscRecords.add(RecordData("🔋", labelLongestRange, "%,.1f km".format(record.distance), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
     }
     quickStats.longestGapWithoutCharging?.let { gap ->
         miscRecords.add(RecordData("⏰", labelNoCharging, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeCharging) })
@@ -820,7 +820,7 @@ private fun RecordsCard(
         miscRecords.add(RecordData("🅿️", labelNoDriving, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeDriving) })
     }
     quickStats.mostDistanceDay?.let { day ->
-        miscRecords.add(RecordData("🛣️", labelMostDistanceDay, "%.1f km".format(day.totalDistance), day.day) { onDayClick(day.day) })
+        miscRecords.add(RecordData("🛣️", labelMostDistanceDay, "%,.1f km".format(day.totalDistance), day.day) { onDayClick(day.day) })
     }
 
     // Build list of all categories with their records
@@ -1510,7 +1510,7 @@ private fun RangeRecordDialog(
                                 color = palette.onSurfaceVariant
                             )
                             Text(
-                                text = "%.1f km".format(record.distance),
+                                text = "%,.1f km".format(record.distance),
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = palette.onSurface
@@ -1655,7 +1655,7 @@ private fun DriveListItem(
             Spacer(modifier = Modifier.width(8.dp))
             Column(horizontalAlignment = Alignment.End) {
                 Text(
-                    text = "%.1f km".format(drive.distance),
+                    text = "%,.1f km".format(drive.distance),
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
                     color = palette.onSurface


### PR DESCRIPTION
## Summary
- Added locale-aware thousands separator to all distance format strings
- Changed `%.Xf` to `%,.Xf` format specifier which respects locale grouping conventions
- Spanish: "38.379 km" (dot as thousands separator)
- English: "38,379 km" (comma as thousands separator)

## Files changed
- `UnitFormatter.kt` - core formatting function
- `MileageScreen.kt` - mileage display (main issue location)
- `BatteryScreen.kt` - range values
- `DrivesScreen.kt` - drive summary distance
- `WeatherAlongTheWayCard.kt` - distance markers
- `StatsScreen.kt` - stats records
- `CountriesVisitedScreen.kt` - country distances
- `RegionsVisitedScreen.kt` - region distances

## Test plan
- [ ] Check Mileage screen in Spanish locale - verify "38.379 km" format
- [ ] Check Mileage screen in English locale - verify "38,379 km" format
- [ ] Check Battery Health ranges display correctly
- [ ] Check Stats screen distances display correctly

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)