### PR TITLE
fix: guard live charge navigation behind API availability check (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dashboard / Notifications**: Live charge navigation and notification deep-link are now hidden when TeslaMate API < 1.24 (endpoint unavailable) (#155)
+
 ## [1.1.0-beta1] - 2026-02-10
 
 ### Changed

--- a/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
+++ b/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
@@ -219,9 +219,11 @@ class ChargingMonitorService : Service() {
                     activeNotificationCarIds.add(car.carId)
                     Log.d(TAG, "Car ${car.carId} charging at ${status.batteryLevel}%")
 
+                    val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(car.carId)
+
                     // Update notification with real data
                     val notificationId = ChargingNotificationManager.NOTIFICATION_ID_BASE + car.carId
-                    val notification = chargingNotificationManager.buildNotification(car, status)
+                    val notification = chargingNotificationManager.buildNotification(car, status, liveChargeAvailable)
 
                     // Switch to the real notification ID (replaces placeholder)
                     try {
@@ -237,7 +239,7 @@ class ChargingMonitorService : Service() {
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to update foreground notification", e)
                         // Fall back to just showing the notification
-                        chargingNotificationManager.showChargingNotification(car, status)
+                        chargingNotificationManager.showChargingNotification(car, status, liveChargeAvailable)
                     }
                 } else {
                     // Cancel notification for this car if not charging

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -270,6 +270,7 @@ fun DashboardScreen(
                         totalCharges = uiState.totalCharges,
                         totalDrives = uiState.totalDrives,
                         imageOverride = uiState.carImageOverride,
+                        isCurrentChargeAvailable = uiState.isCurrentChargeAvailable,
                         onNavigateToCharges = {
                             uiState.selectedCarId?.let { carId ->
                                 onNavigateToCharges(carId, uiState.selectedCarExterior?.exteriorColor)
@@ -451,6 +452,7 @@ private fun DashboardContent(
     totalCharges: Int? = null,
     totalDrives: Int? = null,
     imageOverride: CarImageOverride? = null,
+    isCurrentChargeAvailable: Boolean = false,
     onNavigateToCharges: () -> Unit = {},
     onNavigateToDrives: () -> Unit = {},
     onNavigateToBattery: () -> Unit = {},
@@ -500,6 +502,7 @@ private fun DashboardContent(
             carTrimBadging = carTrimBadging,
             carExterior = carExterior,
             imageOverride = imageOverride,
+            isCurrentChargeAvailable = isCurrentChargeAvailable,
             onNavigateToBattery = onNavigateToBattery,
             onNavigateToStats = onNavigateToStats,
             onNavigateToCurrentCharge = onNavigateToCurrentCharge,
@@ -1041,6 +1044,7 @@ private fun BatteryCard(
     carTrimBadging: String? = null,
     carExterior: CarExterior? = null,
     imageOverride: CarImageOverride? = null,
+    isCurrentChargeAvailable: Boolean = false,
     onNavigateToBattery: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToCurrentCharge: () -> Unit = {},
@@ -1121,8 +1125,8 @@ private fun BatteryCard(
                     )
                     if (status.isCharging) {
                         Spacer(modifier = Modifier.width(8.dp))
-                        // Mini charging gauge with AC/DC badge - tappable to open live charge
-                        Box(modifier = Modifier.clickable(onClick = onNavigateToCurrentCharge)) {
+                        // Mini charging gauge with AC/DC badge - tappable to open live charge if API available
+                        Box(modifier = if (isCurrentChargeAvailable) Modifier.clickable(onClick = onNavigateToCurrentCharge) else Modifier) {
                             ChargingPowerGaugeCompact(
                                 status = status,
                                 carTrimBadging = carTrimBadging
@@ -1180,11 +1184,11 @@ private fun BatteryCard(
 
             Spacer(modifier = Modifier.height(6.dp))
 
-            // Charging info row - shows details when charging, tappable to open live charge
+            // Charging info row - shows details when charging, tappable to open live charge if API available
             if (status.isCharging) {
                 Box(modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = onNavigateToCurrentCharge)
+                    .then(if (isCurrentChargeAvailable) Modifier.clickable(onClick = onNavigateToCurrentCharge) else Modifier)
                 ) {
                     ChargingDetailsRow(
                         status = status,


### PR DESCRIPTION
## Summary
The current charge endpoint (`/api/v1/cars/{carId}/charges/current`) only exists in TeslaMate API 1.24+. On older API versions, the dashboard's charging gauge and details row were clickable but navigated to an error screen, and the charging notification deep-linked to the unsupported live charge page.

Fixes #155

## Root Cause
No availability check was performed before rendering the navigation links or setting the notification deep-link intent. The endpoint check only happened *after* the user navigated to the current charge screen.

## Solution
- **TeslamateRepository**: Added `isCurrentChargeAvailable(carId)` that calls the endpoint once and caches the result (true if not 404, false on 404) for the app session
- **DashboardViewModel / DashboardUiState**: New `isCurrentChargeAvailable` flag, checked when the car starts charging
- **DashboardScreen / BatteryCard**: Charging power gauge and details row are only tappable when the API is available
- **ChargingNotificationManager**: `buildNotification()` and `createContentIntent()` accept `liveChargeAvailable` — when false, the notification just opens the main activity instead of deep-linking to the live charge screen
- **ChargingMonitorService**: Checks availability before building each notification

## Test Plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Lint passes (`./gradlew lintDebug`)
- [ ] Manual: connect to TeslaMate API < 1.24, start charging → dashboard gauge is not clickable, notification opens main screen
- [ ] Manual: connect to TeslaMate API 1.24+, start charging → dashboard gauge is clickable, notification opens live charge screen

Generated with [Claude Code](https://claude.com/claude-code)