### PR TITLE
fix: eliminate screen flickering when changing time filters (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Model X**: Wheels now display correctly in car images (fixes #119)
+- **Drives/Charges**: Screen no longer flickers when changing time filters (fixes #117)
 
 ## [0.12.3] - 2026-01-27
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -168,7 +168,8 @@ class ChargesViewModel @Inject constructor(
 
         viewModelScope.launch {
             val state = _uiState.value
-            if (!state.isRefreshing) {
+            // Only show loading spinner on initial load, not when changing filters
+            if (!state.isRefreshing && state.charges.isEmpty()) {
                 _uiState.update { it.copy(isLoading = true) }
             }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -180,7 +180,8 @@ class DrivesViewModel @Inject constructor(
 
         viewModelScope.launch {
             val state = _uiState.value
-            if (!state.isRefreshing) {
+            // Only show loading spinner on initial load, not when changing filters
+            if (!state.isRefreshing && state.drives.isEmpty()) {
                 _uiState.update { it.copy(isLoading = true) }
             }
 


### PR DESCRIPTION
## Summary
Fixes the screen flickering that occurred when applying time filters (Today, Last 7 days, etc.) on the Charges and Drives screens.

Fixes #117

## Root Cause
Time filters triggered `loadCharges()`/`loadDrives()` which set `isLoading = true`. This caused the UI to show a loading spinner, replacing the existing content, then swap back when data loaded - causing visible flickering.

Other filters (charge type AC/DC, trip length) did not have this issue because they only called `applyFiltersAndUpdateState()` which filters locally without changing the loading state.

## Solution
Modified `loadCharges()` and `loadDrives()` to only show the loading spinner on initial load (when no data exists), not when changing filters with existing data already displayed.

The condition was changed from:
```kotlin
if (!state.isRefreshing) {
    _uiState.update { it.copy(isLoading = true) }
}
```

To:
```kotlin
if (!state.isRefreshing && state.charges.isEmpty()) {
    _uiState.update { it.copy(isLoading = true) }
}
```

## Test Plan
- [x] Unit tests pass
- [ ] Manual testing: Open Charges screen, switch between time filters - no flickering
- [ ] Manual testing: Open Drives screen, switch between time filters - no flickering
- [ ] Verify initial load still shows loading spinner correctly

Generated with [Claude Code](https://claude.com/claude-code)