### PR TITLE
fixed missing queries for yearly average

### DIFF
--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -155,6 +155,15 @@ interface AggregateDao {
     """)
     suspend fun coldestDrive(carId: Int): DriveDetailAggregate?
 
+    // Coldest outside temperature while driving in Range
+    @Query("""
+        SELECT MIN(minOutsideTemp) FROM drive_detail_aggregates a
+        JOIN drives_summary d ON a.driveId = d.driveId
+        WHERE a.carId = :carId
+        AND d.startDate >= :startDate AND d.startDate < :endDate
+    """)
+    suspend fun minOutsideTempDrivingInRange(carId: Int, startDate: String, endDate: String): Double?
+
     @Query("""
         SELECT a.* FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
@@ -163,6 +172,33 @@ interface AggregateDao {
         ORDER BY a.minOutsideTemp ASC LIMIT 1
     """)
     suspend fun coldestDriveInRange(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+
+    // Hottest cabin temperature in Range
+    @Query("""
+        SELECT MAX(maxInsideTemp) FROM drive_detail_aggregates a
+        JOIN drives_summary d ON a.driveId = d.driveId
+        WHERE a.carId = :carId
+        AND d.startDate >= :startDate AND d.startDate < :endDate
+    """)
+    suspend fun maxInsideTempInRange(carId: Int, startDate: String, endDate: String): Double?
+
+    // Coldest cabin temperature in Range
+    @Query("""
+        SELECT MIN(minInsideTemp) FROM drive_detail_aggregates a
+        JOIN drives_summary d ON a.driveId = d.driveId
+        WHERE a.carId = :carId
+        AND d.startDate >= :startDate AND d.startDate < :endDate
+    """)
+    suspend fun minInsideTempInRange(carId: Int, startDate: String, endDate: String): Double?
+
+    // Coldest outside temperature while charging in Range
+    @Query("""
+        SELECT MIN(minOutsideTemp) FROM charge_detail_aggregates a
+        JOIN charges_summary c ON a.chargeId = c.chargeId
+        WHERE a.carId = :carId
+        AND c.startDate >= :startDate AND c.startDate < :endDate
+    """)
+    suspend fun minOutsideTempChargingInRange(carId: Int, startDate: String, endDate: String): Double?
 
     // Hottest cabin temperature
     @Query("SELECT MAX(maxInsideTemp) FROM drive_detail_aggregates WHERE carId = :carId")

--- a/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
@@ -75,6 +75,17 @@ interface ChargeSummaryDao {
     """)
     suspend fun avgCostPerKwh(carId: Int): Double
 
+    // Average cost per kWh in range
+    @Query("""
+        SELECT COALESCE(SUM(cost) / NULLIF(SUM(energyAdded), 0), 0)
+        FROM charges_summary 
+        WHERE carId = :carId 
+        AND startDate >= :startDate 
+        AND startDate < :endDate
+        AND cost IS NOT NULL
+    """)
+    suspend fun avgCostPerKwhInRange(carId: Int, startDate: String, endDate: String): Double
+
     // Biggest single charge (by energy added)
     @Query("""
         SELECT * FROM charges_summary

--- a/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
@@ -154,7 +154,7 @@ class StatsRepository @Inject constructor(
             totalCharges = chargeSummaryDao.countInRange(carId, startDate, endDate),
             totalEnergyAddedKwh = chargeSummaryDao.sumEnergyAddedInRange(carId, startDate, endDate),
             totalCost = chargeSummaryDao.sumCostInRange(carId, startDate, endDate).takeIf { it > 0 },
-            avgCostPerKwh = null, // Not critical for year view
+            avgCostPerKwh = chargeSummaryDao.avgCostPerKwhInRange(carId, startDate, endDate).takeIf { it > 0 },
             avgChargeMinutes = null, // Not critical for year view
 
             longestDrive = driveSummaryDao.longestDriveInRange(carId, startDate, endDate),
@@ -389,9 +389,9 @@ class StatsRepository @Inject constructor(
             },
 
             maxOutsideTempDrivingC = aggregateDao.maxOutsideTempDrivingInRange(carId, startDate, endDate),
-            minOutsideTempDrivingC = null, // Not needed for records
-            maxCabinTempC = null, // Not needed for records
-            minCabinTempC = null, // Not needed for records
+            minOutsideTempDrivingC = aggregateDao.minOutsideTempDrivingInRange(carId, startDate, endDate),
+            maxCabinTempC = aggregateDao.maxInsideTempInRange(carId, startDate, endDate),
+            minCabinTempC = aggregateDao.minInsideTempInRange(carId, startDate, endDate),
             hottestDrive = hottestDriveAgg?.let { agg ->
                 val drive = driveSummaryDao.get(agg.driveId)
                 DriveTempRecord(
@@ -410,7 +410,7 @@ class StatsRepository @Inject constructor(
             },
 
             maxOutsideTempChargingC = aggregateDao.maxOutsideTempChargingInRange(carId, startDate, endDate),
-            minOutsideTempChargingC = null, // Not needed for records
+            minOutsideTempChargingC = aggregateDao.minOutsideTempChargingInRange(carId, startDate, endDate),
             hottestCharge = hottestChargeAgg?.let { agg ->
                 val charge = chargeSummaryDao.get(agg.chargeId)
                 ChargeTempRecord(


### PR DESCRIPTION
## Summary

Fixed missing statistics when filtering by year in the Stats screen. Previously, when any year filter was applied (not "All Time"), several values displayed as "N/A" even though data was available:
- **Avg Cost/kWh** in Charges Overview
- **Coldest** temperature in Temperature Extremes (charging)
- **Cabin Temperature** (both Hottest and Coldest)
- **Coldest While Driving** temperature

## Changes

### StatsRepository.kt
- Updated `getQuickStatsForYear()` to calculate `avgCostPerKwh` instead of setting it to null
- Updated `getDeepStatsForYear()` to calculate temperature extremes instead of setting them to null:
  - `minOutsideTempDrivingC`
  - `minOutsideTempChargingC`
  - `maxCabinTempC`
  - `minCabinTempC`

### ChargeSummaryDao.kt
- Added `avgCostPerKwhInRange()` method to calculate average cost per kWh within a date range

### AggregateDao.kt
- Added `maxInsideTempInRange()` to get max cabin temperature within a date range
- Added `minInsideTempInRange()` to get min cabin temperature within a date range
- Added `minOutsideTempChargingInRange()` to get coldest charging temperature within a date range
- Added `minOutsideTempDrivingInRange()` to get coldest driving temperature within a date range

## Testing

Verified that all previously missing values now display correctly when filtering by year, while "All Time" filter continues to work as expected.

fix #150 