### PR TITLE
feat: add trip timeline bar on detail screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Trip timeline**: Horizontal timeline bar on the trip detail screen, under the map, visualizing each drive, charge, and parking gap as a colored segment proportional to its duration. Drives use the car's accent color, charges use the established AC/DC palette (green/orange, harmonized with the car's theme), parking gaps use a muted neutral. Tap any segment to see its details; multi-day parking stretches are compressed with a sqrt curve so driving and charging stay readable.
+
 ## [1.5.0] - 2026-04-15
 
 ### Added

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -1,0 +1,356 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.ui.theme.CarColorPalette
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/** A segment in a trip timeline, representing a slice of the trip's wall-clock time. */
+sealed class TripTimelineSegment {
+    abstract val durationMin: Int
+
+    data class Drive(
+        override val durationMin: Int,
+        val index: Int,
+        val distanceKm: Double
+    ) : TripTimelineSegment()
+
+    data class Charge(
+        override val durationMin: Int,
+        val index: Int,
+        val energyKwh: Double,
+        val isDc: Boolean
+    ) : TripTimelineSegment()
+
+    data class Parking(
+        override val durationMin: Int
+    ) : TripTimelineSegment()
+}
+
+private const val PARKING_LINEAR_THRESHOLD_MIN = 120f
+private const val MIN_SEGMENT_RATIO = 0.02f
+
+/**
+ * Horizontal trip timeline bar. Each segment's width is proportional to its duration,
+ * with sqrt compression applied to Parking segments longer than 2h so multi-day idle
+ * periods don't dominate the bar while drive/charge segments collapse to slivers.
+ */
+@Composable
+fun TripTimeline(
+    segments: List<TripTimelineSegment>,
+    startDate: String,
+    endDate: String,
+    palette: CarColorPalette,
+    modifier: Modifier = Modifier
+) {
+    if (segments.isEmpty()) return
+
+    val parkingColor = MaterialTheme.colorScheme.surfaceVariant
+
+    var selectedIndex by remember(segments) { mutableStateOf<Int?>(null) }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Schedule,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.trip_timeline_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            SegmentInfoPanel(
+                selection = selectedIndex?.let { idx -> segments.getOrNull(idx)?.let { idx to it } },
+                palette = palette,
+                parkingColor = parkingColor
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            TimelineBar(
+                segments = segments,
+                palette = palette,
+                parkingColor = parkingColor,
+                selectedIndex = selectedIndex,
+                onSegmentTap = { idx ->
+                    selectedIndex = if (selectedIndex == idx) null else idx
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = formatClockTime(startDate),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = formatClockTime(endDate),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SegmentInfoPanel(
+    selection: Pair<Int, TripTimelineSegment>?,
+    palette: CarColorPalette,
+    parkingColor: Color
+) {
+    // Reserve a constant height so tapping segments doesn't shift the bar position
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(44.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        if (selection != null) {
+            val seg = selection.second
+            val title: String
+            val subtitle: String
+            val dotColor: Color
+            when (seg) {
+                is TripTimelineSegment.Drive -> {
+                    title = "${stringResource(R.string.trip_timeline_driving)} · " +
+                            stringResource(R.string.trip_leg_drive, seg.index)
+                    subtitle = "%.1f km · %s".format(
+                        seg.distanceKm,
+                        formatTimelineDuration(seg.durationMin)
+                    )
+                    dotColor = palette.accent
+                }
+                is TripTimelineSegment.Charge -> {
+                    val chargeLabel = if (seg.isDc) {
+                        stringResource(R.string.trip_timeline_charging_dc)
+                    } else {
+                        stringResource(R.string.trip_timeline_charging_ac)
+                    }
+                    title = "$chargeLabel · " +
+                            stringResource(R.string.trip_leg_charge, seg.index)
+                    subtitle = "+%.1f kWh · %s".format(
+                        seg.energyKwh,
+                        formatTimelineDuration(seg.durationMin)
+                    )
+                    dotColor = if (seg.isDc) palette.dcColor else palette.acColor
+                }
+                is TripTimelineSegment.Parking -> {
+                    title = stringResource(R.string.trip_timeline_parked)
+                    subtitle = formatTimelineDuration(seg.durationMin)
+                    dotColor = parkingColor
+                }
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(12.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(dotColor)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Column {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineBar(
+    segments: List<TripTimelineSegment>,
+    palette: CarColorPalette,
+    parkingColor: Color,
+    selectedIndex: Int?,
+    onSegmentTap: (Int) -> Unit
+) {
+    val density = LocalDensity.current
+    val barHeightPx = with(density) { 16.dp.toPx() }
+    val selectedExtraPx = with(density) { 4.dp.toPx() }
+    val gapPx = with(density) { 1.dp.toPx() }
+    val cornerRadiusPx = with(density) { 8.dp.toPx() }
+
+    val ratios = remember(segments) { computeSegmentRatios(segments) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .pointerInput(segments) {
+                detectTapGestures { offset ->
+                    val w = size.width.toFloat()
+                    if (w <= 0f) return@detectTapGestures
+                    var accum = 0f
+                    for ((idx, r) in ratios.withIndex()) {
+                        val segW = r * w
+                        if (offset.x <= accum + segW) {
+                            onSegmentTap(idx)
+                            return@detectTapGestures
+                        }
+                        accum += segW
+                    }
+                    onSegmentTap(ratios.lastIndex)
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .clip(RoundedCornerShape(10.dp))
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val total = size.width
+                var x = 0f
+                ratios.forEachIndexed { idx, ratio ->
+                    val segWidth = ratio * total
+                    val isLast = idx == ratios.lastIndex
+                    val drawWidth = if (isLast) segWidth else (segWidth - gapPx).coerceAtLeast(0f)
+                    val seg = segments[idx]
+                    val color: Color = when (seg) {
+                        is TripTimelineSegment.Drive -> palette.accent
+                        is TripTimelineSegment.Charge ->
+                            if (seg.isDc) palette.dcColor else palette.acColor
+                        is TripTimelineSegment.Parking -> parkingColor
+                    }
+                    val isSelected = idx == selectedIndex
+                    val thisBarHeight = if (isSelected) barHeightPx + selectedExtraPx else barHeightPx
+                    val y = (size.height - thisBarHeight) / 2f
+                    drawRect(
+                        color = color,
+                        topLeft = Offset(x, y),
+                        size = Size(drawWidth, thisBarHeight)
+                    )
+                    x += segWidth
+                }
+                // Redraw the rounded clip edges by overlaying small corner triangles? Not needed,
+                // the parent Box already clips to RoundedCornerShape. Ignore cornerRadiusPx.
+                @Suppress("UNUSED_EXPRESSION") cornerRadiusPx
+            }
+        }
+    }
+}
+
+/** Compute visual width ratios for each segment, with parking sqrt-compression and a minimum visual width. */
+private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
+    if (segments.isEmpty()) return emptyList()
+    val weights = segments.map { seg ->
+        when (seg) {
+            is TripTimelineSegment.Parking -> compressParkingWeight(seg.durationMin)
+            else -> seg.durationMin.toFloat().coerceAtLeast(1f)
+        }
+    }
+    val total = weights.sum().coerceAtLeast(1f)
+    val raw = weights.map { it / total }
+    // Lift to minimum and renormalize (cap min so n * min <= 1)
+    val effectiveMin = MIN_SEGMENT_RATIO.coerceAtMost(1f / segments.size)
+    val lifted = raw.map { max(it, effectiveMin) }
+    val liftedSum = lifted.sum()
+    return lifted.map { it / liftedSum }
+}
+
+private fun compressParkingWeight(durationMin: Int): Float {
+    val d = durationMin.toFloat().coerceAtLeast(1f)
+    return if (d <= PARKING_LINEAR_THRESHOLD_MIN) d
+    else PARKING_LINEAR_THRESHOLD_MIN +
+            sqrt((d - PARKING_LINEAR_THRESHOLD_MIN) * PARKING_LINEAR_THRESHOLD_MIN)
+}
+
+private fun formatTimelineDuration(minutes: Int): String {
+    val h = minutes / 60
+    val m = minutes % 60
+    return when {
+        h >= 24 -> {
+            val days = h / 24
+            val remH = h % 24
+            if (remH > 0) "${days}d ${remH}h" else "${days}d"
+        }
+        h > 0 -> "${h}h ${m}m"
+        else -> "${m}m"
+    }
+}
+
+private fun formatClockTime(dateStr: String): String {
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (e: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        }
+        dt.format(DateTimeFormatter.ofPattern("HH:mm"))
+    } catch (e: Exception) {
+        dateStr
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
@@ -37,7 +39,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.matedroid.R
 import com.matedroid.ui.theme.CarColorPalette
 import java.time.LocalDateTime
@@ -69,6 +73,12 @@ sealed class TripTimelineSegment {
     ) : TripTimelineSegment()
 }
 
+/** A country shown in the timeline's route header (start, end, or intermediate). */
+data class TripTimelineCountry(
+    val countryCode: String,
+    val flagEmoji: String
+)
+
 private const val PARKING_LINEAR_THRESHOLD_MIN = 120f
 private const val MIN_SEGMENT_RATIO = 0.02f
 
@@ -82,7 +92,11 @@ fun TripTimeline(
     segments: List<TripTimelineSegment>,
     startDate: String,
     endDate: String,
+    startCity: String,
+    endCity: String,
+    countries: List<TripTimelineCountry>,
     palette: CarColorPalette,
+    onCountryClick: (countryCode: String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (segments.isEmpty()) return
@@ -115,10 +129,16 @@ fun TripTimeline(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            SegmentInfoPanel(
+            InfoPanel(
                 selection = selectedIndex?.let { idx -> segments.getOrNull(idx)?.let { idx to it } },
+                startDate = startDate,
+                endDate = endDate,
+                startCity = startCity,
+                endCity = endCity,
+                countries = countries,
                 palette = palette,
-                parkingColor = parkingColor
+                parkingColor = parkingColor,
+                onCountryClick = onCountryClick
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -133,7 +153,7 @@ fun TripTimeline(
                 }
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(6.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -155,74 +175,220 @@ fun TripTimeline(
 }
 
 @Composable
-private fun SegmentInfoPanel(
+private fun InfoPanel(
     selection: Pair<Int, TripTimelineSegment>?,
+    startDate: String,
+    endDate: String,
+    startCity: String,
+    endCity: String,
+    countries: List<TripTimelineCountry>,
     palette: CarColorPalette,
-    parkingColor: Color
+    parkingColor: Color,
+    onCountryClick: (countryCode: String) -> Unit
 ) {
     // Reserve a constant height so tapping segments doesn't shift the bar position
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(44.dp),
+            .height(48.dp),
         contentAlignment = Alignment.CenterStart
     ) {
         if (selection != null) {
-            val seg = selection.second
-            val title: String
-            val subtitle: String
-            val dotColor: Color
-            when (seg) {
-                is TripTimelineSegment.Drive -> {
-                    title = "${stringResource(R.string.trip_timeline_driving)} · " +
-                            stringResource(R.string.trip_leg_drive, seg.index)
-                    subtitle = "%.1f km · %s".format(
-                        seg.distanceKm,
-                        formatTimelineDuration(seg.durationMin)
-                    )
-                    dotColor = palette.accent
-                }
-                is TripTimelineSegment.Charge -> {
-                    val chargeLabel = if (seg.isDc) {
-                        stringResource(R.string.trip_timeline_charging_dc)
-                    } else {
-                        stringResource(R.string.trip_timeline_charging_ac)
-                    }
-                    title = "$chargeLabel · " +
-                            stringResource(R.string.trip_leg_charge, seg.index)
-                    subtitle = "+%.1f kWh · %s".format(
-                        seg.energyKwh,
-                        formatTimelineDuration(seg.durationMin)
-                    )
-                    dotColor = if (seg.isDc) palette.dcColor else palette.acColor
-                }
-                is TripTimelineSegment.Parking -> {
-                    title = stringResource(R.string.trip_timeline_parked)
-                    subtitle = formatTimelineDuration(seg.durationMin)
-                    dotColor = parkingColor
-                }
+            SegmentInfoContent(
+                segment = selection.second,
+                palette = palette,
+                parkingColor = parkingColor
+            )
+        } else {
+            RouteHeaderContent(
+                startDate = startDate,
+                endDate = endDate,
+                startCity = startCity,
+                endCity = endCity,
+                countries = countries,
+                onCountryClick = onCountryClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun SegmentInfoContent(
+    segment: TripTimelineSegment,
+    palette: CarColorPalette,
+    parkingColor: Color
+) {
+    val title: String
+    val subtitle: String
+    val dotColor: Color
+    when (segment) {
+        is TripTimelineSegment.Drive -> {
+            title = "${stringResource(R.string.trip_timeline_driving)} · " +
+                    stringResource(R.string.trip_leg_drive, segment.index)
+            subtitle = "%.1f km · %s".format(
+                segment.distanceKm,
+                formatTimelineDuration(segment.durationMin)
+            )
+            dotColor = palette.accent
+        }
+        is TripTimelineSegment.Charge -> {
+            val chargeLabel = if (segment.isDc) {
+                stringResource(R.string.trip_timeline_charging_dc)
+            } else {
+                stringResource(R.string.trip_timeline_charging_ac)
             }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(12.dp)
-                        .clip(RoundedCornerShape(50))
-                        .background(dotColor)
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-                Column {
+            title = "$chargeLabel · " +
+                    stringResource(R.string.trip_leg_charge, segment.index)
+            subtitle = "+%.1f kWh · %s".format(
+                segment.energyKwh,
+                formatTimelineDuration(segment.durationMin)
+            )
+            dotColor = if (segment.isDc) palette.dcColor else palette.acColor
+        }
+        is TripTimelineSegment.Parking -> {
+            title = stringResource(R.string.trip_timeline_parked)
+            subtitle = formatTimelineDuration(segment.durationMin)
+            dotColor = parkingColor
+        }
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .clip(RoundedCornerShape(50))
+                .background(dotColor)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun RouteHeaderContent(
+    startDate: String,
+    endDate: String,
+    startCity: String,
+    endCity: String,
+    countries: List<TripTimelineCountry>,
+    onCountryClick: (countryCode: String) -> Unit
+) {
+    val startCountry = countries.firstOrNull()
+    val endCountry = if (countries.size >= 2) countries.last() else startCountry
+    val intermediate = if (countries.size > 2) countries.subList(1, countries.size - 1) else emptyList()
+    val startDateShort = formatShortDate(startDate)
+    val endDateShort = formatShortDate(endDate)
+    val sameDay = startDateShort == endDateShort
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Endpoint(
+            city = startCity,
+            date = startDateShort,
+            country = startCountry,
+            alignment = Alignment.Start,
+            onCountryClick = onCountryClick,
+            modifier = Modifier.weight(1f)
+        )
+        if (intermediate.isNotEmpty()) {
+            Row(
+                modifier = Modifier.wrapContentWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                intermediate.forEach { country ->
                     Text(
-                        text = title,
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
+                        text = "·",
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = country.flagEmoji,
+                        fontSize = 16.sp,
+                        modifier = Modifier.clickable { onCountryClick(country.countryCode) }
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
                 }
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
+        }
+        Endpoint(
+            city = endCity,
+            date = endDateShort,
+            country = endCountry,
+            alignment = Alignment.End,
+            onCountryClick = onCountryClick,
+            // When the trip starts and ends the same day, hide the duplicate date on the end side
+            hideDate = sameDay,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun Endpoint(
+    city: String,
+    date: String,
+    country: TripTimelineCountry?,
+    alignment: Alignment.Horizontal,
+    onCountryClick: (countryCode: String) -> Unit,
+    modifier: Modifier = Modifier,
+    hideDate: Boolean = false
+) {
+    val isEnd = alignment == Alignment.End
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = if (isEnd) Arrangement.End else Arrangement.Start
+    ) {
+        if (!isEnd && country != null) {
+            Text(
+                text = country.flagEmoji,
+                fontSize = 22.sp,
+                modifier = Modifier.clickable { onCountryClick(country.countryCode) }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Column(horizontalAlignment = alignment) {
+            Text(
+                text = city,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (!hideDate) {
+                Text(
+                    text = date,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+            }
+        }
+        if (isEnd && country != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = country.flagEmoji,
+                fontSize = 22.sp,
+                modifier = Modifier.clickable { onCountryClick(country.countryCode) }
+            )
         }
     }
 }
@@ -350,6 +516,19 @@ private fun formatClockTime(dateStr: String): String {
             LocalDateTime.parse(dateStr.replace("Z", ""))
         }
         dt.format(DateTimeFormatter.ofPattern("HH:mm"))
+    } catch (e: Exception) {
+        dateStr
+    }
+}
+
+private fun formatShortDate(dateStr: String): String {
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (e: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        }
+        dt.format(DateTimeFormatter.ofPattern("d MMM"))
     } catch (e: Exception) {
         dateStr
     }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -72,6 +72,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
+import com.matedroid.ui.components.TripTimeline
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.components.createZapMarkerDrawable
 import com.matedroid.ui.theme.CarColorPalette
@@ -195,6 +196,13 @@ private fun TripDetailContent(
             isMapLoading = isMapLoading,
             palette = palette,
             onChargeClick = onChargeClick
+        )
+
+        TripTimeline(
+            segments = remember(trip) { buildTimelineSegments(trip) },
+            startDate = trip.startDate,
+            endDate = trip.endDate,
+            palette = palette
         )
 
         StatsSectionCard(

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -62,9 +62,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.matedroid.R
@@ -73,6 +71,7 @@ import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.components.TripTimeline
+import com.matedroid.ui.components.TripTimelineCountry
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.components.createZapMarkerDrawable
 import com.matedroid.ui.theme.CarColorPalette
@@ -85,11 +84,6 @@ import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Polyline
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -188,8 +182,6 @@ private fun TripDetailContent(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        RouteHeaderCard(trip, countries, onCountryClick)
-
         TripMapCard(
             routeSegments = routeSegments,
             markers = markers,
@@ -202,7 +194,13 @@ private fun TripDetailContent(
             segments = remember(trip) { buildTimelineSegments(trip) },
             startDate = trip.startDate,
             endDate = trip.endDate,
-            palette = palette
+            startCity = extractCity(trip.startAddress),
+            endCity = extractCity(trip.endAddress),
+            countries = remember(countries) {
+                countries.map { TripTimelineCountry(it.countryCode, it.flagEmoji) }
+            },
+            palette = palette,
+            onCountryClick = onCountryClick
         )
 
         StatsSectionCard(
@@ -252,149 +250,6 @@ private fun TripDetailContent(
         }
 
         Spacer(modifier = Modifier.height(8.dp))
-    }
-}
-
-// === Route Header — matches DriveDetailScreen ===
-
-@Composable
-private fun RouteHeaderCard(
-    trip: Trip,
-    countries: List<TripCountry>,
-    onCountryClick: (countryCode: String) -> Unit
-) {
-    val startFlag = countries.firstOrNull()?.flagEmoji
-    val endFlag = if (countries.size >= 2) countries.last().flagEmoji else startFlag
-    val midFlags = if (countries.size > 2) countries.subList(1, countries.size - 1) else emptyList()
-    val lineColor = MaterialTheme.colorScheme.primary
-
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            // Start stop: flag + city + time
-            val startCountry = countries.firstOrNull()
-            TimelineStop(
-                flag = startCountry?.flagEmoji,
-                fallbackColor = StatusSuccess,
-                city = extractCity(trip.startAddress),
-                label = stringResource(R.string.from),
-                time = formatDateTime(trip.startDate),
-                onFlagClick = startCountry?.let { { onCountryClick(it.countryCode) } }
-            )
-
-            // Line + intermediate countries
-            if (midFlags.isEmpty()) {
-                TimelineLine(lineColor, height = 16)
-            } else {
-                midFlags.forEach { country ->
-                    TimelineLine(lineColor, height = 8)
-                    TimelineStop(
-                        flag = country.flagEmoji,
-                        flagSize = 20,
-                        city = null,
-                        label = null,
-                        onFlagClick = { onCountryClick(country.countryCode) }
-                    )
-                }
-                TimelineLine(lineColor, height = 8)
-            }
-
-            // End stop: flag + city + time
-            val endCountry = if (countries.size >= 2) countries.last() else startCountry
-            TimelineStop(
-                flag = endCountry?.flagEmoji,
-                fallbackColor = StatusError,
-                city = extractCity(trip.endAddress),
-                label = stringResource(R.string.to),
-                time = formatDateTime(trip.endDate),
-                onFlagClick = endCountry?.let { { onCountryClick(it.countryCode) } }
-            )
-        }
-    }
-}
-
-/** A single stop on the timeline: flag marker + city label + optional right-aligned time. */
-@Composable
-private fun TimelineStop(
-    flag: String?,
-    flagSize: Int = 24,
-    fallbackColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.primary,
-    city: String?,
-    label: String?,
-    time: String? = null,
-    onFlagClick: (() -> Unit)? = null
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        // Flag or colored dot, centered in 32dp column
-        Box(
-            modifier = Modifier
-                .width(32.dp)
-                .then(if (onFlagClick != null) Modifier.clickable(onClick = onFlagClick) else Modifier),
-            contentAlignment = Alignment.Center
-        ) {
-            if (flag != null) {
-                Text(text = flag, fontSize = flagSize.sp)
-            } else {
-                Box(
-                    modifier = Modifier
-                        .size((flagSize - 4).dp)
-                        .background(fallbackColor, shape = RoundedCornerShape(50))
-                )
-            }
-        }
-        if (city != null) {
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                if (label != null) {
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f)
-                    )
-                }
-                Text(
-                    text = city,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            if (time != null) {
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = time,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-                    textAlign = TextAlign.End
-                )
-            }
-        }
-    }
-}
-
-/** Vertical connecting line between timeline stops. */
-@Composable
-private fun TimelineLine(
-    color: androidx.compose.ui.graphics.Color,
-    height: Int = 16
-) {
-    Box(
-        modifier = Modifier.width(32.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .width(2.dp)
-                .height(height.dp)
-                .background(color.copy(alpha = 0.3f))
-        )
     }
 }
 
@@ -907,17 +762,4 @@ private fun formatDuration(minutes: Int): String {
     val h = minutes / 60
     val m = minutes % 60
     return if (h > 0) "${h}h ${m}m" else "${m}m"
-}
-
-private fun formatDateTime(dateStr: String): String {
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        dt.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM))
-    } catch (e: Exception) {
-        dateStr
-    }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
@@ -1,0 +1,84 @@
+package com.matedroid.ui.screens.trips
+
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.domain.model.Trip
+import com.matedroid.ui.components.TripTimelineSegment
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+private const val MIN_PARKING_GAP_MIN = 5L
+
+/**
+ * Build a chronological list of TripTimelineSegments from a Trip.
+ * Inserts Parking segments for any gap >= MIN_PARKING_GAP_MIN between consecutive legs.
+ *
+ * Note: auto-detected trips only include DC charges (see TripDetector), so every charge
+ * here is marked isDc = true. When user-created trips land, this will need to consult
+ * the fast-charger flag per charge.
+ */
+fun buildTimelineSegments(trip: Trip): List<TripTimelineSegment> {
+    val allEvents = mutableListOf<Pair<String, Any>>()
+    trip.drives.forEach { allEvents.add(it.startDate to it) }
+    trip.charges.forEach { allEvents.add(it.startDate to it) }
+    allEvents.sortBy { it.first }
+
+    val segments = mutableListOf<TripTimelineSegment>()
+    var driveIdx = 0
+    var chargeIdx = 0
+    var prevEnd: LocalDateTime? = null
+
+    for ((_, event) in allEvents) {
+        val (startStr, endStr) = when (event) {
+            is DriveSummary -> event.startDate to event.endDate
+            is ChargeSummary -> event.startDate to event.endDate
+            else -> continue
+        }
+        val start = parseTimelineDate(startStr)
+        if (prevEnd != null && start != null) {
+            val gap = ChronoUnit.MINUTES.between(prevEnd, start)
+            if (gap >= MIN_PARKING_GAP_MIN) {
+                segments.add(TripTimelineSegment.Parking(durationMin = gap.toInt()))
+            }
+        }
+        when (event) {
+            is DriveSummary -> {
+                driveIdx++
+                segments.add(
+                    TripTimelineSegment.Drive(
+                        durationMin = event.durationMin,
+                        index = driveIdx,
+                        distanceKm = event.distance
+                    )
+                )
+            }
+            is ChargeSummary -> {
+                chargeIdx++
+                segments.add(
+                    TripTimelineSegment.Charge(
+                        durationMin = event.durationMin,
+                        index = chargeIdx,
+                        energyKwh = event.energyAdded,
+                        isDc = true
+                    )
+                )
+            }
+        }
+        prevEnd = parseTimelineDate(endStr)
+    }
+    return segments
+}
+
+private fun parseTimelineDate(dateStr: String): LocalDateTime? {
+    return try {
+        OffsetDateTime.parse(dateStr).toLocalDateTime()
+    } catch (e: DateTimeParseException) {
+        try {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        } catch (e2: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1068,6 +1068,12 @@
     <string name="trip_leg_drive">Trajecte %1$d</string>
     <string name="trip_leg_charge">Càrrega %1$d</string>
 
+    <string name="trip_timeline_title">Cronologia</string>
+    <string name="trip_timeline_driving">Conduint</string>
+    <string name="trip_timeline_charging_dc">Càrrega DC</string>
+    <string name="trip_timeline_charging_ac">Càrrega AC</string>
+    <string name="trip_timeline_parked">Aparcat</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Selecciona l\'aspecte del cotxe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1068,6 +1068,12 @@
     <string name="trip_leg_drive">Trayecto %1$d</string>
     <string name="trip_leg_charge">Carga %1$d</string>
 
+    <string name="trip_timeline_title">Cronología</string>
+    <string name="trip_timeline_driving">Conduciendo</string>
+    <string name="trip_timeline_charging_dc">Carga DC</string>
+    <string name="trip_timeline_charging_ac">Carga AC</string>
+    <string name="trip_timeline_parked">Estacionado</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleccionar aspecto del coche</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1068,6 +1068,12 @@
     <string name="trip_leg_drive">Tratta %1$d</string>
     <string name="trip_leg_charge">Ricarica %1$d</string>
 
+    <string name="trip_timeline_title">Cronologia</string>
+    <string name="trip_timeline_driving">In marcia</string>
+    <string name="trip_timeline_charging_dc">Ricarica DC</string>
+    <string name="trip_timeline_charging_ac">Ricarica AC</string>
+    <string name="trip_timeline_parked">In sosta</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleziona aspetto auto</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1069,6 +1069,12 @@
     <string name="trip_leg_drive">行驶 %1$d</string>
     <string name="trip_leg_charge">充电 %1$d</string>
 
+    <string name="trip_timeline_title">时间轴</string>
+    <string name="trip_timeline_driving">行驶中</string>
+    <string name="trip_timeline_charging_dc">DC 充电</string>
+    <string name="trip_timeline_charging_ac">AC 充电</string>
+    <string name="trip_timeline_parked">已停车</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">选择车辆外观</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1095,6 +1095,21 @@
     <!-- Charge leg label with number -->
     <string name="trip_leg_charge">Charge %1$d</string>
 
+    <!-- Section title for the horizontal trip timeline bar under the map, visualizes durations of drive/charge/parking segments -->
+    <string name="trip_timeline_title">Timeline</string>
+
+    <!-- Tooltip label for a drive segment on the trip timeline -->
+    <string name="trip_timeline_driving">Driving</string>
+
+    <!-- Tooltip label for a DC fast-charge segment on the trip timeline. DC is a technical unit and MUST NOT be translated. -->
+    <string name="trip_timeline_charging_dc">DC Charging</string>
+
+    <!-- Tooltip label for an AC charge segment on the trip timeline. AC is a technical unit and MUST NOT be translated. -->
+    <string name="trip_timeline_charging_ac">AC Charging</string>
+
+    <!-- Tooltip label for a parking gap segment on the trip timeline (time between legs when the car is idle) -->
+    <string name="trip_timeline_parked">Parked</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>


### PR DESCRIPTION
## Summary
- New horizontal timeline bar on the trip detail screen, placed directly under the map.
- Each drive, charge, and parking gap is drawn as a colored segment whose width is proportional to its duration.
- Colors follow the existing design language: drives in the car's accent, DC charges in `palette.dcColor` (orange, harmonized ~10% toward accent), AC charges in `palette.acColor` (green, harmonized ~20% toward accent), parking gaps in `surfaceVariant`.
- Parking segments longer than 2h use sqrt compression so multi-day idle stretches don't crush the driving/charging segments visually.
- Tapping a segment reveals its details (duration + distance / energy added) in an info panel above the bar; tapping the same segment again clears the selection.
- Selected segment grows 4dp taller to give M3-style feedback.
- Start and end clock times are shown beneath the bar as orientation.
- Strings added in all 5 locales (en, it, es, ca, zh) via the translate skill. AC/DC kept untranslated per project convention.

Note: auto-detected trips only include DC charges, so every charge segment is flagged `isDc = true` for now. The `isDc` field is already part of the composable's contract so custom user-created trips (future work) can mix AC and DC without changes to the renderer.

## Test plan
- [ ] Open a trip detail screen — timeline appears between the map and the summary card.
- [ ] Tap each type of segment (drive, charge, parking) and verify the info panel shows the right label and metrics in the selected locale.
- [ ] Verify colors match the car's theme: switch between different exterior colors and confirm the accent/DC/AC colors update accordingly.
- [ ] Verify on a multi-day trip (e.g., car parked overnight between drives) that the parking segment does not dominate.
- [ ] Verify on a short, tight trip that small charges are still visible and tappable.
- [ ] Dark theme: colors remain distinguishable, info panel remains readable.
- [ ] Rotate device: state (selected segment) is preserved within the same Compose tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)