### PR TITLE
Added smooth tansition when refresh filters

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -2,6 +2,8 @@ package com.matedroid.ui.screens.charges
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -61,6 +63,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -127,12 +130,12 @@ fun ChargesScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            if (uiState.isLoading && !uiState.isRefreshing) {
+            if (uiState.isLoading && uiState.charges.isEmpty()) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(color = palette.accent)
                 }
             } else {
                 ChargesContent(
@@ -152,8 +155,8 @@ fun ChargesScreen(
                     onChargeTypeFilterSelected = { viewModel.setChargeTypeFilter(it) },
                     onChargeClick = { chargeId, scrollIndex, scrollOffset ->
                         viewModel.saveScrollPosition(scrollIndex, scrollOffset)
-                        onNavigateToChargeDetail(chargeId)
-                    }
+                        onNavigateToChargeDetail(chargeId) },
+                    isLoading = uiState.isLoading
                 )
             }
         }
@@ -174,6 +177,7 @@ private fun ChargesContent(
     selectedChargeTypeFilter: ChargeTypeFilter,
     initialScrollPosition: Int,
     initialScrollOffset: Int,
+    isLoading: Boolean,
     palette: CarColorPalette,
     onDateFilterSelected: (DateFilter) -> Unit,
     onChargeTypeFilterSelected: (ChargeTypeFilter) -> Unit,
@@ -184,10 +188,19 @@ private fun ChargesContent(
         initialFirstVisibleItemIndex = initialScrollPosition,
         initialFirstVisibleItemScrollOffset = initialScrollOffset
     )
-
+    // Animation of opacity: 0.6f when loading, 1f when ready.
+    // The "tween" of 300ms makes the change not abrupt.
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (isLoading) 0.6f else 1f,
+        animationSpec = tween(durationMillis = 300),
+        label = "chargesContentAlpha"
+    )
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize(),
+        // Applying the opacity here to make the entire list dim when loading
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer(alpha = contentAlpha),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -198,7 +211,6 @@ private fun ChargesContent(
                 onFilterSelected = onDateFilterSelected
             )
         }
