### PR TITLE
fix(#103):  use locale-aware date formatting in charge details

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -77,6 +77,7 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -853,7 +854,8 @@ private fun formatDateTime(dateStr: String?, unknownLabel: String = "Unknown"): 
         } catch (e: DateTimeParseException) {
             LocalDateTime.parse(dateStr.replace("Z", ""))
         }
-        val formatter = DateTimeFormatter.ofPattern("EEEE, MMM d, yyyy 'at' HH:mm")
+        // Use locale-aware formatter for proper date/time localization
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
         dateTime.format(formatter)
     } catch (e: Exception) {
         dateStr


### PR DESCRIPTION
## Summary
- Replaced hardcoded English date pattern (EEEE, MMM d, yyyy 'at' HH:mm) with DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
- Dates in charge details screen now display properly according to device locale

closes #103 