### PR TITLE
fix: dismiss chart tooltips when scrolling

### DIFF
--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -103,6 +104,13 @@ fun DualAxisLineChart(
             valueRight = rightVal,
             position = Offset(pointX, leftY)
         )
+    }
+
+    // When the parent clears the shared fraction (e.g. scroll, tap outside), also clear local state
+    LaunchedEffect(externalSelectedFraction) {
+        if (externalSelectedFraction == null && onXSelected != null && !isUserInteracting) {
+            selectedPoint = null
+        }
     }
 
     val displayedPoint = if (!isUserInteracting && externalSelectedFraction != null) {

--- a/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -104,6 +105,13 @@ fun OptimizedLineChart(
         val pointX = index * stepX
         val pointY = chartHeightPx * (1 - (points[index] - chartData.minValue) / chartData.range)
         SelectedPoint(index, points[index], Offset(pointX, pointY))
+    }
+
+    // When the parent clears the shared fraction (e.g. scroll, tap outside), also clear local state
+    LaunchedEffect(externalSelectedFraction) {
+        if (externalSelectedFraction == null && onXSelected != null && !isUserInteracting) {
+            selectedPoint = null
+        }
     }
 
     // Show external state when user is not touching this chart and external sync is active

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -161,6 +162,11 @@ private fun ChargeDetailContent(
 ) {
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.isScrollInProgress }
+            .collect { isScrolling -> if (isScrolling) sharedXFraction = null }
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -227,6 +228,11 @@ private fun CurrentChargeContent(
 ) {
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.isScrollInProgress }
+            .collect { isScrolling -> if (isScrolling) sharedXFraction = null }
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -171,6 +172,11 @@ private fun DriveDetailContent(
 ) {
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.isScrollInProgress }
+            .collect { isScrolling -> if (isScrolling) sharedXFraction = null }
+    }
 
     Column(
         modifier = modifier


### PR DESCRIPTION
## Summary
- Tooltips were staying visible at fixed screen positions when the user scrolled (the `Popup` anchors to screen coordinates, not scroll position)
- `LaunchedEffect` in each screen now clears `sharedXFraction` as soon as a scroll gesture starts
- `LaunchedEffect` inside `OptimizedLineChart` and `DualAxisLineChart` clears local `selectedPoint` when the parent clears the shared fraction, so all tooltip state is fully reset

## Test plan
- [ ] Open a drive/charge detail or live charge screen and select a tooltip on a chart
- [ ] Scroll the page — tooltip disappears immediately
- [ ] Tooltip no longer floats over the page title / app bar