### PR TITLE
fix(ui): center text in loading and error screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Stats for nerds**: Fixed AC/DC translation inconsistency - technical terms should not be translated (CA/CC → AC/DC)
+- **Dashboard**: Loading and error messages now properly center each line when text wraps
 
 ## [0.12.4] - 2026-01-29
 

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.graphics.graphicsLayer
@@ -327,10 +328,16 @@ private fun LoadingContent() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        ) {
             CircularProgressIndicator()
             Spacer(modifier = Modifier.height(16.dp))
-            Text(stringResource(R.string.loading_vehicle_data))
+            Text(
+                text = stringResource(R.string.loading_vehicle_data),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -341,7 +348,10 @@ private fun EmptyContent() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        ) {
             Icon(
                 imageVector = Icons.Filled.DirectionsCar,
                 contentDescription = null,
@@ -351,12 +361,14 @@ private fun EmptyContent() {
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(R.string.no_vehicles_found),
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center
             )
             Text(
                 text = stringResource(R.string.no_vehicles_hint),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
         }
     }
@@ -380,13 +392,15 @@ private fun ErrorContent(
             Text(
                 text = stringResource(R.string.error_loading_data),
                 style = MaterialTheme.typography.titleMedium,
-                color = StatusError
+                color = StatusError,
+                textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
             if (details != null) {
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -139,13 +140,18 @@ fun SettingsScreen(
 @Composable
 private fun LoadingContent(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         CircularProgressIndicator()
         Spacer(modifier = Modifier.height(16.dp))
-        Text(stringResource(R.string.loading_settings))
+        Text(
+            text = stringResource(R.string.loading_settings),
+            textAlign = TextAlign.Center
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
Loading and error messages in Dashboard and Settings screens now properly center each line when text wraps, especially important for translations.

## Changes
- Added `textAlign = TextAlign.Center` to text components in:
  - `LoadingContent` in DashboardScreen
  - `EmptyContent` in DashboardScreen
  - `ErrorContent` in DashboardScreen
  - `LoadingContent` in SettingsScreen
- Added horizontal padding to ensure text doesn't touch screen edges

## Test Plan
- [ ] Change device language to a language with longer translations (e.g., Italian, Spanish)
- [ ] Verify loading screen text is centered on each line
- [ ] Disconnect from server and verify error message is centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)