### PR TITLE
feat: add HTTP Basic Auth support (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **HTTP Basic Auth**: Support for HTTP Basic Authentication in the Advanced network settings, for servers behind a reverse proxy requiring credentials.
 - **Custom date range filter**: Drives, charges, and trips pages now have a "Custom" filter chip that opens two date pickers (from/to). The chip label shows the selected range in locale-aware DD/MM or MM/DD format.
 - **Charging elapsed timer in status bar**: Live chronometer displayed next to the notification icon in the Android status bar during active charging sessions (MM:SS, then H:MM:SS after 1 hour).
 - **DC unplug warning**: When a DC charge completes but the cable remains plugged in, the notification icon switches to a warning variant with a chronometer counting time since completion. The live charge screen shows an orange warning banner prompting the user to unplug and free the DC spot. AC charges continue to dismiss the notification as before.

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -48,6 +48,8 @@ data class AppSettings(
     val serverUrl: String = "",
     val secondaryServerUrl: String = "",
     val apiToken: String = "",
+    val httpBasicAuthUsername: String = "",
+    val httpBasicAuthPassword: String = "",
     val acceptInvalidCerts: Boolean = false,
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
@@ -68,6 +70,8 @@ class SettingsDataStore @Inject constructor(
     private val serverUrlKey = stringPreferencesKey("server_url")
     private val secondaryServerUrlKey = stringPreferencesKey("secondary_server_url")
     private val apiTokenKey = stringPreferencesKey("api_token")
+    private val httpBasicAuthUsernameKey = stringPreferencesKey("http_basic_auth_username")
+    private val httpBasicAuthPasswordKey = stringPreferencesKey("http_basic_auth_password")
     private val acceptInvalidCertsKey = booleanPreferencesKey("accept_invalid_certs")
     private val currencyCodeKey = stringPreferencesKey("currency_code")
     private val showShortDrivesChargesKey = booleanPreferencesKey("show_short_drives_charges")
@@ -85,6 +89,8 @@ class SettingsDataStore @Inject constructor(
             serverUrl = preferences[serverUrlKey] ?: "",
             secondaryServerUrl = preferences[secondaryServerUrlKey] ?: "",
             apiToken = preferences[apiTokenKey] ?: "",
+            httpBasicAuthUsername = preferences[httpBasicAuthUsernameKey] ?: "",
+            httpBasicAuthPassword = preferences[httpBasicAuthPasswordKey] ?: "",
             acceptInvalidCerts = preferences[acceptInvalidCertsKey] ?: false,
             currencyCode = preferences[currencyCodeKey] ?: "EUR",
             showShortDrivesCharges = preferences[showShortDrivesChargesKey] ?: false,
@@ -141,6 +147,8 @@ class SettingsDataStore @Inject constructor(
         serverUrl: String,
         secondaryServerUrl: String,
         apiToken: String,
+        httpBasicAuthUsername: String,
+        httpBasicAuthPassword: String,
         acceptInvalidCerts: Boolean,
         currencyCode: String
     ) {
@@ -148,6 +156,8 @@ class SettingsDataStore @Inject constructor(
             preferences[serverUrlKey] = serverUrl
             preferences[secondaryServerUrlKey] = secondaryServerUrl
             preferences[apiTokenKey] = apiToken
+            preferences[httpBasicAuthUsernameKey] = httpBasicAuthUsername
+            preferences[httpBasicAuthPasswordKey] = httpBasicAuthPassword
             preferences[acceptInvalidCertsKey] = acceptInvalidCerts
             preferences[currencyCodeKey] = currencyCode
         }

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -163,6 +163,13 @@ class SettingsDataStore @Inject constructor(
         }
     }
 
+    suspend fun saveHttpBasicAuth(username: String, password: String) {
+        context.dataStore.edit { preferences ->
+            preferences[httpBasicAuthUsernameKey] = username
+            preferences[httpBasicAuthPasswordKey] = password
+        }
+    }
+
     suspend fun saveServerUrl(url: String) {
         context.dataStore.edit { preferences ->
             preferences[serverUrlKey] = url

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -96,7 +96,9 @@ object NetworkModule {
 private data class ApiCacheKey(
     val baseUrl: String,
     val acceptInvalidCerts: Boolean,
-    val apiToken: String
+    val apiToken: String,
+    val httpBasicAuthUsername: String,
+    val httpBasicAuthPassword: String
 )
 
 /**
@@ -124,14 +126,16 @@ class TeslamateApiFactory(
         val settings = runBlocking { settingsDataStore.settings.first() }
         val useInsecure = acceptInvalidCerts ?: settings.acceptInvalidCerts
         val apiToken = settings.apiToken
+        val basicAuthUsername = settings.httpBasicAuthUsername
+        val basicAuthPassword = settings.httpBasicAuthPassword
 
-        val cacheKey = ApiCacheKey(normalizedUrl, useInsecure, apiToken)
+        val cacheKey = ApiCacheKey(normalizedUrl, useInsecure, apiToken, basicAuthUsername, basicAuthPassword)
 
         // Return cached API if available
         apiCache[cacheKey]?.let { return it }
 
         // Create new API instance
-        val okHttpClient = createOkHttpClient(apiToken, useInsecure)
+        val okHttpClient = createOkHttpClient(apiToken, useInsecure, basicAuthUsername, basicAuthPassword)
 
         val api = Retrofit.Builder()
             .baseUrl(normalizedUrl)
@@ -160,11 +164,20 @@ class TeslamateApiFactory(
         apiCache.clear()
     }
 
-    private fun createOkHttpClient(apiToken: String, acceptInvalidCerts: Boolean): OkHttpClient {
+    private fun createOkHttpClient(
+        apiToken: String,
+        acceptInvalidCerts: Boolean,
+        basicAuthUsername: String = "",
+        basicAuthPassword: String = ""
+    ): OkHttpClient {
         val builder = OkHttpClient.Builder()
             .addInterceptor { chain ->
                 val requestBuilder = chain.request().newBuilder()
                     .header("User-Agent", "MateDroid/${BuildConfig.VERSION_NAME}")
+                if (basicAuthUsername.isNotBlank() && basicAuthPassword.isNotBlank()) {
+                    requestBuilder.addHeader("Authorization",
+                        okhttp3.Credentials.basic(basicAuthUsername, basicAuthPassword))
+                }
                 if (apiToken.isNotBlank()) {
                     requestBuilder.addHeader("Authorization", "Bearer $apiToken")
                 }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -122,6 +122,8 @@ fun SettingsScreen(
                 onServerUrlChange = viewModel::updateServerUrl,
                 onSecondaryServerUrlChange = viewModel::updateSecondaryServerUrl,
                 onApiTokenChange = viewModel::updateApiToken,
+                onHttpBasicAuthUsernameChange = viewModel::updateHttpBasicAuthUsername,
+                onHttpBasicAuthPasswordChange = viewModel::updateHttpBasicAuthPassword,
                 onAcceptInvalidCertsChange = viewModel::updateAcceptInvalidCerts,
                 onCurrencyChange = viewModel::updateCurrency,
                 onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges,
@@ -204,6 +206,8 @@ private fun SettingsContent(
     onServerUrlChange: (String) -> Unit,
     onSecondaryServerUrlChange: (String) -> Unit,
     onApiTokenChange: (String) -> Unit,
+    onHttpBasicAuthUsernameChange: (String) -> Unit,
+    onHttpBasicAuthPasswordChange: (String) -> Unit,
     onAcceptInvalidCertsChange: (Boolean) -> Unit,
     onCurrencyChange: (String) -> Unit,
     onShowShortDrivesChargesChange: (Boolean) -> Unit,
@@ -217,6 +221,7 @@ private fun SettingsContent(
     onSimulateSentryEvent: () -> Unit = {}
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
+    var basicAuthPasswordVisible by remember { mutableStateOf(false) }
     var currencyDropdownExpanded by remember { mutableStateOf(false) }
     var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
     var showResyncConfirmDialog by remember { mutableStateOf(false) }
@@ -326,6 +331,58 @@ private fun SettingsContent(
 
             Text(
                 text = stringResource(R.string.settings_api_token_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // HTTP Basic Auth
+            OutlinedTextField(
+                value = uiState.httpBasicAuthUsername,
+                onValueChange = onHttpBasicAuthUsernameChange,
+                label = { Text(stringResource(R.string.settings_http_basic_auth_username_label)) },
+                placeholder = { Text(stringResource(R.string.settings_http_basic_auth_username_placeholder)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                enabled = !uiState.isTesting && !uiState.isSaving
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = uiState.httpBasicAuthPassword,
+                onValueChange = onHttpBasicAuthPasswordChange,
+                label = { Text(stringResource(R.string.settings_http_basic_auth_password_label)) },
+                placeholder = { Text(stringResource(R.string.settings_http_basic_auth_password_placeholder)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                visualTransformation = if (basicAuthPasswordVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { basicAuthPasswordVisible = !basicAuthPasswordVisible }) {
+                        Icon(
+                            imageVector = if (basicAuthPasswordVisible) {
+                                Icons.Filled.VisibilityOff
+                            } else {
+                                Icons.Filled.Visibility
+                            },
+                            contentDescription = stringResource(
+                                if (basicAuthPasswordVisible) R.string.hide_password else R.string.show_password
+                            )
+                        )
+                    }
+                },
+                enabled = !uiState.isTesting && !uiState.isSaving
+            )
+
+            Text(
+                text = stringResource(R.string.settings_http_basic_auth_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp)
@@ -812,6 +869,8 @@ private fun SettingsScreenPreview() {
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
             onAcceptInvalidCertsChange = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},
@@ -836,6 +895,8 @@ private fun SettingsScreenWithResultPreview() {
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
             onAcceptInvalidCertsChange = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},
@@ -862,6 +923,8 @@ private fun SettingsScreenWithBothResultsPreview() {
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
             onAcceptInvalidCertsChange = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},
@@ -884,6 +947,8 @@ private fun SettingsScreenWithWarningPreview() {
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
             onAcceptInvalidCertsChange = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -37,6 +37,8 @@ data class SettingsUiState(
     val serverUrl: String = "",
     val secondaryServerUrl: String = "",
     val apiToken: String = "",
+    val httpBasicAuthUsername: String = "",
+    val httpBasicAuthPassword: String = "",
     val acceptInvalidCerts: Boolean = false,
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
@@ -98,6 +100,8 @@ class SettingsViewModel @Inject constructor(
                 serverUrl = settings.serverUrl,
                 secondaryServerUrl = settings.secondaryServerUrl,
                 apiToken = settings.apiToken,
+                httpBasicAuthUsername = settings.httpBasicAuthUsername,
+                httpBasicAuthPassword = settings.httpBasicAuthPassword,
                 acceptInvalidCerts = settings.acceptInvalidCerts,
                 currencyCode = settings.currencyCode,
                 showShortDrivesCharges = settings.showShortDrivesCharges,
@@ -125,6 +129,22 @@ class SettingsViewModel @Inject constructor(
     fun updateApiToken(token: String) {
         _uiState.value = _uiState.value.copy(
             apiToken = token,
+            testResult = null,
+            error = null
+        )
+    }
+
+    fun updateHttpBasicAuthUsername(username: String) {
+        _uiState.value = _uiState.value.copy(
+            httpBasicAuthUsername = username,
+            testResult = null,
+            error = null
+        )
+    }
+
+    fun updateHttpBasicAuthPassword(password: String) {
+        _uiState.value = _uiState.value.copy(
+            httpBasicAuthPassword = password,
             testResult = null,
             error = null
         )
@@ -262,6 +282,8 @@ class SettingsViewModel @Inject constructor(
                     serverUrl = url,
                     secondaryServerUrl = secondaryUrl,
                     apiToken = _uiState.value.apiToken,
+                    httpBasicAuthUsername = _uiState.value.httpBasicAuthUsername,
+                    httpBasicAuthPassword = _uiState.value.httpBasicAuthPassword,
                     acceptInvalidCerts = _uiState.value.acceptInvalidCerts,
                     currencyCode = _uiState.value.currencyCode
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -140,6 +140,10 @@ class SettingsViewModel @Inject constructor(
             testResult = null,
             error = null
         )
+        // Save eagerly so testConnection() picks up the unsaved value
+        viewModelScope.launch {
+            settingsDataStore.saveHttpBasicAuth(username, _uiState.value.httpBasicAuthPassword)
+        }
     }
 
     fun updateHttpBasicAuthPassword(password: String) {
@@ -148,6 +152,10 @@ class SettingsViewModel @Inject constructor(
             testResult = null,
             error = null
         )
+        // Save eagerly so testConnection() picks up the unsaved value
+        viewModelScope.launch {
+            settingsDataStore.saveHttpBasicAuth(_uiState.value.httpBasicAuthUsername, password)
+        }
     }
 
     fun updateAcceptInvalidCerts(accept: Boolean) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -187,6 +187,15 @@
     <string name="hide_token">Amaga el token</string>
     <string name="show_token">Mostra el token</string>
 
+    <!-- HTTP Basic Auth for reverse proxy -->
+    <string name="settings_http_basic_auth_username_label">Usuari HTTP Basic Auth (opcional)</string>
+    <string name="settings_http_basic_auth_username_placeholder">Usuari</string>
+    <string name="settings_http_basic_auth_password_label">Contrasenya HTTP Basic Auth</string>
+    <string name="settings_http_basic_auth_password_placeholder">Contrasenya</string>
+    <string name="settings_http_basic_auth_hint">Configura aquests camps si el servidor està darrere d\'un proxy invers amb autenticació HTTP Basic.</string>
+    <string name="hide_password">Amaga la contrasenya</string>
+    <string name="show_password">Mostra la contrasenya</string>
+
     <!-- Accept invalid certificates toggle -->
     <string name="settings_accept_invalid_certs">Accepta certificats no vàlids</string>
     <string name="settings_accept_invalid_certs_hint">Activa per a certificats autofirmats</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -192,7 +192,7 @@
     <string name="settings_http_basic_auth_username_placeholder">Usuari</string>
     <string name="settings_http_basic_auth_password_label">Contrasenya HTTP Basic Auth</string>
     <string name="settings_http_basic_auth_password_placeholder">Contrasenya</string>
-    <string name="settings_http_basic_auth_hint">Configura aquests camps si el servidor està darrere d\'un proxy invers amb autenticació HTTP Basic.</string>
+    <string name="settings_http_basic_auth_hint">Configura aquests camps si el servidor està darrere d\'un proxy invers amb autenticació HTTP Basic (per exemple, si fas servir MyTeslaMate).</string>
     <string name="hide_password">Amaga la contrasenya</string>
     <string name="show_password">Mostra la contrasenya</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -192,7 +192,7 @@
     <string name="settings_http_basic_auth_username_placeholder">Usuario</string>
     <string name="settings_http_basic_auth_password_label">Contraseña HTTP Basic Auth</string>
     <string name="settings_http_basic_auth_password_placeholder">Contraseña</string>
-    <string name="settings_http_basic_auth_hint">Configura estos campos si tu servidor está detrás de un proxy inverso con autenticación HTTP Basic.</string>
+    <string name="settings_http_basic_auth_hint">Configura estos campos si tu servidor está detrás de un proxy inverso con autenticación HTTP Basic (por ejemplo, si usas MyTeslaMate).</string>
     <string name="hide_password">Ocultar contraseña</string>
     <string name="show_password">Mostrar contraseña</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -187,6 +187,15 @@
     <string name="hide_token">Ocultar token</string>
     <string name="show_token">Mostrar token</string>
 
+    <!-- HTTP Basic Auth for reverse proxy -->
+    <string name="settings_http_basic_auth_username_label">Usuario HTTP Basic Auth (opcional)</string>
+    <string name="settings_http_basic_auth_username_placeholder">Usuario</string>
+    <string name="settings_http_basic_auth_password_label">Contraseña HTTP Basic Auth</string>
+    <string name="settings_http_basic_auth_password_placeholder">Contraseña</string>
+    <string name="settings_http_basic_auth_hint">Configura estos campos si tu servidor está detrás de un proxy inverso con autenticación HTTP Basic.</string>
+    <string name="hide_password">Ocultar contraseña</string>
+    <string name="show_password">Mostrar contraseña</string>
+
     <!-- Accept invalid certificates toggle -->
     <string name="settings_accept_invalid_certs">Aceptar certificados inválidos</string>
     <string name="settings_accept_invalid_certs_hint">Activar para certificados autofirmados</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -187,6 +187,15 @@
     <string name="hide_token">Nascondi token</string>
     <string name="show_token">Mostra token</string>
 
+    <!-- HTTP Basic Auth for reverse proxy -->
+    <string name="settings_http_basic_auth_username_label">Nome utente HTTP Basic Auth (opzionale)</string>
+    <string name="settings_http_basic_auth_username_placeholder">Nome utente</string>
+    <string name="settings_http_basic_auth_password_label">Password HTTP Basic Auth</string>
+    <string name="settings_http_basic_auth_password_placeholder">Password</string>
+    <string name="settings_http_basic_auth_hint">Imposta questi campi se il server è dietro un reverse proxy con autenticazione HTTP Basic.</string>
+    <string name="hide_password">Nascondi password</string>
+    <string name="show_password">Mostra password</string>
+
     <!-- Accept invalid certificates toggle -->
     <string name="settings_accept_invalid_certs">Accetta certificati non validi</string>
     <string name="settings_accept_invalid_certs_hint">Abilita per certificati autofirmati</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -192,7 +192,7 @@
     <string name="settings_http_basic_auth_username_placeholder">Nome utente</string>
     <string name="settings_http_basic_auth_password_label">Password HTTP Basic Auth</string>
     <string name="settings_http_basic_auth_password_placeholder">Password</string>
-    <string name="settings_http_basic_auth_hint">Imposta questi campi se il server è dietro un reverse proxy con autenticazione HTTP Basic.</string>
+    <string name="settings_http_basic_auth_hint">Imposta questi campi se il server è dietro un reverse proxy con autenticazione HTTP Basic (ad esempio se usi MyTeslaMate).</string>
     <string name="hide_password">Nascondi password</string>
     <string name="show_password">Mostra password</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -192,7 +192,7 @@
     <string name="settings_http_basic_auth_username_placeholder">用户名</string>
     <string name="settings_http_basic_auth_password_label">HTTP Basic Auth 密码</string>
     <string name="settings_http_basic_auth_password_placeholder">密码</string>
-    <string name="settings_http_basic_auth_hint">如果你的服务器在使用 HTTP Basic 认证的反向代理后面，请设置这些字段。</string>
+    <string name="settings_http_basic_auth_hint">如果你的服务器在使用 HTTP Basic 认证的反向代理后面，请设置这些字段（例如使用 MyTeslaMate 时）。</string>
     <string name="hide_password">隐藏密码</string>
     <string name="show_password">显示密码</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -187,6 +187,15 @@
     <string name="hide_token">隐藏令牌</string>
     <string name="show_token">显示令牌</string>
 
+    <!-- HTTP Basic Auth for reverse proxy -->
+    <string name="settings_http_basic_auth_username_label">HTTP Basic Auth 用户名（可选）</string>
+    <string name="settings_http_basic_auth_username_placeholder">用户名</string>
+    <string name="settings_http_basic_auth_password_label">HTTP Basic Auth 密码</string>
+    <string name="settings_http_basic_auth_password_placeholder">密码</string>
+    <string name="settings_http_basic_auth_hint">如果你的服务器在使用 HTTP Basic 认证的反向代理后面，请设置这些字段。</string>
+    <string name="hide_password">隐藏密码</string>
+    <string name="show_password">显示密码</string>
+
     <!-- Accept invalid certificates toggle -->
     <string name="settings_accept_invalid_certs">接受无效证书</string>
     <string name="settings_accept_invalid_certs_hint">为自签名证书启用此选项</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,7 +192,7 @@
     <string name="settings_http_basic_auth_username_placeholder">Username</string>
     <string name="settings_http_basic_auth_password_label">HTTP Basic Auth password</string>
     <string name="settings_http_basic_auth_password_placeholder">Password</string>
-    <string name="settings_http_basic_auth_hint">Set these if your server is behind a reverse proxy with HTTP Basic Authentication.</string>
+    <string name="settings_http_basic_auth_hint">Set these if your server is behind a reverse proxy with HTTP Basic Authentication (i.e. if you are using MyTeslaMate).</string>
     <string name="hide_password">Hide password</string>
     <string name="show_password">Show password</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,15 @@
     <string name="hide_token">Hide token</string>
     <string name="show_token">Show token</string>
 
+    <!-- HTTP Basic Auth for reverse proxy -->
+    <string name="settings_http_basic_auth_username_label">HTTP Basic Auth username (optional)</string>
+    <string name="settings_http_basic_auth_username_placeholder">Username</string>
+    <string name="settings_http_basic_auth_password_label">HTTP Basic Auth password</string>
+    <string name="settings_http_basic_auth_password_placeholder">Password</string>
+    <string name="settings_http_basic_auth_hint">Set these if your server is behind a reverse proxy with HTTP Basic Authentication.</string>
+    <string name="hide_password">Hide password</string>
+    <string name="show_password">Show password</string>
+
     <!-- Accept invalid certificates toggle -->
     <string name="settings_accept_invalid_certs">Accept invalid certificates</string>
     <string name="settings_accept_invalid_certs_hint">Enable for self-signed certificates</string>

--- a/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
@@ -243,7 +243,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `saveSettings calls datastore with all fields and triggers callback`() = runTest {
-        coEvery { settingsDataStore.saveSettings(any(), any(), any(), any(), any()) } returns Unit
+        coEvery { settingsDataStore.saveSettings(any(), any(), any(), any(), any(), any(), any()) } returns Unit
 
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -262,6 +262,8 @@ class SettingsViewModelTest {
                 "https://saved.com",
                 "https://backup.com",
                 "saved-token",
+                "",
+                "",
                 true,
                 "EUR"
             )


### PR DESCRIPTION
## Summary
- Adds optional HTTP Basic Auth username/password fields under **Advanced network settings**
- Sends `Authorization: Basic` header on all API requests when credentials are configured
- Both Basic Auth and Bearer token can coexist (for reverse proxy + TeslaMate API token setups)

Closes #36

## Implementation
- **SettingsDataStore**: Two new preference keys (`http_basic_auth_username`, `http_basic_auth_password`) persisted via DataStore
- **NetworkModule**: OkHttp interceptor sends `Authorization: Basic base64(user:pass)` before the Bearer token header when both username and password are non-blank. Uses `okhttp3.Credentials.basic()` for proper encoding. Cache key includes credentials for correct invalidation.
- **Settings UI**: Two new fields (username + masked password with visibility toggle) in the existing "Advanced network settings" collapsible section, between API Token and Accept Invalid Certificates
- **Localization**: All 5 locales updated (en, it, es, ca, zh)

## Test Plan
- [x] `./gradlew lintDebug` passes (no hardcoded strings)
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Manual: open Settings, expand Advanced Network, verify username/password fields appear
- [ ] Manual: configure Basic Auth credentials, test connection against a server with Basic Auth
- [ ] Manual: verify both Basic Auth + API Token work together

🤖 Generated with [Claude Code](https://claude.com/claude-code)