### PR TITLE
Live charge layout tweaks + drive chart perf fix

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -552,7 +552,7 @@ private fun CurrentChargeHeaderCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.Top
             ) {
-                // Energy added with AC/DC badge
+                // Energy added as "+NN% (MM,NN kWh)"
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Default.Bolt,
@@ -562,16 +562,14 @@ private fun CurrentChargeHeaderCard(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Column {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = "%.2f kWh".format(detail.chargeEnergyAdded ?: 0.0),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = solidGreen
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            LiveChargeTypeBadge(isDcCharge = isDcCharge)
-                        }
+                        val socAdded = currentLevel - startLevel
+                        val kwhAdded = detail.chargeEnergyAdded ?: 0.0
+                        Text(
+                            text = "+%d%% (%.2f kWh)".format(socAdded, kwhAdded),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = solidGreen
+                        )
                         Text(
                             text = stringResource(R.string.soc_energy_added),
                             style = MaterialTheme.typography.labelSmall,
@@ -580,29 +578,26 @@ private fun CurrentChargeHeaderCard(
                     }
                 }
 
-                // Instant power
-                if (instantPower != null) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Default.Bolt,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Column(horizontalAlignment = Alignment.End) {
-                            Text(
-                                text = "$instantPower kW",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                            Text(
-                                text = stringResource(R.string.soc_instant_power),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                            )
+                // Instant power with AC/DC badge
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(horizontalAlignment = Alignment.End) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            LiveChargeTypeBadge(isDcCharge = isDcCharge)
+                            if (instantPower != null) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(
+                                    text = "$instantPower kW",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                            }
                         }
+                        Text(
+                            text = stringResource(R.string.soc_instant_power),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -556,16 +556,16 @@ private fun CurrentChargeHeaderCard(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Column {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            LiveChargeTypeBadge(isDcCharge = isDcCharge)
                             if (instantPower != null) {
-                                Spacer(modifier = Modifier.width(6.dp))
                                 Text(
                                     text = "$instantPower kW",
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Bold,
                                     color = MaterialTheme.colorScheme.onPrimaryContainer
                                 )
+                                Spacer(modifier = Modifier.width(6.dp))
                             }
+                            LiveChargeTypeBadge(isDcCharge = isDcCharge)
                         }
                         Text(
                             text = stringResource(R.string.soc_instant_power),

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -552,35 +552,9 @@ private fun CurrentChargeHeaderCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.Top
             ) {
-                // Energy added as "+NN% (MM,NN kWh)"
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Bolt,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                        tint = solidGreen
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        val socAdded = currentLevel - startLevel
-                        val kwhAdded = detail.chargeEnergyAdded ?: 0.0
-                        Text(
-                            text = "+%d%% (%.2f kWh)".format(socAdded, kwhAdded),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = solidGreen
-                        )
-                        Text(
-                            text = stringResource(R.string.soc_energy_added),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
-                    }
-                }
-
                 // Instant power with AC/DC badge
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Column(horizontalAlignment = Alignment.End) {
+                    Column {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             LiveChargeTypeBadge(isDcCharge = isDcCharge)
                             if (instantPower != null) {
@@ -595,6 +569,25 @@ private fun CurrentChargeHeaderCard(
                         }
                         Text(
                             text = stringResource(R.string.soc_instant_power),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+
+                // Energy added as "+NN% (MM,NN kWh)"
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(horizontalAlignment = Alignment.End) {
+                        val socAdded = currentLevel - startLevel
+                        val kwhAdded = detail.chargeEnergyAdded ?: 0.0
+                        Text(
+                            text = "+%d%% (%.2f kWh)".format(socAdded, kwhAdded),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = solidGreen
+                        )
+                        Text(
+                            text = stringResource(R.string.soc_energy_added),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                         )

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -267,22 +267,25 @@ private fun DriveDetailContent(
 
             // Charts
             if (!detail.positions.isNullOrEmpty() && detail.positions.size > 2) {
-                // Extract time labels for X axis (5 labels: start, 1st quarter, half, 3rd quarter, end)
-                val timeLabels = extractTimeLabels(detail.positions)
                 val positions = detail.positions
-                val timeFormatter = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
-                val fractionToTimeLabel: (Float) -> String = { fraction ->
-                    val index = (fraction * positions.lastIndex).roundToInt().coerceIn(0, positions.lastIndex)
-                    positions[index].date?.let { dateStr ->
-                        try {
-                            val dt = try {
-                                java.time.OffsetDateTime.parse(dateStr).toLocalDateTime()
-                            } catch (e: java.time.format.DateTimeParseException) {
-                                java.time.LocalDateTime.parse(dateStr.replace("Z", ""))
-                            }
-                            dt.format(timeFormatter)
-                        } catch (e: Exception) { "" }
-                    } ?: ""
+                // Remember expensive computations so they don't re-run on every
+                // recomposition during tooltip swipe interactions
+                val timeLabels = remember(positions) { extractTimeLabels(positions) }
+                val timeFormatter = remember { java.time.format.DateTimeFormatter.ofPattern("HH:mm") }
+                val fractionToTimeLabel: (Float) -> String = remember(positions) {
+                    { fraction: Float ->
+                        val index = (fraction * positions.lastIndex).roundToInt().coerceIn(0, positions.lastIndex)
+                        positions[index].date?.let { dateStr ->
+                            try {
+                                val dt = try {
+                                    java.time.OffsetDateTime.parse(dateStr).toLocalDateTime()
+                                } catch (e: java.time.format.DateTimeParseException) {
+                                    java.time.LocalDateTime.parse(dateStr.replace("Z", ""))
+                                }
+                                dt.format(timeFormatter)
+                            } catch (e: Exception) { "" }
+                        } ?: ""
+                    }
                 }
 
                 SpeedChartCard(
@@ -666,8 +669,13 @@ private fun SpeedChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val speeds = positions.mapNotNull { it.speed?.toFloat() }
+    val speeds = remember(positions) { positions.mapNotNull { it.speed?.toFloat() } }
     if (speeds.size < 2) return
+
+    val isImperial = units?.isImperial == true
+    val stableConvertValue: (Float) -> Float = remember(isImperial) {
+        { value: Float -> if (isImperial) (value * 0.621371f) else value }
+    }
 
     ChartCard(
         title = stringResource(R.string.speed_profile),
@@ -679,9 +687,7 @@ private fun SpeedChartCard(
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,
         fractionToTimeLabel = fractionToTimeLabel,
-        convertValue = { value ->
-            if (units?.isImperial == true) (value * 0.621371f) else value
-        }
+        convertValue = stableConvertValue
     )
 }
 
@@ -693,7 +699,7 @@ private fun PowerChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val powers = positions.mapNotNull { it.power?.toFloat() }
+    val powers = remember(positions) { positions.mapNotNull { it.power?.toFloat() } }
     if (powers.size < 2) return
 
     ChartCard(
@@ -718,13 +724,13 @@ private fun BatteryChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val batteryLevels = positions.mapNotNull { it.batteryLevel?.toFloat() }
+    val batteryLevels = remember(positions) { positions.mapNotNull { it.batteryLevel?.toFloat() } }
     if (batteryLevels.size < 2) return
-    var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
-    var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
-    if (yMin == yMax) {
-        yMin -= 1
-        yMax += 1
+    val fixedMinMax = remember(batteryLevels) {
+        var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
+        var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
+        if (yMin == yMax) { yMin -= 1; yMax += 1 }
+        Pair(yMin, yMax)
     }
 
     ChartCard(
@@ -733,7 +739,7 @@ private fun BatteryChartCard(
         data = batteryLevels,
         color = MaterialTheme.colorScheme.secondary,
         unit = "%",
-        fixedMinMax = Pair(yMin, yMax),
+        fixedMinMax = fixedMinMax,
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,
@@ -749,7 +755,7 @@ private fun ElevationChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val elevations = positions.mapNotNull { it.elevation?.toFloat() }
+    val elevations = remember(positions) { positions.mapNotNull { it.elevation?.toFloat() } }
     if (elevations.size < 2) return
 
     ChartCard(


### PR DESCRIPTION
## Summary
- Tweak live charge header layout: swap instant power to left, energy added to right
- Move AC/DC badge to the right of the kW value
- Fix drive detail chart tooltip swipe performance by memoizing expensive data computations (extractTimeLabels, mapNotNull, convertValue lambda) that were re-running on every frame with 1000+ position points

## Test plan
- [ ] Open a live charge session and verify the header layout looks correct
- [ ] Open a drive detail screen with charts and swipe on tooltips — should be smooth
- [ ] Verify charge detail chart tooltips still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)