### PR TITLE
Fix/120 duplicate percent symbol

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -442,7 +442,7 @@
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degradació Estimada</string>
-    <string name="estimated_degradation_message">La degradació de la bateria s\'estima basant-se en dades de Teslamate.\n\n• Capacitat %%: Salut restant de la bateria comparada amb nova\n• Pèrdua (kWh): Capacitat energètica perduda per degradació\n• Pèrdua (%%): Percentatge de la capacitat original perduda\n\nNota: Això és una estimació. Tesla no proporciona dades oficials de degradació.</string>
+    <string name="estimated_degradation_message">La degradació de la bateria s\'estima basant-se en dades de Teslamate.\n\n• Capacitat (%): Salut restant de la bateria comparada amb nova\n• Pèrdua (kWh): Capacitat energètica perduda per degradació\n• Pèrdua (%): Percentatge de la capacitat original perduda\n\nNota: Això és una estimació. Tesla no proporciona dades oficials de degradació.</string>
 
     <!-- Range section -->
     <string name="range">Autonomia</string>
@@ -460,7 +460,7 @@
 
     <!-- Current charge info dialog -->
     <string name="current_charge_title">Càrrega Actual</string>
-    <string name="current_charge_message">Mostra l\'estat de càrrega actual de la bateria.\n\n• Bateria %%: El nivell de càrrega mostrat al tauler\n• Utilitzable %%: Càrrega realment utilitzable (Tesla reserva un petit búfer per protecció)\n\nAquesta és la càrrega actual, no la salut a llarg termini de la bateria.</string>
+    <string name="current_charge_message">Mostra l\'estat de càrrega actual de la bateria.\n • Bateria (%): El nivell de càrrega mostrat al tauler\n • Utilitzable (%): Càrrega realment utilitzable (Tesla reserva un petit búfer per protecció)\n \n Aquesta és la càrrega actual, no la salut a llarg termini de la bateria.</string>
 
     <!-- Range information section -->
     <string name="range_information">Informació d\'Autonomia</string>
@@ -477,7 +477,7 @@
 
     <!-- Estimated total capacity section -->
     <string name="estimated_total_capacity">Capacitat Total Estimada</string>
-    <string name="range_at_100">Autonomia al 100%%</string>
+    <string name="range_at_100">Autonomia al 100%</string>
     <!-- %1$d is the current battery percentage, %2$.1f is the rated range in km -->
     <string name="estimated_range_description">Estimació basada en el %1$d%% actual i autonomia nominal de %2$.1f km</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -442,7 +442,7 @@
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degradación Estimada</string>
-    <string name="estimated_degradation_message">La degradación de la batería se estima basándose en datos de Teslamate.\n\n• Capacidad %%: Salud restante de la batería comparada con nueva\n• Pérdida (kWh): Capacidad energética perdida por degradación\n• Pérdida (%%): Porcentaje de la capacidad original perdida\n\nNota: Esta es una estimación. Tesla no proporciona datos oficiales de degradación.</string>
+    <string name="estimated_degradation_message">La degradación de la batería se estima basándose en datos de Teslamate.\n\n• Capacidad (%): Salud restante de la batería comparada con nueva\n• Pérdida (kWh): Capacidad energética perdida por degradación\n• Pérdida (%): Porcentaje de la capacidad original perdida\n\n\nNota: Esta es una estimación. Tesla no proporciona datos oficiales de degradación.</string>
 
     <!-- Range section -->
     <string name="range">Autonomía</string>
@@ -460,7 +460,7 @@
 
     <!-- Current charge info dialog -->
     <string name="current_charge_title">Carga Actual</string>
-    <string name="current_charge_message">Muestra el estado de carga actual de tu batería.\n\n• Batería %%: El nivel de carga mostrado en el salpicadero\n• Utilizable %%: Carga realmente utilizable (Tesla reserva un pequeño búfer para protección)\n\nEsta es la carga actual, no la salud a largo plazo de la batería.</string>
+    <string name="current_charge_message">Muestra el estado de carga actual de tu batería.\n\n• Batería (%): El nivel de carga mostrado en el salpicadero\n• Utilizable (%): Carga realmente utilizable (Tesla reserva un pequeño búfer para protección)\n\nEsta es la carga actual, no la salud a largo plazo de la batería.</string>
 
     <!-- Range information section -->
     <string name="range_information">Información de Autonomía</string>
@@ -477,7 +477,7 @@
 
     <!-- Estimated total capacity section -->
     <string name="estimated_total_capacity">Capacidad Total Estimada</string>
