### PR TITLE
feat: auto-close live charge screen when charging stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Live Charge Screen**: Screen now automatically closes and navigates back when charging stops, as the completed charge is immediately available in the charges list
+
 ## [1.1.0-beta3] - 2026-02-12
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -46,7 +46,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -89,6 +91,27 @@ fun CurrentChargeScreen(
             snackbarHostState.showSnackbar(error)
             viewModel.clearError()
         }
+    }
+
+    // Auto-close screen when charging stops
+    var previouslyCharging by remember { mutableStateOf<Boolean?>(null) }
+    LaunchedEffect(uiState.isNotCharging, uiState.isLoading) {
+        // Skip if still loading initial data
+        if (uiState.isLoading) return@LaunchedEffect
+
+        // Initialize previous state on first load
+        if (previouslyCharging == null) {
+            previouslyCharging = !uiState.isNotCharging
+            return@LaunchedEffect
+        }
+
+        // Detect transition: was charging → now not charging
+        if (previouslyCharging == true && uiState.isNotCharging) {
+            onNavigateBack()
+        }
+
+        // Update previous state for next check
+        previouslyCharging = !uiState.isNotCharging
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
Automatically closes the live charge screen and navigates back to the previous screen when the car stops charging. Since the live screen is designed for real-time updates, once charging completes, the charge is immediately available in the charges list and the live view is no longer needed.

## Implementation
- Added state tracking in `CurrentChargeScreen` to detect charging transitions
- Uses `LaunchedEffect` to monitor `isNotCharging` flag changes
- Triggers automatic navigation via `onNavigateBack()` when charging stops
- Preserves existing fallback behavior when opening screen with no active charge

### Key Files Modified
- `app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt`
- `CHANGELOG.md`

## Behavior
**Automatic close triggers when:**
- User is viewing the live charge screen
- Car stops charging (detected via API polling every 30s)
- Screen automatically navigates back

**No automatic close when:**
- Screen is opened when car is already not charging (shows fallback message)
- Charging resumes after stopping

## Test Plan
- [x] Lint passed: `./gradlew lintDebug`
- [x] Unit tests passed: `./gradlew testDebugUnitTest`
- [ ] Manual testing with real charging session
  - Start charging and open live screen
  - Stop charging (unplug or reach limit)
  - Verify screen auto-closes within 30 seconds
- [ ] Edge case: Open screen when not charging (should show fallback, not auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)