### PR TITLE
Fix/stats filtering

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsViewModel.kt
@@ -44,7 +44,8 @@ data class StatsUiState(
     val geocodeProgress: GeocodeProgressInfo? = null,
     val isGeocoding: Boolean = false,
     val currencySymbol: String = "€",
-    val error: String? = null
+    val error: String? = null,
+    val isUpdating: Boolean = false
 )
 
 @HiltViewModel
@@ -149,8 +150,11 @@ class StatsViewModel @Inject constructor(
     }
 
     fun setYearFilter(yearFilter: YearFilter) {
-        _uiState.update { it.copy(selectedYearFilter = yearFilter) }
-        loadStats()
+        _uiState.update { it.copy(selectedYearFilter = yearFilter, isUpdating = true) }
+        viewModelScope.launch {
+            loadStatsInternal()
+            _uiState.update { it.copy(isUpdating = false) }
+        }
     }
 
     fun refresh() {


### PR DESCRIPTION
### Remember stats view
When using the filter, the view always returned to Drives.
Now it remembers which view it is in and remains after filtering. 

### Fix flickering when filtering
Only refresh whole screen if there is no data

### Added minimal progress bar
When filtering, the screen flickers when new data is incoming.
Removing the screen update on filtering fixed this flicker, but if the updating time is more than 0,1 seconds there is a percectible lag between user click and new data shown.
With a progress bar, this lag is not anoying.

Closes #151 