### PR TITLE
feat: add notification permission dialog at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Notifications**: One-time permission dialog at startup explaining notification features (sentry events, tyre pressure, charging status) before requesting Android 13+ POST_NOTIFICATIONS permission
+
 ## [1.2.2] - 2026-03-07
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -74,6 +74,11 @@ class SettingsDataStore @Inject constructor(
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
+    private val notificationPermissionAskedKey = booleanPreferencesKey("notification_permission_asked")
+
+    val notificationPermissionAsked: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[notificationPermissionAskedKey] ?: false
+    }
 
     val settings: Flow<AppSettings> = context.dataStore.data.map { preferences ->
         AppSettings(
@@ -190,6 +195,12 @@ class SettingsDataStore @Inject constructor(
             }
 
             preferences[carImageOverridesKey] = overridesToJson(currentMap)
+        }
+    }
+
+    suspend fun saveNotificationPermissionAsked() {
+        context.dataStore.edit { preferences ->
+            preferences[notificationPermissionAskedKey] = true
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -1,15 +1,26 @@
 package com.matedroid.ui.navigation
 
+import android.Manifest
+import android.content.Intent
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.matedroid.R
 import com.matedroid.ui.screens.battery.BatteryScreen
 import com.matedroid.ui.screens.charges.ChargeDetailScreen
 import com.matedroid.ui.screens.charges.ChargesScreen
@@ -28,7 +39,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import com.matedroid.ui.screens.updates.SoftwareVersionsScreen
 import com.matedroid.domain.model.YearFilter
-import android.content.Intent
+import kotlinx.coroutines.launch
 
 sealed class Screen(val route: String) {
     data object Settings : Screen("settings")
@@ -152,9 +163,38 @@ fun NavGraph(
 ) {
     val navController = rememberNavController()
     val startDestination by startViewModel.startDestination.collectAsState()
+    val notificationPermissionAsked by startViewModel.notificationPermissionAsked.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
 
     if (startDestination == null) {
         return // Wait for determination
+    }
+
+    // One-time notification permission dialog (Android 13+)
+    if (startDestination == Screen.Dashboard.route &&
+        !notificationPermissionAsked &&
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    ) {
+        val permissionLauncher = rememberLauncherForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) {
+            coroutineScope.launch { startViewModel.markNotificationPermissionAsked() }
+        }
+
+        AlertDialog(
+            onDismissRequest = {
+                coroutineScope.launch { startViewModel.markNotificationPermissionAsked() }
+            },
+            title = { Text(stringResource(R.string.notification_permission_title)) },
+            text = { Text(stringResource(R.string.notification_permission_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }) {
+                    Text(stringResource(R.string.notification_permission_grant))
+                }
+            }
+        )
     }
 
     // Handle deep-link from notification or adb intent

--- a/app/src/main/java/com/matedroid/ui/navigation/StartDestinationViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/StartDestinationViewModel.kt
@@ -19,6 +19,9 @@ class StartDestinationViewModel @Inject constructor(
     private val _startDestination = MutableStateFlow<String?>(null)
     val startDestination: StateFlow<String?> = _startDestination.asStateFlow()
 
+    private val _notificationPermissionAsked = MutableStateFlow(true) // default true to avoid flash
+    val notificationPermissionAsked: StateFlow<Boolean> = _notificationPermissionAsked.asStateFlow()
+
     init {
         viewModelScope.launch {
             val settings = settingsDataStore.settings.first()
@@ -28,5 +31,14 @@ class StartDestinationViewModel @Inject constructor(
                 Screen.Settings.route
             }
         }
+        viewModelScope.launch {
+            settingsDataStore.notificationPermissionAsked.collect {
+                _notificationPermissionAsked.value = it
+            }
+        }
+    }
+
+    suspend fun markNotificationPermissionAsked() {
+        settingsDataStore.saveNotificationPermissionAsked()
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1075,4 +1075,9 @@
     <string name="widget_loading">Carregant…</string>
     <string name="widget_error_configure">Toca per configurar</string>
     <string name="widget_tap_to_open">Toca per obrir MateDroid</string>
+
+    <!-- ==================== Diàleg de permís de notificacions ==================== -->
+    <string name="notification_permission_title">Mantingues-te informat</string>
+    <string name="notification_permission_message">MateDroid pot avisar-te sobre esdeveniments del mode sentinella, avisos de pressió dels pneumàtics i estat de càrrega. Activa les notificacions per estar al dia sobre el teu cotxe.</string>
+    <string name="notification_permission_grant">Activar notificacions</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1075,4 +1075,9 @@
     <string name="widget_loading">Cargando…</string>
     <string name="widget_error_configure">Toca para configurar</string>
     <string name="widget_tap_to_open">Toca para abrir MateDroid</string>
+
+    <!-- ==================== Diálogo de permiso de notificaciones ==================== -->
+    <string name="notification_permission_title">Mantente informado</string>
+    <string name="notification_permission_message">MateDroid puede notificarte sobre eventos del modo centinela, avisos de presión de neumáticos y estado de carga. Activa las notificaciones para estar al día sobre tu coche.</string>
+    <string name="notification_permission_grant">Activar notificaciones</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1075,4 +1075,9 @@
     <string name="widget_loading">Caricamento…</string>
     <string name="widget_error_configure">Tocca per configurare</string>
     <string name="widget_tap_to_open">Tocca per aprire MateDroid</string>
+
+    <!-- ==================== Finestra permesso notifiche ==================== -->
+    <string name="notification_permission_title">Resta informato</string>
+    <string name="notification_permission_message">MateDroid può avvisarti su eventi della modalità sentinella, avvisi di pressione pneumatici e stato di ricarica. Abilita le notifiche per restare aggiornato sulla tua auto.</string>
+    <string name="notification_permission_grant">Abilita notifiche</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1086,4 +1086,12 @@
 
     <!-- Tap hint shown on the widget (accessibility / tooltip) -->
     <string name="widget_tap_to_open">Tap to open MateDroid</string>
+
+    <!-- ==================== Notification Permission Dialog ==================== -->
+    <!-- Title of the one-time dialog asking the user to enable notifications -->
+    <string name="notification_permission_title">Stay informed</string>
+    <!-- Body text explaining why notifications are useful -->
+    <string name="notification_permission_message">MateDroid can notify you about sentry mode events, tyre pressure warnings, and charging status. Enable notifications to stay informed about your car.</string>
+    <!-- Confirm button to trigger the system notification permission prompt -->
+    <string name="notification_permission_grant">Enable notifications</string>
 </resources>


### PR DESCRIPTION
## Summary
- Adds a one-time Material3 dialog on Android 13+ explaining why notifications are useful (sentry events, tyre pressure, charging status)
- On confirm, triggers the system POST_NOTIFICATIONS permission prompt; on dismiss, saves the flag so the dialog never reappears
- New `notification_permission_asked` preference in SettingsDataStore; strings in all 4 locales (EN, IT, ES, CA)

## Test plan
- [x] Fresh install on Android 13+ device: dialog appears on first launch after configuration
- [x] Tap "Enable notifications" → system permission prompt appears → dialog never shows again
- [ ] Dismiss dialog (back/tap outside) → dialog never shows again
- [x] Second launch: no dialog
- [ ] Android 12 or lower: no dialog shown
- [x] Unconfigured app (Settings screen): no dialog shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)