-    <string name="range_at_100">Autonomía al 100%%</string>
+    <string name="range_at_100">Autonomía al 100%</string>
     <!-- %1$d is the current battery percentage, %2$.1f is the rated range in km -->
     <string name="estimated_range_description">Estimación basada en el %1$d%% actual y autonomía nominal de %2$.1f km</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -442,7 +442,7 @@
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Degrado Stimato</string>
-    <string name="estimated_degradation_message">Il degrado della batteria è stimato in base ai dati di Teslamate.\n\n• Capacità %%: Salute residua della batteria rispetto al nuovo\n• Perdita (kWh): Capacità energetica persa per degrado\n• Perdita (%%): Percentuale della capacità originale persa\n\nNota: Questa è una stima. Tesla non fornisce dati ufficiali sul degrado.</string>
+    <string name="estimated_degradation_message">Il degrado della batteria è stimato in base ai dati di Teslamate.\n\n• Capacità (%): Salute residua della batteria rispetto al nuovo\n• Perdita (kWh): Capacità energetica persa per degrado\n• Perdita (%): Percentuale della capacità originale persa\n\nNota: Questa è una stima. Tesla non fornisce dati ufficiali sul degrado.</string>
 
     <!-- Range section -->
     <string name="range">Autonomia</string>
@@ -460,7 +460,7 @@
 
     <!-- Current charge info dialog -->
     <string name="current_charge_title">Carica Attuale</string>
-    <string name="current_charge_message">Mostra lo stato di carica attuale della batteria.\n\n• Batteria %%: Il livello di carica mostrato sul cruscotto\n• Utilizzabile %%: Carica effettivamente utilizzabile (Tesla riserva un piccolo buffer per protezione)\n\nQuesta è la carica attuale, non la salute a lungo termine della batteria.</string>
+    <string name="current_charge_message">Mostra lo stato di carica attuale della batteria.\n\n • Batteria (%): Il livello di carica mostrato sul cruscotto\n • Utilizzabile (%): Carica effettivamente utilizzabile (Tesla riserva un piccolo buffer per protezione)\n\nQuesta è la carica attuale, non la salute a lungo termine della batteria.</string>
 
     <!-- Range information section -->
     <string name="range_information">Informazioni Autonomia</string>
@@ -477,7 +477,7 @@
 
     <!-- Estimated total capacity section -->
     <string name="estimated_total_capacity">Capacità Totale Stimata</string>
-    <string name="range_at_100">Autonomia al 100%%</string>
+    <string name="range_at_100">Autonomia al 100%</string>
     <!-- %1$d is the current battery percentage, %2$.1f is the rated range in km -->
     <string name="estimated_range_description">Stima basata sul %1$d%% attuale e autonomia nominale di %2$.1f km</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,7 +442,7 @@
 
     <!-- Degradation info dialog -->
     <string name="estimated_degradation_title">Estimated Degradation</string>
-    <string name="estimated_degradation_message">Battery degradation is estimated based on Teslamate data.\n\n• Capacity %%: Remaining battery health compared to new\n• Loss (kWh): Energy capacity lost due to degradation\n• Loss (%%): Percentage of original capacity lost\n\nNote: This is an estimate. Tesla does not provide official degradation data.</string>
+    <string name="estimated_degradation_message">Battery degradation is estimated based on Teslamate data.\n\n• Capacity (%): Remaining battery health compared to new\n• Loss (kWh): Energy capacity lost due to degradation\n• Loss (%): Percentage of original capacity lost\n\nNote: This is an estimate. Tesla does not provide official degradation data.</string>
 
     <!-- Range section -->
     <string name="range">Range</string>
@@ -460,7 +460,7 @@
 
     <!-- Current charge info dialog -->
     <string name="current_charge_title">Current Charge</string>
-    <string name="current_charge_message">Shows your battery\'s current state of charge.\n\n• Battery %%: The charge level displayed on your dashboard\n• Usable %%: Actual usable charge (Tesla reserves a small buffer for battery protection)\n\nThis is the current charge, not the battery\'s long-term health.</string>
+    <string name="current_charge_message">Shows your battery\'s current state of charge.\n\n • Battery (%): The charge level displayed on your dashboard\n • Usable (%): Actual usable charge (Tesla reserves a small buffer for battery protection)\n\nThis is the current charge, not the battery\'s long-term health.</string>
 
     <!-- Range information section -->
     <string name="range_information">Range Information</string>
@@ -477,7 +477,7 @@
 
     <!-- Estimated total capacity section -->
     <string name="estimated_total_capacity">Estimated Total Capacity</string>
-    <string name="range_at_100">Range at 100%%</string>
+    <string name="range_at_100">Range at 100%</string>
     <!-- %1$d is the current battery percentage, %2$.1f is the rated range in km -->
     <string name="estimated_range_description">Estimate based on current %1$d%% and rated range of %2$.1f km</string>
 


### PR DESCRIPTION
Fixed `percent` string in ES/IT/CA locales that incorrectly used `%%` instead of `%`
The escape sequence `%%` is only needed when format placeholders are present; this static label doesn't need it

fix #120 