### PR TITLE
fix: use AC/DC instead of CA/CC in translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Charging Notifications**: Live update notifications during charging sessions (Android 16+) with visual battery progress bar showing current level and charge limit. Falls back to standard dismissable notifications on older Android versions.
 
+### Fixed
+- **Stats for nerds**: Fixed AC/DC translation inconsistency - technical terms should not be translated (CA/CC → AC/DC)
+
 ## [0.12.4] - 2026-01-29
 
 ### Changed

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -658,7 +658,7 @@
     <string name="stats_cabin_temperature">Temperatura de l\'Habitacle</string>
 
     <!-- Section: ratio between AC and DC charging -->
-    <string name="stats_ac_dc_ratio">Ràtio CA/CC</string>
+    <string name="stats_ac_dc_ratio">Ràtio AC/DC</string>
 
     <!-- Label for energy charged via AC -->
     <string name="stats_ac_energy">Energia AC</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -658,7 +658,7 @@
     <string name="stats_cabin_temperature">Temperatura del Habitáculo</string>
 
     <!-- Section: ratio between AC and DC charging -->
-    <string name="stats_ac_dc_ratio">Ratio CA/CC</string>
+    <string name="stats_ac_dc_ratio">Ratio AC/DC</string>
 
     <!-- Label for energy charged via AC -->
     <string name="stats_ac_energy">Energía AC</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -658,7 +658,7 @@
     <string name="stats_cabin_temperature">Temperatura Abitacolo</string>
 
     <!-- Section: ratio between AC and DC charging -->
-    <string name="stats_ac_dc_ratio">Rapporto CA/CC</string>
+    <string name="stats_ac_dc_ratio">Rapporto AC/DC</string>
 
     <!-- Label for energy charged via AC -->
     <string name="stats_ac_energy">Energia AC</string>


### PR DESCRIPTION
## Summary
Fixed translation inconsistency in the "Stats for nerds" page where `stats_ac_dc_ratio` was using translated terms (CA/CC) while `stats_ac_energy` and `stats_dc_energy` were correctly using AC/DC.

## Root Cause
The translation strings were inconsistent - `stats_ac_dc_ratio` used localized abbreviations (CA/CC for Corriente Alterna/Corriente Continua) while other AC/DC strings kept the technical terms untranslated.

Per project guidelines in CLAUDE.md: "Technical terms like AC, DC, kW, kWh should NOT be translated."

## Solution
Changed `stats_ac_dc_ratio` from localized form to keep AC/DC:
- Spanish: "Ratio CA/CC" → "Ratio AC/DC"
- Italian: "Rapporto CA/CC" → "Rapporto AC/DC"
- Catalan: "Ràtio CA/CC" → "Ràtio AC/DC"

## Test Plan
- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Manual verification: Open Stats for nerds screen in Spanish/Italian/Catalan and verify AC/DC labels are consistent

Generated with [Claude Code](https://claude.com/claude-code)