### PR TITLE
fix temperature conversion

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -821,10 +821,7 @@ private fun TemperatureChartCard(
         fixedMinMax = Pair(yMin, yMax),
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,
-        fractionToTimeLabel = fractionToTimeLabel,
-        convertValue = { value ->
-            if (units?.unitOfTemperature == "F") (value * 9f / 5f + 32f) else value
-        }
+        fractionToTimeLabel = fractionToTimeLabel
     )
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/WeatherAlongTheWayCard.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/WeatherAlongTheWayCard.kt
@@ -186,6 +186,7 @@ private fun WeatherTableRow(
     units: Units?,
     isLastPoint: Boolean
 ) {
+    val temperature = convertWeatherTemperature(weatherPoint.temperatureCelsius, units)
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -214,7 +215,7 @@ private fun WeatherTableRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = UnitFormatter.formatTemperature(weatherPoint.temperatureCelsius, units),
+                text = UnitFormatter.formatTemperature(temperature, units),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold
             )
@@ -296,5 +297,18 @@ private fun formatWeatherDistance(distanceKm: Double, units: Units?, isLastPoint
         "%,.1f mi".format(miles)
     } else {
         "%,.1f km".format(distanceKm)
+    }
+}
+
+/**
+ * Converts temperature for the weather table.
+ */
+@Composable
+private fun convertWeatherTemperature(tempC: Double, units: Units?): Double {
+    val isFahrenheit = units?.unitOfTemperature == "F"
+    return if (isFahrenheit) {
+        (tempC * 1.8) + 32
+    } else {
+        tempC
     }
 }


### PR DESCRIPTION
En ChargeDetails hay una conversión innecesaria que introduce valores erróneos en la gráfica de temperaturas.

Y por el contrario, en WheatherAlongTheWay, se ajustan correctamente las unidades pero el valor original en Celsius no se convierte.
He optado por poner la conversión en ese mismo archivo, (al igual que se hace con las distancias), ya que estas temperaturas no vienen de la API de Teslamate