### PR TITLE
Remove Z from start/end dates in Today filters

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -179,9 +179,19 @@ class ChargesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format: 2006-01-02T15:04:05Z but Z excludes early hours.
-            val startDateStr = startDate?.let { "${it}T00:00:00" }
-            val endDateStr = endDate?.let { "${it}T23:59:59" }
+            // API expects RFC3339 format:
+            // 2006-01-02T15:04:05Z for UTC time
+            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
+            val zoneId = java.time.ZoneId.systemDefault()
+            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
+            val startDateStr = startDate?.let {
+                val offset = zoneId.rules.getOffset(it.atStartOfDay())
+                "${it}T00:00:00${offset.toString()}"
+            }
+            val endDateStr = endDate?.let {
+                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
+                "${it}T23:59:59${offset.toString()}"
+            }
 
             // Fetch charge IDs from local database aggregates
             val dcChargeIds = try {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -185,9 +185,19 @@ class DrivesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format: 2006-01-02T15:04:05Z but Z excludes early hours.
-            val startDateStr = startDate?.let { "${it}T00:00:00" }
-            val endDateStr = endDate?.let { "${it}T23:59:59" }
+            // API expects RFC3339 format:
+            // 2006-01-02T15:04:05Z for UTC time
+            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
+            val zoneId = java.time.ZoneId.systemDefault()
+            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
+            val startDateStr = startDate?.let {
+                val offset = zoneId.rules.getOffset(it.atStartOfDay())
+                "${it}T00:00:00${offset.toString()}"
+            }
+            val endDateStr = endDate?.let {
+                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
+                "${it}T23:59:59${offset.toString()}"
+            }
 
             when (val result = repository.getDrives(id, startDateStr, endDateStr)) {
                 is ApiResult.Success -> {


### PR DESCRIPTION
The documentation mentions supporting "Canonical UTC format in RFC3339, e.g. 2006-01-02T15:04:05Z", but it seems the Z suffix might be interpreted differently than expected.

I have a charge that started at `2026-02-07T00:20:00+01:00`. When I query:
GET /api/v1/cars/1/charges?startDate=2026-02-07T00:00:00Z&endDate=2026-02-07T23:59:59Z
No charges returned

But when I use either of these formats, it works:
GET /api/v1/cars/1/charges?startDate=2026-02-07T00:00:00
GET /api/v1/cars/1/charges?startDate=2026-02-07T00:00:00+01:00
Charge is returned 

I also created an Issue in TeslamateApi GitHub:
https://github.com/tobiasehlert/teslamateapi/issues/446