### PR TITLE
fix timezone in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **"Where was I?" screen redesign**: the separate Location and State cards are merged into a single "what + where" card, with a state-aware sentence on top — "Heading to Home" / "Charging at Tesla SC" / "Parked at Home" — that makes the relationship between the activity and the named place unambiguous (no more bare "Home" appearing during a drive headed home). The map is now fully interactive — single-finger drag pans, pinch zooms — and a new "Open in Maps" button overlay on the map opens the location in your external maps app. The chevron that opens the related drive/charge moved to the top-right of the merged card, vertically aligned with the title.
 
+### Fixed
+- **"Today" filter showed the wrong day's drives/charges outside UTC**: date filters were sent to the API as UTC midnight (`...T00:00:00Z`) regardless of your timezone, so the "today" window was shifted by your UTC offset — pulling in the previous day's activity for users behind UTC (e.g. the Americas) and dropping early-morning activity for users ahead of it (e.g. Europe). Filters now use your device's local timezone offset, computed per boundary so DST days are correct. Same fix applied to the "Where was I?" date window.
+
 ## [1.7.0] - 2026-04-30
 
 Complete visual refresh of the **drives and charges lists**, plus a new fast-scroll bar and several smaller fixes.

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -183,7 +183,6 @@ class ChargesViewModel @Inject constructor(
             // 2006-01-02T15:04:05Z for UTC time
             // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
             val zoneId = java.time.ZoneId.systemDefault()
-            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
             val startDateStr = startDate?.let {
                 val offset = zoneId.rules.getOffset(it.atStartOfDay())
                 "${it}T00:00:00${offset.toString()}"

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -318,7 +318,6 @@ class ChargesViewModel @Inject constructor(
             // 2006-01-02T15:04:05Z for UTC time
             // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
             val zoneId = java.time.ZoneId.systemDefault()
-            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
             val startDateStr = startDate?.let {
                 val offset = zoneId.rules.getOffset(it.atStartOfDay())
                 "${it}T00:00:00${offset.toString()}"

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -314,9 +314,19 @@ class ChargesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format: 2006-01-02T15:04:05Z
-            val startDateStr = startDate?.let { "${it}T00:00:00Z" }
-            val endDateStr = endDate?.let { "${it}T23:59:59Z" }
+            // API expects RFC3339 format:
+            // 2006-01-02T15:04:05Z for UTC time
+            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
+            val zoneId = java.time.ZoneId.systemDefault()
+            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
+            val startDateStr = startDate?.let {
+                val offset = zoneId.rules.getOffset(it.atStartOfDay())
+                "${it}T00:00:00${offset.toString()}"
+            }
+            val endDateStr = endDate?.let {
+                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
+                "${it}T23:59:59${offset.toString()}"
+            }
 
             // Fetch charge IDs from local database aggregates
             val dcChargeIds = try {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -185,9 +185,19 @@ class DrivesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format: 2006-01-02T15:04:05Z
-            val startDateStr = startDate?.let { "${it}T00:00:00Z" }
-            val endDateStr = endDate?.let { "${it}T23:59:59Z" }
+            // API expects RFC3339 format:
+            // 2006-01-02T15:04:05Z for UTC time
+            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
+            val zoneId = java.time.ZoneId.systemDefault()
+            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
+            val startDateStr = startDate?.let {
+                val offset = zoneId.rules.getOffset(it.atStartOfDay())
+                "${it}T00:00:00${offset.toString()}"
+            }
+            val endDateStr = endDate?.let {
+                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
+                "${it}T23:59:59${offset.toString()}"
+            }
 
             when (val result = repository.getDrives(id, startDateStr, endDateStr)) {
                 is ApiResult.Success -> {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -189,7 +189,6 @@ class DrivesViewModel @Inject constructor(
             // 2006-01-02T15:04:05Z for UTC time
             // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
             val zoneId = java.time.ZoneId.systemDefault()
-            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
             val startDateStr = startDate?.let {
                 val offset = zoneId.rules.getOffset(it.atStartOfDay())
                 "${it}T00:00:00${offset.toString()}"

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -263,7 +263,6 @@ class DrivesViewModel @Inject constructor(
             // 2006-01-02T15:04:05Z for UTC time
             // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
             val zoneId = java.time.ZoneId.systemDefault()
-            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
             val startDateStr = startDate?.let {
                 val offset = zoneId.rules.getOffset(it.atStartOfDay())
                 "${it}T00:00:00${offset.toString()}"

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -259,9 +259,19 @@ class DrivesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format: 2006-01-02T15:04:05Z
-            val startDateStr = startDate?.let { "${it}T00:00:00Z" }
-            val endDateStr = endDate?.let { "${it}T23:59:59Z" }
+            // API expects RFC3339 format:
+            // 2006-01-02T15:04:05Z for UTC time
+            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
+            val zoneId = java.time.ZoneId.systemDefault()
+            val offsetFormatter = DateTimeFormatter.ofPattern("xxx") // format: +01:00
+            val startDateStr = startDate?.let {
+                val offset = zoneId.rules.getOffset(it.atStartOfDay())
+                "${it}T00:00:00${offset.toString()}"
+            }
+            val endDateStr = endDate?.let {
+                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
+                "${it}T23:59:59${offset.toString()}"
+            }
 
             when (val result = repository.getDrives(id, startDateStr, endDateStr)) {
                 is ApiResult.Success -> {

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
@@ -83,9 +83,9 @@ class WhereWasIViewModel @Inject constructor(
                 val displayFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm")
                 _uiState.value = _uiState.value.copy(targetDateTime = targetTime.format(displayFormatter))
 
-                val dateStr = targetTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
-                val dayStart = "${dateStr}T00:00:00Z"
-                val dayEnd = "${dateStr}T23:59:59Z"
+                val targetDate = targetTime.toLocalDate()
+                val dayStart = startOfDayRfc3339(targetDate)
+                val dayEnd = endOfDayRfc3339(targetDate)
 
                 // Fetch drives, charges, and units in parallel
                 val drivesDeferred = async { repository.getDrives(carId, dayStart, dayEnd) }
@@ -333,8 +333,8 @@ class WhereWasIViewModel @Inject constructor(
      * The API returns results most-recent-first, so show=1 is a cheap query.
      */
     private suspend fun findLastActivityInHistory(carId: Int, targetTime: LocalDateTime): ActivityEnd? = coroutineScope {
-        val searchEnd = targetTime.format(DateTimeFormatter.ISO_LOCAL_DATE) + "T00:00:00Z"
-        val searchStart = targetTime.minusYears(1).format(DateTimeFormatter.ISO_LOCAL_DATE) + "T00:00:00Z"
+        val searchEnd = startOfDayRfc3339(targetTime.toLocalDate())
+        val searchStart = startOfDayRfc3339(targetTime.toLocalDate().minusYears(1))
 
         val drivesDeferred = async {
             repository.getDrives(carId, searchStart, searchEnd, page = 1, show = 1)
@@ -464,6 +464,21 @@ class WhereWasIViewModel @Inject constructor(
 
     private fun parseEndLatFromAddress(drive: DriveData): Double? = null
     private fun parseEndLonFromAddress(drive: DriveData): Double? = null
+
+    // RFC3339 day boundaries in the device's local timezone. Using an explicit offset
+    // (e.g. +02:00) instead of a hardcoded Z keeps the "this date" window aligned with the
+    // user's local day — without it, the query window is shifted by the UTC offset and pulls
+    // in (or drops) activity from the adjacent local day. Offset is computed per boundary so
+    // DST transition days are handled correctly.
+    private fun startOfDayRfc3339(date: java.time.LocalDate): String {
+        val offset = java.time.ZoneId.systemDefault().rules.getOffset(date.atStartOfDay())
+        return "${date}T00:00:00$offset"
+    }
+
+    private fun endOfDayRfc3339(date: java.time.LocalDate): String {
+        val offset = java.time.ZoneId.systemDefault().rules.getOffset(date.atTime(23, 59, 59))
+        return "${date}T23:59:59$offset"
+    }
 
     companion object {
         private const val TAG = "WhereWasIViewModel"


### PR DESCRIPTION
## Fix: Use explicit timezone offset in API date parameters

### Problem
Previously, date parameters sent to TeslaMateAPI were formatted as UTC (e.g., `2026-02-07T00:00:00Z`), instead of local time + timezone offset (e.g., `2026-02-07T00:00:00+01:00`)
. This approach had several issues:
- Assumes API server is in the same timezone as the client and both UTC
- Not portable across different timezones
- "Today" filters omitted charges or drives made before the timezone offset (e.g., for Europe/Madrid all those started between 00 and 01 local time)

### Solution
Now explicitly calculates and includes the system timezone offset in date strings (e.g., `2026-02-07T00:00:00+01:00`), following RFC3339 standard.

Changes:
- Calculates timezone offset using `ZoneId.systemDefault()`
- Applies offset to both `startDate` and `endDate` parameters
- Handles daylight saving time correctly by calculating offset per date

### Benefits
- RFC3339 compliant
- Works regardless of API server timezone
- Portable across different user timezones