-
         item {
             ChargeTypeFilterChips(
                 selectedFilter = selectedChargeTypeFilter,
@@ -206,12 +218,9 @@ private fun ChargesContent(
                 onFilterSelected = onChargeTypeFilterSelected
             )
         }
-
         item {
             SummaryCard(summary = summary, currencySymbol = currencySymbol, palette = palette)
         }
-
-        // Charges charts (daily/weekly/monthly based on date range) - swipeable
         if (chartData.isNotEmpty()) {
             item {
                 ChargesChartsPager(
@@ -222,7 +231,6 @@ private fun ChargesContent(
                 )
             }
         }
-
         item {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
@@ -231,8 +239,8 @@ private fun ChargesContent(
                 fontWeight = FontWeight.Bold
             )
         }
-
-        if (charges.isEmpty()) {
+        // only show the empty message if there's no data and we're not loading
+        if (charges.isEmpty() && !isLoading) {
             item {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -258,8 +266,6 @@ private fun ChargesContent(
             items(charges, key = { it.chargeId }) { charge ->
                 ChargeItem(
                     charge = charge,
-                    // Show DC badge if in dcChargeIds, AC otherwise
-                    // Will be correct once sync has processed charge details
                     isDcCharge = charge.chargeId in dcChargeIds,
                     currencySymbol = currencySymbol,
                     onEditCost = if (teslamateBaseUrl.isNotBlank()) {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -48,6 +49,9 @@ data class ChargeChartData(
     val label: String,
     val count: Int,
     val totalEnergy: Double,
+    //val energyAc: Double,
+    // val energyDc: Double,
+    val hasDc: Boolean,
     val totalCost: Double,
     val sortKey: Long // For sorting (epoch day, week number, or year-month)
 )
@@ -125,8 +129,16 @@ class ChargesViewModel @Inject constructor(
 
     fun setDateFilter(filter: DateFilter) {
         val endDate = LocalDate.now()
-        val startDate = filter.days?.let { endDate.minusDays(it) }
-        _uiState.update { it.copy(startDate = startDate, endDate = if (filter.days != null) endDate else null, selectedFilter = filter) }
+        val startDate = filter.days?.let { days ->
+            if (days > 0) endDate.minusDays(days - 1) else endDate
+        }
+        _uiState.update { it.copy(
+            selectedFilter = filter,
+            startDate = startDate,
+            endDate = if (filter.days != null) endDate else null,
+            scrollPosition = 0,
+            scrollOffset = 0
+        )}
         loadCharges(startDate, if (filter.days != null) endDate else null)
     }
 
@@ -151,7 +163,11 @@ class ChargesViewModel @Inject constructor(
         } else {
             filter
         }
-        _uiState.update { it.copy(chargeTypeFilter = newFilter) }
+        _uiState.update { it.copy(
+            chargeTypeFilter = newFilter,
+            scrollPosition = 0,
+            scrollOffset = 0
+        )}
         applyFiltersAndUpdateState()
     }
 
@@ -251,7 +267,7 @@ class ChargesViewModel @Inject constructor(
 
         // Calculate summary and chart data from filtered charges
         val summary = calculateSummary(chargesForStats)
-        val chartData = calculateChartData(chargesForStats, granularity)
+        val chartData = calculateChartData(chargesForStats, granularity, state.startDate)
 
         _uiState.update {
             it.copy(
@@ -274,51 +290,92 @@ class ChargesViewModel @Inject constructor(
         }
     }
 
-    private fun calculateChartData(charges: List<ChargeData>, granularity: ChartGranularity): List<ChargeChartData> {
+    private fun calculateChartData(charges: List<ChargeData>, granularity: ChartGranularity, startDate: LocalDate?): List<ChargeChartData> {
         if (charges.isEmpty()) return emptyList()
 
         val formatter = DateTimeFormatter.ISO_DATE_TIME
         val weekFields = WeekFields.of(Locale.getDefault())
 
-        return charges
-            .mapNotNull { charge ->
+        //  Group the charges by day
+        val chargesByDay = charges.mapNotNull { charge ->
+            charge.startDate?.let {
+                try {
+                    // Use of localdatetime to support the full ISO format
+                    val date = LocalDateTime.parse(it, formatter).toLocalDate()
+                    date.toEpochDay() to charge
+                } catch (e: Exception) { null }
+            }
+        }.groupBy({ it.first }, { it.second })
+
+        return if (granularity == ChartGranularity.DAILY) {
+            // DAILY ranges (today, last 7 and last 30 days
+            // If not startDate (All Time), get the first trip, or today
+            val start = startDate ?: (chargesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
+            val end = LocalDate.now()
+            val result = mutableListOf<ChargeChartData>()
+            var current = start
+            while (!current.isAfter(end)) {
+                val key = current.toEpochDay()
+                val itemsInDay = chargesByDay[key] ?: emptyList()
+                result.add(
+                    createChargeChartPoint(
+                        label = current.format(DateTimeFormatter.ofPattern("d/M")),
+                        sortKey = key,
+                        charges = itemsInDay,
+                        dcChargeIds = _uiState.value.dcChargeIds
+                    )
+                )
+                current = current.plusDays(1)
+            }
+            result
+        } else {
+            // WEEKLY and MONTHLY ranges
+            charges.mapNotNull { charge ->
                 charge.startDate?.let { dateStr ->
                     try {
-                        val date = LocalDate.parse(dateStr, formatter)
+                        val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
                         val (label, sortKey) = when (granularity) {
-                            ChartGranularity.DAILY -> {
-                                val dayLabel = date.format(DateTimeFormatter.ofPattern("d/M"))
-                                dayLabel to date.toEpochDay()
-                            }
                             ChartGranularity.WEEKLY -> {
-                                val weekOfYear = date.get(weekFields.weekOfWeekBasedYear())
-                                val year = date.get(weekFields.weekBasedYear())
-                                "W$weekOfYear" to (year * 100L + weekOfYear)
+                                val firstDay = date.with(weekFields.dayOfWeek(), 1)
+                                "W${date.get(weekFields.weekOfYear())}" to firstDay.toEpochDay()
                             }
-                            ChartGranularity.MONTHLY -> {
-                                val yearMonth = YearMonth.of(date.year, date.month)
-                                yearMonth.format(DateTimeFormatter.ofPattern("MMM yy")) to (date.year * 12L + date.monthValue)
+                            else -> { // MONTHLY
+                                date.format(DateTimeFormatter.ofPattern("MMM yy")) to YearMonth.from(date).atDay(1).toEpochDay()
                             }
                         }
                         Triple(label, sortKey, charge)
-                    } catch (e: Exception) {
-                        null
-                    }
+                    } catch (e: Exception) { null }
                 }
             }
-            .groupBy { Pair(it.first, it.second) }
-            .map { (key, chargesInPeriod) ->
-                ChargeChartData(
-                    label = key.first,
-                    count = chargesInPeriod.size,
-                    totalEnergy = chargesInPeriod.sumOf { it.third.chargeEnergyAdded ?: 0.0 },
-                    totalCost = chargesInPeriod.sumOf { it.third.cost ?: 0.0 },
-                    sortKey = key.second
-                )
-            }
-            .sortedBy { it.sortKey }
+                .groupBy { it.first to it.second }
+                .map { (key, list) ->
+                    createChargeChartPoint(
+                        key.first,
+                        key.second,
+                        list.map { it.third },
+                        dcChargeIds = _uiState.value.dcChargeIds
+                    )
+                }
+                .sortedBy { it.sortKey }
+        }
     }
 
+    // Helper function to centralize chart data creation
+    private fun createChargeChartPoint(label: String, sortKey: Long, charges: List<ChargeData>, dcChargeIds: Set<Int>): ChargeChartData {
+        //val dcCharges = charges.filter { it.chargeId in dcChargeIds }
+        //val energyDc = dcCharges.sumOf { it.chargeEnergyAdded ?: 0.0 }
+        //val energyTotal = charges.sumOf { it.chargeEnergyAdded ?: 0.0 }
+        return ChargeChartData(
+            label = label,
+            count = charges.size,
+            totalEnergy = charges.sumOf { it.chargeEnergyAdded ?: 0.0 },
+            //energyAc = energyTotal - energyDc,
+            //energyDc = energyDc,
+            totalCost = charges.sumOf { it.cost ?: 0.0 },
+            sortKey = sortKey,
+            hasDc = charges.any { it.chargeId in dcChargeIds }
+        )
+    }
     private fun calculateSummary(charges: List<ChargeData>): ChargesSummary {
         if (charges.isEmpty()) return ChargesSummary()
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -1,5 +1,7 @@
 package com.matedroid.ui.screens.drives
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +30,8 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.graphicsLayer
 import com.matedroid.ui.icons.CustomIcons
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
@@ -140,12 +144,12 @@ fun DrivesScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            if (uiState.isLoading && !uiState.isRefreshing) {
+            if (uiState.isLoading && uiState.drives.isEmpty()) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(color = palette.accent)
                 }
             } else {
                 DrivesContent(
@@ -160,7 +164,8 @@ fun DrivesScreen(
                     listState = listState,
                     onDateFilterSelected = { viewModel.setDateFilter(it) },
                     onDistanceFilterSelected = { viewModel.setDistanceFilter(it) },
-                    onDriveClick = onNavigateToDriveDetail
+                    onDriveClick = onNavigateToDriveDetail,
+                    isLoading = uiState.isLoading
                 )
             }
         }
@@ -179,13 +184,24 @@ private fun DrivesContent(
     units: Units?,
     palette: CarColorPalette,
     listState: androidx.compose.foundation.lazy.LazyListState,
+    isLoading: Boolean, // New parameter for loading state
     onDateFilterSelected: (DriveDateFilter) -> Unit,
     onDistanceFilterSelected: (DriveDistanceFilter) -> Unit,
     onDriveClick: (driveId: Int) -> Unit
 ) {
+    // Animation of opacity: 0.6f when loading, 1f when ready.
+    // The "tween" of 300ms makes the change not abrupt.
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (isLoading) 0.6f else 1f,
+        animationSpec = tween(durationMillis = 300),
+        label = "drivesContentAlpha"
+    )
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize(),
+        // Use graphicsLayer to apply opacity more efficiently
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer(alpha = contentAlpha),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -196,7 +212,6 @@ private fun DrivesContent(
                 onFilterSelected = onDateFilterSelected
             )
         }
-
         item {
             DistanceFilterChips(
                 selectedFilter = selectedDistanceFilter,
@@ -205,11 +220,9 @@ private fun DrivesContent(
                 onFilterSelected = onDistanceFilterSelected
             )
         }
-
         item {
             SummaryCard(summary = summary, palette = palette)
         }
-
         // Drives charts (daily/weekly/monthly based on date range) - swipeable
         if (chartData.isNotEmpty()) {
             item {
@@ -221,7 +234,6 @@ private fun DrivesContent(
                 )
             }
         }
-
         item {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
@@ -230,8 +242,7 @@ private fun DrivesContent(
                 fontWeight = FontWeight.Bold
             )
         }
-
-        if (drives.isEmpty()) {
+        if (drives.isEmpty() && !isLoading) { // Solo mostramos "vacío" si no está cargando
             item {
                 Card(
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -122,25 +123,23 @@ class DrivesViewModel @Inject constructor(
         // Only apply default filter on first initialization
         if (!isInitialized) {
             isInitialized = true
-            applyDateFilterEnum(_uiState.value.dateFilter)
+            setDateFilter(_uiState.value.dateFilter)
         }
     }
 
     fun setDateFilter(filter: DriveDateFilter) {
-        _uiState.update { it.copy(dateFilter = filter) }
-        applyDateFilterEnum(filter)
-    }
-
-    private fun applyDateFilterEnum(filter: DriveDateFilter) {
-        if (filter.days != null) {
-            val endDate = LocalDate.now()
-            val startDate = endDate.minusDays(filter.days)
-            _uiState.update { it.copy(startDate = startDate, endDate = endDate) }
-            loadDrives(startDate, endDate)
-        } else {
-            _uiState.update { it.copy(startDate = null, endDate = null) }
-            loadDrives(null, null)
+        val endDate = LocalDate.now()
+        val startDate = filter.days?.let { days ->
+            if (days > 0) endDate.minusDays(days - 1) else endDate
         }
+        _uiState.update { it.copy(
+            dateFilter = filter,
+            startDate = startDate,
+            endDate = if (filter.days != null) endDate else null,
+            scrollPosition = 0,
+            scrollOffset = 0
+        )}
+        loadDrives(startDate, if (filter.days != null) endDate else null)
     }
 
     fun saveScrollPosition(index: Int, offset: Int) {
@@ -148,7 +147,11 @@ class DrivesViewModel @Inject constructor(
     }
 
     fun setDistanceFilter(filter: DriveDistanceFilter) {
-        _uiState.update { it.copy(distanceFilter = filter) }
+        _uiState.update { it.copy(
+            distanceFilter = filter,
+            scrollPosition = 0,
+            scrollOffset = 0
+            ) }
         applyFiltersAndUpdateState()
     }
 
@@ -251,7 +254,7 @@ class DrivesViewModel @Inject constructor(
 
         // Calculate summary and chart data from filtered drives
         val summary = calculateSummary(drivesForStats)
-        val chartData = calculateChartData(drivesForStats, granularity)
+        val chartData = calculateChartData(drivesForStats, granularity, state.startDate)
 
         _uiState.update {
             it.copy(
@@ -274,50 +277,77 @@ class DrivesViewModel @Inject constructor(
         }
     }
 
-    private fun calculateChartData(drives: List<DriveData>, granularity: DriveChartGranularity): List<DriveChartData> {
+    private fun calculateChartData(drives: List<DriveData>, granularity: DriveChartGranularity, startDate: LocalDate?): List<DriveChartData> {
         if (drives.isEmpty()) return emptyList()
 
         val formatter = DateTimeFormatter.ISO_DATE_TIME
         val weekFields = WeekFields.of(Locale.getDefault())
 
-        return drives
-            .mapNotNull { drive ->
+        //  Group the charges by day
+        val drivesByDay = drives.mapNotNull { drive ->
+            drive.startDate?.let {
+                try {
+                    val date = LocalDateTime.parse(it, formatter).toLocalDate()
+                    date.toEpochDay() to drive
+                } catch (e: Exception) { null }
+            }
+        }.groupBy({ it.first }, { it.second })
+
+        return if (granularity == DriveChartGranularity.DAILY) {
+            // DAILY ranges (today, last 7 and last 30 days
+            // If not startDate (All Time), get the first trip, or today
+            val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
+            val end = LocalDate.now()
+            val result = mutableListOf<DriveChartData>()
+            var current = start
+            while (!current.isAfter(end)) {
+                val key = current.toEpochDay()
+                val drivesInDay = drivesByDay[key] ?: emptyList()
+                result.add(
+                    createChartPoint(
+                        label = current.format(DateTimeFormatter.ofPattern("d/M")),
+                        sortKey = key,
+                        drives = drivesInDay
+                    )
+                )
+                current = current.plusDays(1)
+            }
+            result
+        } else {
+            // WEEKLY and MONTHLY ranges
+            drives.mapNotNull { drive ->
                 drive.startDate?.let { dateStr ->
                     try {
-                        val date = LocalDate.parse(dateStr, formatter)
+                        val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
                         val (label, sortKey) = when (granularity) {
-                            DriveChartGranularity.DAILY -> {
-                                val dayLabel = date.format(DateTimeFormatter.ofPattern("d/M"))
-                                dayLabel to date.toEpochDay()
-                            }
                             DriveChartGranularity.WEEKLY -> {
-                                val weekOfYear = date.get(weekFields.weekOfWeekBasedYear())
-                                val year = date.get(weekFields.weekBasedYear())
-                                "W$weekOfYear" to (year * 100L + weekOfYear)
+                                val firstDay = date.with(weekFields.dayOfWeek(), 1)
+                                "W${date.get(weekFields.weekOfYear())}" to firstDay.toEpochDay()
                             }
-                            DriveChartGranularity.MONTHLY -> {
-                                val yearMonth = YearMonth.of(date.year, date.month)
-                                yearMonth.format(DateTimeFormatter.ofPattern("MMM yy")) to (date.year * 12L + date.monthValue)
+                            else -> { // MONTHLY
+                                date.format(DateTimeFormatter.ofPattern("MMM yy")) to YearMonth.from(date).atDay(1).toEpochDay()
                             }
                         }
                         Triple(label, sortKey, drive)
-                    } catch (e: Exception) {
-                        null
-                    }
+                    } catch (e: Exception) { null }
                 }
             }
-            .groupBy { Pair(it.first, it.second) }
-            .map { (key, drivesInPeriod) ->
-                DriveChartData(
-                    label = key.first,
-                    count = drivesInPeriod.size,
-                    totalDistance = drivesInPeriod.sumOf { it.third.distance ?: 0.0 },
-                    totalDurationMin = drivesInPeriod.sumOf { it.third.durationMin ?: 0 },
-                    maxSpeed = drivesInPeriod.maxOfOrNull { it.third.speedMax ?: 0 } ?: 0,
-                    sortKey = key.second
-                )
-            }
-            .sortedBy { it.sortKey }
+                .groupBy { it.first to it.second }
+                .map { (key, list) -> createChartPoint(key.first, key.second, list.map { it.third }) }
+                .sortedBy { it.sortKey }
+        }
+    }
+
+    // Helper function to centralize chart data creation
+    private fun createChartPoint(label: String, sortKey: Long, drives: List<DriveData>): DriveChartData {
+        return DriveChartData(
+            label = label,
+            count = drives.size,
+            totalDistance = drives.sumOf { it.distance ?: 0.0 },
+            totalDurationMin = drives.sumOf { it.durationMin ?: 0 },
+            maxSpeed = drives.maxOfOrNull { it.speedMax ?: 0 } ?: 0,
+            sortKey = sortKey
+        )
     }
 
     private fun calculateSummary(drives: List<DriveData>): DrivesSummary {


### PR DESCRIPTION
## Summary
Refactored scroll state persistence and loading logic in `Charges` and `Drives` modules to eliminate UI flickering and incorrect scroll restoration during data filtering.

## Changes
* **ViewModel State**: Forced explicit scroll resets (`scrollPosition = 0`, `scrollOffset = 0`) when updating filter criteria to ensure a clean list view.
* **Non-destructive Recomposition**: Modified UI screens to keep the list in the composition during data fetches, preventing `LazyListState` disposal and screen flickering.
* **Visual Feedback**: Implemented GPU-accelerated alpha transitions using `animateFloatAsState` and `graphicsLayer` to provide subtle feedback during background updates.
* **Smart Loading**: Optimized the loading logic to show a full-screen spinner only during initial empty-state loads, maintaining the existing list during subsequent refreshes.

fixes #117 