### PR TITLE
fix: anchor widget location text below charging details row

### DIFF
--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -280,21 +280,7 @@ class CarWidget : GlanceAppWidget() {
                                             )
                                         )
                                     }
-                                    if (useHomeLayout) {
-                                        // Home screen 2×2+: location right-aligned, no SoC limit.
-                                        // Range is rendered as a separate top-center overlay (below).
-                                        if (!locationText.isNullOrBlank()) {
-                                            Spacer(modifier = GlanceModifier.defaultWeight())
-                                            Text(
-                                                text = locationText,
-                                                style = TextStyle(
-                                                    color = ColorProvider(Color.White.copy(alpha = 0.7f)),
-                                                    fontSize = 10.sp
-                                                ),
-                                                maxLines = 2
-                                            )
-                                        }
-                                    } else if (layout.showMileage || layout.showChargeLimit) {
+                                    if (layout.showMileage || layout.showChargeLimit) {
                                         // Lock screen / small sizes: right-aligned range + charge limit
                                         Spacer(modifier = GlanceModifier.defaultWeight())
                                         val rightParts = buildList<String> {
@@ -349,6 +335,22 @@ class CarWidget : GlanceAppWidget() {
                                                 color = ColorProvider(Color.White.copy(alpha = 0.9f)),
                                                 fontSize = if (isCompact) 9.sp else 11.sp
                                             )
+                                        )
+                                    }
+                                }
+
+                                // Home screen 2×2+: location right-aligned, always at the bottom
+                                // regardless of whether charging details are shown above it.
+                                if (useHomeLayout && !locationText.isNullOrBlank()) {
+                                    Row(modifier = GlanceModifier.fillMaxWidth()) {
+                                        Spacer(modifier = GlanceModifier.defaultWeight())
+                                        Text(
+                                            text = locationText,
+                                            style = TextStyle(
+                                                color = ColorProvider(Color.White.copy(alpha = 0.7f)),
+                                                fontSize = 10.sp
+                                            ),
+                                            maxLines = 2
                                         )
                                     }
                                 }


### PR DESCRIPTION
## Summary
- When charging, an extra charging details row is added after the battery SoC row, which was pushing the location text (previously inside the SoC row) upward
- Moved location text out of the SoC `Row` and into its own `Row` appended at the bottom of the Column, so it always stays at the bottom regardless of charge state

## Test plan
- [ ] Widget with a geofence name: verify location text is at the bottom when not charging
- [ ] Widget with a geofence name: verify location text stays at the same position when charging
- [ ] Widget with a regular address: verify same behaviour (not charging / charging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)