### PR TITLE
feat: add Open Tesla action to sentry notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,11 @@
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Required for getLaunchIntentForPackage on Android 11+ (package visibility) -->
+    <queries>
+        <package android:name="com.teslamotors.tesla" />
+    </queries>
+
     <application
         android:name=".MateDroidApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/matedroid/notification/SentryNotificationManager.kt
+++ b/app/src/main/java/com/matedroid/notification/SentryNotificationManager.kt
@@ -29,6 +29,7 @@ class SentryNotificationManager @Inject constructor(
         private const val TAG = "SentryNotificationManager"
         const val CHANNEL_ID = "sentry_alerts_channel"
         const val NOTIFICATION_ID_BASE = 4000
+        private const val TESLA_PACKAGE_NAME = "com.teslamotors.tesla"
     }
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE)
@@ -58,6 +59,21 @@ class SentryNotificationManager @Inject constructor(
             .setAutoCancel(true)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setContentIntent(createContentIntent(carId))
+
+        // Add "Open Tesla" action button if the Tesla app is installed
+        createTeslaAppIntent()?.let { teslaIntent ->
+            val teslaPendingIntent = PendingIntent.getActivity(
+                context,
+                NOTIFICATION_ID_BASE + carId + 1000,
+                teslaIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            builder.addAction(
+                R.drawable.ic_notification,
+                context.getString(R.string.sentry_action_open_tesla),
+                teslaPendingIntent
+            )
+        }
 
         if (!shouldAlert) {
             // Suppress sound/vibration/heads-up for counter-only updates
@@ -97,6 +113,13 @@ class SentryNotificationManager @Inject constructor(
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+    }
+
+    private fun createTeslaAppIntent(): Intent? {
+        val intent = context.packageManager.getLaunchIntentForPackage(TESLA_PACKAGE_NAME)
+        return intent?.apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1006,6 +1006,9 @@
         <item quantity="other">%d events detectats</item>
     </plurals>
 
+    <!-- Notification action button to open the Tesla app -->
+    <string name="sentry_action_open_tesla">Obrir app Tesla</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Selecciona l\'aspecte del cotxe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1006,6 +1006,9 @@
         <item quantity="other">%d eventos detectados</item>
     </plurals>
 
+    <!-- Notification action button to open the Tesla app -->
+    <string name="sentry_action_open_tesla">Abrir app Tesla</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleccionar aspecto del coche</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1006,6 +1006,9 @@
         <item quantity="other">%d eventi rilevati</item>
     </plurals>
 
+    <!-- Notification action button to open the Tesla app -->
+    <string name="sentry_action_open_tesla">Apri app Tesla</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleziona aspetto auto</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1007,6 +1007,9 @@
         <item quantity="other">%d events detected</item>
     </plurals>
 
+    <!-- Notification action button to open the Tesla app -->
+    <string name="sentry_action_open_tesla">Open Tesla app</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>


### PR DESCRIPTION
## Summary
- Sentry alert notifications now include an "Open Tesla" action button that launches the Tesla app
- Button only appears if the Tesla app (`com.teslamotors.tesla`) is installed on the device
- Tapping the button opens the Tesla app so the user can quickly check the live camera feed

## Test plan
- [x] `./gradlew assembleDebug` — builds
- [ ] Manual: trigger sentry notification and verify "Open Tesla" button appears
- [ ] Manual: verify button opens the Tesla app
- [ ] Manual: verify button is absent when Tesla app is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)