### PR TITLE
fix: center bolt+SOC label in live charge header

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -359,7 +359,11 @@ private fun CurrentChargeHeaderCard(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.weight(2f)
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Bolt,
                             contentDescription = null,
@@ -372,6 +376,8 @@ private fun CurrentChargeHeaderCard(
                             fontWeight = FontWeight.ExtraBold,
                             color = solidGreen
                         )
+                        // Balance the bolt icon so the percentage text is visually centered
+                        Spacer(modifier = Modifier.size(28.dp))
                     }
                     Text(
                         text = stringResource(R.string.soc_now),


### PR DESCRIPTION
## Summary
- The bolt icon + SOC percentage `Row` in the live charge header card was slightly off-center compared to the "now" label underneath
- Added `horizontalArrangement = Arrangement.Center` and `Modifier.fillMaxWidth()` to the inner `Row` so the bolt+percentage group is properly centered within its column

## Test plan
- [ ] Open the live charge screen while a car is charging
- [ ] Verify the bolt icon + SOC percentage is visually centered above the "now" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)