### PR TITLE
fix: use distinct colors for V and A lines in live charge chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Notifications**: Charging notification now shows a 3-segment progress bar — charged (bright), charging-to-limit (dimmed), and beyond-limit (gray) — with bolt tracker at current SoC (#147)
+- **Live Charge Screen**: Voltage and Current lines in the V/A chart now use distinct colors (amber and blue) instead of similar gray tones
 
 ## [1.0.0] - 2026-02-08
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -263,8 +263,8 @@ private fun CurrentChargeContent(
                     FullscreenDualAxisLineChart(
                         dataLeft = voltages,
                         dataRight = currents,
-                        colorLeft = MaterialTheme.colorScheme.tertiary,
-                        colorRight = MaterialTheme.colorScheme.secondary,
+                        colorLeft = Color(0xFFFFA726),
+                        colorRight = Color(0xFF42A5F5),
                         unitLeft = "V",
                         unitRight = "A",
                         timeLabels = timeLabels,


### PR DESCRIPTION
## Summary

The Voltage and Current lines in the live charge screen's V/A chart used `MaterialTheme.colorScheme.tertiary` and `.secondary`, which are both grayish tones in our theme — nearly indistinguishable on the chart.

Changed to explicit distinct colors:
- **Voltage (V)**: Amber (`#FFA726`)
- **Current (A)**: Blue (`#42A5F5`)

## Test Plan
- [ ] Open live charge screen during an AC charge session
- [ ] Verify V and A lines are clearly distinguishable (amber vs blue)
- [ ] Verify Y-axis labels match their respective line colors
- [ ] Verify fullscreen chart also uses the correct colors

Generated with [Claude Code](https://claude.com/claude-code)