### PR TITLE
Add mock skill and Makefile targets for testing

### DIFF
--- a/.claude/skills/mock/SKILL.md
+++ b/.claude/skills/mock/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: mock
+description: Start the Teslamate API mock server to test car image rendering with different vehicle configurations. Takes a description of the car to mock.
+allowed-tools: Read, Bash
+---
+
+# Mock Server
+
+Start the Teslamate API mock server to test car image rendering with different vehicle configurations.
+
+## Usage
+
+The skill takes a description of the car model to mock as an argument. It will find the closest matching profile in `mockserver/cars.json` and start the server on port 4002.
+
+Example arguments:
+- `silver model y legacy apollo`
+- `white model 3 highland`
+- `grey juniper performance`
+- `model y juniper white 19`
+
+## Instructions
+
+1. Read the `.env` file to get `TESLAMATE_API_URL` as the upstream URL
+2. Read `mockserver/cars.json` to list available profiles
+3. Match the user's description to a profile name (partial matching is fine)
+4. Start the mock server with:
+   ```bash
+   cd /home/vide/git/matedroid/mockserver && ./server.py -u <upstream_url> -c <profile_name> -p 4002
+   ```
+5. Tell the user that the mock server is running and they should configure the app to use `http://<local_ip>:4002` as the API URL
+
+## Available Profiles
+
+Profiles follow naming convention: `model[3|y|s|x]_[variant]_[color]_[wheel]`
+
+Common variants:
+- Model 3: `legacy`, `highland`, `highland_perf`
+- Model Y: `legacy`, `juniper`, `juniper_perf`
+- Model S/X: `plaid`, `100d`
+
+Common colors: `white`, `black`, `silver`, `grey`, `blue`, `red`, `diamond`, `quicksilver`
+
+To list all profiles, run:
+```bash
+cd /home/vide/git/matedroid/mockserver && ./server.py --list-cars -u http://localhost -c dummy
+```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install run build-release install-release run-release clean test help
+.PHONY: build install run build-release install-release run-release clean test help mock-list
 
 # Default target
 help:
@@ -11,6 +11,10 @@ help:
 	@echo "  run-release     - Build, install, and launch the app (release)"
 	@echo "  clean           - Clean build artifacts"
 	@echo "  test            - Run unit tests"
+	@echo "  mock-list       - List available mock server car profiles"
+	@echo ""
+	@echo "Mock server (requires UPSTREAM and CAR):"
+	@echo "  make mock UPSTREAM=http://api:4000 CAR=modely_legacy_silver_apollo"
 
 # Build debug APK
 build:
@@ -43,3 +47,18 @@ clean:
 # Run unit tests
 test:
 	./gradlew testDebugUnitTest
+
+# List available mock server car profiles
+mock-list:
+	@cd mockserver && ./server.py --list-cars -u http://localhost -c dummy 2>/dev/null || true
+
+# Start mock server (requires UPSTREAM and CAR variables)
+# Usage: make mock UPSTREAM=http://teslamate-api:4000 CAR=modely_legacy_silver_apollo
+mock:
+ifndef UPSTREAM
+	$(error UPSTREAM is required. Example: make mock UPSTREAM=http://api:4000 CAR=modely_legacy_silver_apollo)
+endif
+ifndef CAR
+	$(error CAR is required. Run 'make mock-list' to see available profiles)
+endif
+	cd mockserver && ./server.py -u $(UPSTREAM) -c $(CAR) -p 4002

--- a/mockserver/cars.json
+++ b/mockserver/cars.json
@@ -98,6 +98,10 @@
     "car_details": { "model": "Y", "trim_badging": "74D" },
     "car_exterior": { "exterior_color": "MidnightSilver", "spoiler_type": "None", "wheel_type": "Gemini19" }
   },
+  "modely_legacy_silver_apollo": {
+    "car_details": { "model": "Y", "trim_badging": "74D" },
+    "car_exterior": { "exterior_color": "MidnightSilver", "spoiler_type": "None", "wheel_type": "Apollo19" }
+  },
   "modely_legacy_blue_gemini": {
     "car_details": { "model": "Y", "trim_badging": "74D" },
     "car_exterior": { "exterior_color": "DeepBlue", "spoiler_type": "None", "wheel_type": "Gemini19" }


### PR DESCRIPTION
## Summary
- Create `/mock` skill to start Teslamate API mock server with a car description
- Add `make mock` target with `UPSTREAM` and `CAR` parameters
- Add `make mock-list` to list available car profiles
- Add `modely_legacy_silver_apollo` profile for testing issue #134

## Usage

### Via skill
```
/mock silver model y legacy apollo
```

### Via Makefile
```bash
make mock-list                                                    # List profiles
make mock UPSTREAM=http://teslamate:4000 CAR=modely_legacy_silver_apollo
```

## Test plan
- [ ] Run `make mock-list` to verify profiles are listed
- [ ] Run `/mock` skill with a car description
- [ ] Verify mock server starts on port 4002

🤖 Generated with [Claude Code](https://claude.com/claude-code)