### PR TITLE
feat: add tappable high SoC warning dialog in battery panel

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1004,6 +1004,31 @@ private fun BatteryCard(
         else -> palette.onSurface
     }
     val chargeLimit = status.chargeLimitSoc ?: 100
+    var showHighSocDialog by remember { mutableStateOf(false) }
+
+    if (showHighSocDialog) {
+        AlertDialog(
+            onDismissRequest = { showHighSocDialog = false },
+            title = {
+                Text(
+                    text = stringResource(R.string.high_soc_warning_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.high_soc_warning_message),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showHighSocDialog = false }) {
+                    Text(stringResource(R.string.got_it))
+                }
+            }
+        )
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -1151,7 +1176,9 @@ private fun BatteryCard(
                         Icon(
                             imageVector = Icons.Filled.Warning,
                             contentDescription = stringResource(R.string.high_charge_level),
-                            modifier = Modifier.size(20.dp),
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clickable { showHighSocDialog = true },
                             tint = StatusWarning
                         )
                     }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -120,6 +120,10 @@
     <!-- Content description for warning icon when battery is above 90% -->
     <string name="high_charge_level">Nivell de càrrega alt</string>
 
+    <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
+    <string name="high_soc_warning_title">Nivell de càrrega elevat</string>
+    <string name="high_soc_warning_message">Mantenir la bateria al 100% o prop d\'aquest valor durant períodes prolongats pot accelerar la degradació.\n\n• Bateries NCM (la majoria dels models Tesla): es recomana carregar fins al 80–90% per a l\'ús diari. Carrega al 100% només abans de viatges llargs.\n• Bateries LFP (Model 3/Y Standard Range): dissenyades per carregar-se regularment al 100% — Tesla ho recomana per a la calibració de la bateria.\n\nEvita deixar el cotxe aparcat amb la càrrega completa durant períodes llargs sempre que sigui possible.</string>
+
     <!-- Location card section title -->
     <string name="location">Ubicació</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -120,6 +120,10 @@
     <!-- Content description for warning icon when battery is above 90% -->
     <string name="high_charge_level">Nivel de carga alto</string>
 
+    <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
+    <string name="high_soc_warning_title">Estado de carga elevado</string>
+    <string name="high_soc_warning_message">Mantener la batería al 100% o cerca de ese valor durante períodos prolongados puede acelerar la degradación.\n\n• Baterías NCM (la mayoría de los modelos Tesla): se recomienda cargar al 80–90% para el uso diario. Carga al 100% solo antes de viajes largos.\n• Baterías LFP (Model 3/Y Standard Range): diseñadas para cargarse regularmente al 100% — Tesla lo recomienda para la calibración de la batería.\n\nEvita dejar el coche aparcado con la carga completa durante períodos prolongados siempre que sea posible.</string>
+
     <!-- Location card section title -->
     <string name="location">Ubicación</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -120,6 +120,10 @@
     <!-- Content description for warning icon when battery is above 90% -->
     <string name="high_charge_level">Livello carica elevato</string>
 
+    <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
+    <string name="high_soc_warning_title">Stato di carica elevato</string>
+    <string name="high_soc_warning_message">Mantenere la batteria al 100% o in prossimità di tale valore per periodi prolungati può accelerare il degrado.\n\n• Batterie NCM (la maggior parte dei modelli Tesla): si consiglia di caricare all\'80–90% per l\'uso quotidiano. Caricare al 100% solo prima di lunghi viaggi.\n• Batterie LFP (Model 3/Y Standard Range): progettate per essere caricate regolarmente al 100% — Tesla lo consiglia per la calibrazione della batteria.\n\nEvita di lasciare l\'auto parcheggiata a piena carica per lunghi periodi quando possibile.</string>
+
     <!-- Location card section title -->
     <string name="location">Posizione</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,10 @@
     <!-- Content description for warning icon when battery is above 90% -->
     <string name="high_charge_level">High charge level</string>
 
+    <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
+    <string name="high_soc_warning_title">High State of Charge</string>
+    <string name="high_soc_warning_message">Keeping your battery at or near 100% for extended periods can accelerate degradation.\n\n• NCM batteries (most Tesla models): charge to 80–90% for daily use. Only charge to 100% before long trips.\n• LFP batteries (Standard Range Model 3/Y): designed to be charged to 100% regularly — Tesla recommends it for battery calibration.\n\nAvoid leaving the car parked at full charge for long periods whenever possible.</string>
+
     <!-- Location card section title -->
     <string name="location">Location</string>
 


### PR DESCRIPTION
## Summary

- The warning triangle shown in the dashboard battery panel when SoC > 90% (not charging) is now tappable
- Tapping it opens an info dialog explaining why keeping the battery at high charge levels accelerates degradation
- The dialog covers both NCM (most Tesla models) and LFP (Standard Range Model 3/Y) battery chemistries
- Fully translated into Italian, Spanish, and Catalan

## Test plan

- [ ] Charge (or simulate) battery above 90% — warning triangle appears next to the percentage
- [ ] Tap the triangle — info dialog opens with correct title and message
- [ ] Dismiss with "Got it" — dialog closes, no other side effects
- [ ] Verify all 4 locales display correct text (en, it, es, ca)
- [ ] Confirm tapping the surrounding battery card row still navigates to battery health

🤖 Generated with [Claude Code](https://claude.com/claude-code)