### PR TITLE
fix: check live charge availability in notification worker

### DIFF
--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -204,7 +204,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
                 // On Android 12+, can't start foreground service from background
                 // Fall back to showing notification directly (won't update in real-time)
                 Log.w(TAG, "Cannot start foreground service, showing notification directly: ${e.message}")
-                chargingNotificationManager.showChargingNotification(car, status)
+                val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(carId)
+                chargingNotificationManager.showChargingNotification(car, status, liveChargeAvailable)
             }
         } else {
             // Car is not charging - stop service and cancel notification


### PR DESCRIPTION
## Summary
- When `ChargingNotificationWorker` falls back to showing the notification directly (e.g., can't start foreground service from background on Android 12+), it wasn't checking API availability before calling `showChargingNotification`
- This caused `liveChargeAvailable` to default to `false`, so the notification wouldn't navigate to the live charge screen when tapped
- Now checks `teslamateRepository.isCurrentChargeAvailable()` before showing the notification, matching the behavior in `ChargingMonitorService`

## Context
- In v1.0.0, notifications always navigated to live charge
- PR #155 added the `liveChargeAvailable` guard to prevent navigation to an unsupported endpoint on older TeslaMate API versions
- The guard was correctly implemented in `ChargingMonitorService` but missed in the Worker's fallback path

## Test plan
- [ ] Install on device with TeslaMate API 1.24+
- [ ] Start charging (or simulate charging state)
- [ ] Wait for notification to appear
- [ ] Tap notification and verify it navigates to the live charge screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)