### PR TITLE
fix: widget tap opens the correct car instead of always the first one

### DIFF
--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -203,6 +203,7 @@ fun NavGraph(
 
         composable(Screen.Dashboard.route) {
             DashboardScreen(
+                intent = intent,
                 onNavigateToSettings = {
                     navController.navigate(Screen.Settings.route)
                 },

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -91,6 +91,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.ColorFilter
@@ -146,6 +148,7 @@ import kotlin.math.roundToInt
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
+    intent: Intent? = null,
     onNavigateToSettings: () -> Unit,
     onNavigateToCharges: (carId: Int, exteriorColor: String?) -> Unit = { _, _ -> },
     onNavigateToDrives: (carId: Int, exteriorColor: String?) -> Unit = { _, _ -> },
@@ -158,6 +161,17 @@ fun DashboardScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // When opened from a widget tap, select the car that belongs to that widget.
+    // Wait until the cars list is populated before switching, in case the app is
+    // cold-starting and the ViewModel hasn't loaded cars yet.
+    LaunchedEffect(intent) {
+        val carIdFromIntent = intent?.getIntExtra("EXTRA_CAR_ID", -1)?.takeIf { it > 0 }
+            ?: return@LaunchedEffect
+        snapshotFlow { uiState.cars }
+            .first { cars -> cars.any { it.carId == carIdFromIntent } }
+        viewModel.selectCar(carIdFromIntent)
+    }
 
     LaunchedEffect(uiState.error) {
         uiState.error?.let {

--- a/app/src/main/java/com/matedroid/widget/RefreshWidgetCallback.kt
+++ b/app/src/main/java/com/matedroid/widget/RefreshWidgetCallback.kt
@@ -5,11 +5,14 @@ import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
 import com.matedroid.MainActivity
 
 /**
  * Glance ActionCallback triggered when the user taps the widget.
- * Schedules an immediate data refresh then opens the app.
+ * Schedules an immediate data refresh then opens the app, selecting the
+ * car that belongs to this specific widget instance.
  */
 class RefreshWidgetCallback : ActionCallback {
     override suspend fun onAction(
@@ -18,9 +21,13 @@ class RefreshWidgetCallback : ActionCallback {
         parameters: ActionParameters
     ) {
         CarWidgetUpdateWorker.scheduleImmediateUpdate(context)
-        context.startActivity(
-            Intent(context, MainActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        )
+        val prefs = getAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId)
+        val carId = prefs[CarWidget.CAR_ID_KEY]
+        val intent = Intent(context, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        if (carId != null) {
+            intent.putExtra("EXTRA_CAR_ID", carId)
+        }
+        context.startActivity(intent)
     }
 }


### PR DESCRIPTION
## Summary

- When tapping a home screen widget for a specific car, the app now navigates to that car's dashboard instead of always showing the first/last-selected car.
- `RefreshWidgetCallback` reads the `carId` from the widget's Glance state and passes it as `EXTRA_CAR_ID` in the launch `Intent`.
- `NavGraph` forwards the `intent` down to `DashboardScreen`.
- `DashboardScreen` uses a `LaunchedEffect(intent)` + `snapshotFlow` to wait for the cars list to be populated and then calls `viewModel.selectCar(carId)`, correctly handling both cold-start and already-running (SINGLE_TOP) cases.

## Root cause

`RefreshWidgetCallback` was opening `MainActivity` with no extras. `DashboardViewModel` then restored whichever car was in `lastSelectedCarId` settings — not the car that owns the tapped widget.

## Test plan

- [ ] Add two cars in Teslamate and create one widget per car
- [ ] Tap widget for car 1 → app opens showing car 1
- [ ] Tap widget for car 2 → app opens showing car 2
- [ ] With the app already in the foreground on car 1, tap widget for car 2 → dashboard switches to car 2
- [ ] Single-car setup: tapping the widget still opens the app normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)