### PR TITLE
fix: only count and log sentry events when notification is sent

### DIFF
--- a/app/src/main/java/com/matedroid/data/repository/SentryStateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/SentryStateRepository.kt
@@ -25,10 +25,9 @@ sealed class SentryEvent {
 /**
  * Business logic layer over [SentryStateDataStore].
  *
- * Every poll where center_display_state == "7" increments the event counter.
  * A 65-second debounce window (just over the 1-minute screen-on duration per
- * sentry event) controls whether the notification should alert (sound + heads-up)
- * or just update silently.
+ * sentry event) gates all side effects: counter increment, history logging,
+ * and notification alerting. Duplicate polls within the window are ignored.
  */
 @Singleton
 class SentryStateRepository @Inject constructor(
@@ -36,7 +35,7 @@ class SentryStateRepository @Inject constructor(
     private val alertLogDao: SentryAlertLogDao
 ) {
     companion object {
-        /** Debounce window for notification alerting (not counting).
+        /** Debounce window for all event processing (counting, logging, alerting).
          *  Slightly over 60s because the car screen stays on for exactly 1 minute per event. */
         private const val NOTIFY_DEBOUNCE_MS = 65_000L
     }
@@ -80,16 +79,13 @@ class SentryStateRepository @Inject constructor(
 
         // Check for a sentry alert event
         if (isSentryAlerted) {
-            // Always increment the counter
-            val updated = dataStore.incrementEventCount(carId)
-
-            // Debounce only controls whether the notification should alert with sound
             val now = System.currentTimeMillis()
             val timeSinceLastEvent = now - state.lastEventAt
             val shouldNotify = timeSinceLastEvent >= NOTIFY_DEBOUNCE_MS
 
-            // Log to persistent history using the same dedup rules as notifications
             if (shouldNotify) {
+                // Increment counter and log to history only when we actually notify
+                val updated = dataStore.incrementEventCount(carId)
                 alertLogDao.insert(
                     SentryAlertLog(
                         carId = carId,
@@ -100,9 +96,9 @@ class SentryStateRepository @Inject constructor(
                         address = geofence?.ifBlank { null }
                     )
                 )
+                return SentryEvent.AlertDetected(updated.eventCount, true)
             }
-
-            return SentryEvent.AlertDetected(updated.eventCount, shouldNotify)
+            // Within debounce window — duplicate poll for the same event, ignore
         }
 
         return null


### PR DESCRIPTION
## Summary
- Counter increment and history logging now only happen when the 65s debounce window has passed — when a notification is actually produced
- Duplicate polls within the window (same real event lasting 60s on the center display) are ignored entirely
- Previously, each 30s poll during a 60s event would increment the counter and log to history (~2x overcounting)

## Test Plan
- [ ] Sentry event detection still works (counter increments once per real event)
- [ ] History log shows one entry per notification, not per poll
- [ ] Debug simulate button still works (bypasses debounce)

Generated with [Claude Code](https://claude.com/claude-code)