### PR TITLE
fix datepicker timezone issue

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1845,20 +1845,14 @@ private fun LocationCard(
                 TextButton(onClick = {
                     showTimePicker = false
                     val selectedMillis = datePickerState.selectedDateMillis ?: return@TextButton
-
                     val selectedDate = java.time.Instant.ofEpochMilli(selectedMillis)
                         .atZone(java.time.ZoneOffset.UTC)
                         .toLocalDate()
 
-                    val localDateTime = selectedDate.atTime(
-                        timePickerState.hour,
-                        timePickerState.minute
-                    )
-                    val timestamp = java.time.OffsetDateTime.of(
-                        selectedDate,
-                        java.time.LocalTime.of(timePickerState.hour, timePickerState.minute),
-                        java.time.ZoneOffset.UTC
-                    ).toString()
+                    val localDateTime = selectedDate.atTime(timePickerState.hour, timePickerState.minute)
+                    val zonedDateTime = localDateTime.atZone(java.time.ZoneId.systemDefault())
+                    val timestamp = zonedDateTime.toOffsetDateTime().toString()
+
                     onNavigateToWhereWasI(timestamp)
                 }) {
                     Text(stringResource(R.string.where_was_i_go))

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1686,7 +1686,12 @@ private fun LocationCard(
     val datePickerState = rememberDatePickerState(
         selectableDates = object : SelectableDates {
             override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-                return utcTimeMillis <= System.currentTimeMillis()
+                val zoneId = java.time.ZoneId.systemDefault()
+                val todayStart = java.time.LocalDate.now(zoneId)
+                    .atStartOfDay(zoneId)
+                    .toInstant()
+                    .toEpochMilli()
+                return utcTimeMillis <= todayStart
             }
         }
     )
@@ -1840,14 +1845,20 @@ private fun LocationCard(
                 TextButton(onClick = {
                     showTimePicker = false
                     val selectedMillis = datePickerState.selectedDateMillis ?: return@TextButton
+
                     val selectedDate = java.time.Instant.ofEpochMilli(selectedMillis)
-                        .atZone(java.time.ZoneId.systemDefault())
+                        .atZone(java.time.ZoneOffset.UTC)
                         .toLocalDate()
-                    val timestamp = "%sT%02d:%02d:00Z".format(
-                        selectedDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE),
+
+                    val localDateTime = selectedDate.atTime(
                         timePickerState.hour,
                         timePickerState.minute
                     )
+                    val timestamp = java.time.OffsetDateTime.of(
+                        selectedDate,
+                        java.time.LocalTime.of(timePickerState.hour, timePickerState.minute),
+                        java.time.ZoneOffset.UTC
+                    ).toString()
                     onNavigateToWhereWasI(timestamp)
                 }) {
                     Text(stringResource(R.string.where_was_i_go))
@@ -1862,7 +1873,7 @@ private fun LocationCard(
                 val selectedMillis = datePickerState.selectedDateMillis
                 val dateText = if (selectedMillis != null) {
                     val date = java.time.Instant.ofEpochMilli(selectedMillis)
-                        .atZone(java.time.ZoneId.systemDefault())
+                        .atZone(java.time.ZoneOffset.UTC)
                         .toLocalDate()
                     date.format(java.time.format.DateTimeFormatter.ofLocalizedDate(java.time.format.FormatStyle.MEDIUM))
                 } else ""

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1687,11 +1687,11 @@ private fun LocationCard(
         selectableDates = object : SelectableDates {
             override fun isSelectableDate(utcTimeMillis: Long): Boolean {
                 val zoneId = java.time.ZoneId.systemDefault()
-                val todayStart = java.time.LocalDate.now(zoneId)
-                    .atStartOfDay(zoneId)
+                val todayUtcDateMillis = java.time.LocalDate.now(zoneId)
+                    .atStartOfDay(java.time.ZoneOffset.UTC)
                     .toInstant()
                     .toEpochMilli()
-                return utcTimeMillis <= todayStart
+                return utcTimeMillis <= todayUtcDateMillis
             }
         }
     )


### PR DESCRIPTION
## Summary

Fix incorrect date shifting when combining `DatePicker` and `TimePicker` across different time zones.

The root cause was treating `selectedDateMillis` as a time-zone-dependent instant and mixing UTC and system time zone logic during intermediate conversions, which produced off-by-one-day errors in some locales.

## Changes

- Treat `DatePicker` value as a pure calendar date using a stable UTC-based extraction
- Remove intermediate use of `ZoneId.systemDefault()` for date derivation
- Combine extracted `LocalDate` with `TimePicker` `LocalTime` into `LocalDateTime`
- Apply time zone only at the final step when generating the timestamp
- Align dialog display logic with the same date extraction approach
- Eliminate mixed UTC/local conversions during date reconstruction

## Result

Consistent date and time handling across all time zones, with no unintended day shifts when selecting a date and then a time.
closes #225 