### PR TITLE
feat: persist trips as first-class entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Trip timeline**: Horizontal timeline bar on the trip detail screen, under the map, visualizing each drive, charge, and parking gap as a colored segment proportional to its duration. Drives use the car's accent color, charges use the established AC/DC palette (green/orange, harmonized with the car's theme), parking gaps use a muted neutral. Tap any segment to see its details; multi-day parking stretches are compressed with a sqrt curve so driving and charging stay readable.
 
+### Changed
+- **Trip persistence**: Trips are now stored as first-class database entities. Auto-detected trips are silently persisted on first detection, unlocking the ability to edit and merge trips in a future update. No visible change for users.
+
 ## [1.5.0] - 2026-04-15
 
 ### Added

--- a/app/schemas/com.matedroid.data.local.StatsDatabase/12.json
+++ b/app/schemas/com.matedroid.data.local.StatsDatabase/12.json
@@ -1,0 +1,1205 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "7b414d8436bade16528a84fa6f42a2e7",
+    "entities": [
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`carId` INTEGER NOT NULL, `lastDriveSyncAt` INTEGER NOT NULL, `lastChargeSyncAt` INTEGER NOT NULL, `lastDriveDetailId` INTEGER NOT NULL, `lastChargeDetailId` INTEGER NOT NULL, `detailSchemaVersion` INTEGER NOT NULL, `totalDrivesToProcess` INTEGER NOT NULL, `totalChargesToProcess` INTEGER NOT NULL, `drivesProcessed` INTEGER NOT NULL, `chargesProcessed` INTEGER NOT NULL, `summariesSynced` INTEGER NOT NULL, `detailsSynced` INTEGER NOT NULL, PRIMARY KEY(`carId`))",
+        "fields": [
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDriveSyncAt",
+            "columnName": "lastDriveSyncAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChargeSyncAt",
+            "columnName": "lastChargeSyncAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDriveDetailId",
+            "columnName": "lastDriveDetailId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChargeDetailId",
+            "columnName": "lastChargeDetailId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailSchemaVersion",
+            "columnName": "detailSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDrivesToProcess",
+            "columnName": "totalDrivesToProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChargesToProcess",
+            "columnName": "totalChargesToProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "drivesProcessed",
+            "columnName": "drivesProcessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chargesProcessed",
+            "columnName": "chargesProcessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summariesSynced",
+            "columnName": "summariesSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailsSynced",
+            "columnName": "detailsSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "carId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "drives_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`driveId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, `durationMin` INTEGER NOT NULL, `startAddress` TEXT NOT NULL, `endAddress` TEXT NOT NULL, `distance` REAL NOT NULL, `speedMax` INTEGER NOT NULL, `speedAvg` INTEGER NOT NULL, `powerMax` INTEGER NOT NULL, `powerMin` INTEGER NOT NULL, `startBatteryLevel` INTEGER NOT NULL, `endBatteryLevel` INTEGER NOT NULL, `outsideTempAvg` REAL, `insideTempAvg` REAL, `energyConsumed` REAL, `efficiency` REAL, PRIMARY KEY(`driveId`))",
+        "fields": [
+          {
+            "fieldPath": "driveId",
+            "columnName": "driveId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMin",
+            "columnName": "durationMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAddress",
+            "columnName": "startAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAddress",
+            "columnName": "endAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedMax",
+            "columnName": "speedMax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedAvg",
+            "columnName": "speedAvg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerMax",
+            "columnName": "powerMax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerMin",
+            "columnName": "powerMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startBatteryLevel",
+            "columnName": "startBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endBatteryLevel",
+            "columnName": "endBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outsideTempAvg",
+            "columnName": "outsideTempAvg",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "insideTempAvg",
+            "columnName": "insideTempAvg",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "energyConsumed",
+            "columnName": "energyConsumed",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "efficiency",
+            "columnName": "efficiency",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "driveId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drives_summary_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drives_summary_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_drives_summary_carId_startDate",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "startDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drives_summary_carId_startDate` ON `${TABLE_NAME}` (`carId`, `startDate`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "charges_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chargeId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, `durationMin` INTEGER NOT NULL, `address` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `energyAdded` REAL NOT NULL, `energyUsed` REAL, `cost` REAL, `startBatteryLevel` INTEGER NOT NULL, `endBatteryLevel` INTEGER NOT NULL, `outsideTempAvg` REAL, `odometer` REAL NOT NULL, PRIMARY KEY(`chargeId`))",
+        "fields": [
+          {
+            "fieldPath": "chargeId",
+            "columnName": "chargeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMin",
+            "columnName": "durationMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energyAdded",
+            "columnName": "energyAdded",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energyUsed",
+            "columnName": "energyUsed",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startBatteryLevel",
+            "columnName": "startBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endBatteryLevel",
+            "columnName": "endBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outsideTempAvg",
+            "columnName": "outsideTempAvg",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "odometer",
+            "columnName": "odometer",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chargeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_charges_summary_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charges_summary_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_charges_summary_carId_startDate",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "startDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charges_summary_carId_startDate` ON `${TABLE_NAME}` (`carId`, `startDate`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "drive_detail_aggregates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`driveId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `schemaVersion` INTEGER NOT NULL, `computedAt` INTEGER NOT NULL, `maxElevation` INTEGER, `minElevation` INTEGER, `startElevation` INTEGER, `endElevation` INTEGER, `elevationGain` INTEGER, `elevationLoss` INTEGER, `hasElevationData` INTEGER NOT NULL, `maxInsideTemp` REAL, `minInsideTemp` REAL, `maxOutsideTemp` REAL, `minOutsideTemp` REAL, `maxPower` INTEGER, `minPower` INTEGER, `climateOnPositions` INTEGER NOT NULL, `positionCount` INTEGER NOT NULL, `startLatitude` REAL, `startLongitude` REAL, `startCountryCode` TEXT, `startCountryName` TEXT, `startRegionName` TEXT, `startCity` TEXT, `endLatitude` REAL, `endLongitude` REAL, `extraJson` TEXT, PRIMARY KEY(`driveId`), FOREIGN KEY(`driveId`) REFERENCES `drives_summary`(`driveId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "driveId",
+            "columnName": "driveId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxElevation",
+            "columnName": "maxElevation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minElevation",
+            "columnName": "minElevation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startElevation",
+            "columnName": "startElevation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endElevation",
+            "columnName": "endElevation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "elevationGain",
+            "columnName": "elevationGain",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "elevationLoss",
+            "columnName": "elevationLoss",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasElevationData",
+            "columnName": "hasElevationData",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxInsideTemp",
+            "columnName": "maxInsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minInsideTemp",
+            "columnName": "minInsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxOutsideTemp",
+            "columnName": "maxOutsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minOutsideTemp",
+            "columnName": "minOutsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxPower",
+            "columnName": "maxPower",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minPower",
+            "columnName": "minPower",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "climateOnPositions",
+            "columnName": "climateOnPositions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionCount",
+            "columnName": "positionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startLatitude",
+            "columnName": "startLatitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startLongitude",
+            "columnName": "startLongitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startCountryCode",
+            "columnName": "startCountryCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startCountryName",
+            "columnName": "startCountryName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startRegionName",
+            "columnName": "startRegionName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startCity",
+            "columnName": "startCity",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endLatitude",
+            "columnName": "endLatitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endLongitude",
+            "columnName": "endLongitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraJson",
+            "columnName": "extraJson",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "driveId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drive_detail_aggregates_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_detail_aggregates_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_drive_detail_aggregates_driveId",
+            "unique": false,
+            "columnNames": [
+              "driveId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_detail_aggregates_driveId` ON `${TABLE_NAME}` (`driveId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "drives_summary",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "driveId"
+            ],
+            "referencedColumns": [
+              "driveId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "charge_detail_aggregates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chargeId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `schemaVersion` INTEGER NOT NULL, `computedAt` INTEGER NOT NULL, `isFastCharger` INTEGER NOT NULL, `fastChargerBrand` TEXT, `connectorType` TEXT, `maxChargerPower` INTEGER, `maxChargerVoltage` INTEGER, `maxChargerCurrent` INTEGER, `chargerPhases` INTEGER, `maxOutsideTemp` REAL, `minOutsideTemp` REAL, `chargePointCount` INTEGER NOT NULL, `countryCode` TEXT, `countryName` TEXT, `regionName` TEXT, `city` TEXT, `extraJson` TEXT, PRIMARY KEY(`chargeId`), FOREIGN KEY(`chargeId`) REFERENCES `charges_summary`(`chargeId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chargeId",
+            "columnName": "chargeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFastCharger",
+            "columnName": "isFastCharger",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fastChargerBrand",
+            "columnName": "fastChargerBrand",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connectorType",
+            "columnName": "connectorType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxChargerPower",
+            "columnName": "maxChargerPower",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxChargerVoltage",
+            "columnName": "maxChargerVoltage",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxChargerCurrent",
+            "columnName": "maxChargerCurrent",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "chargerPhases",
+            "columnName": "chargerPhases",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxOutsideTemp",
+            "columnName": "maxOutsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minOutsideTemp",
+            "columnName": "minOutsideTemp",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "chargePointCount",
+            "columnName": "chargePointCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "countryName",
+            "columnName": "countryName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "regionName",
+            "columnName": "regionName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraJson",
+            "columnName": "extraJson",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chargeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_charge_detail_aggregates_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charge_detail_aggregates_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_charge_detail_aggregates_chargeId",
+            "unique": false,
+            "columnNames": [
+              "chargeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charge_detail_aggregates_chargeId` ON `${TABLE_NAME}` (`chargeId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "charges_summary",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chargeId"
+            ],
+            "referencedColumns": [
+              "chargeId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "geocode_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gridLat` INTEGER NOT NULL, `gridLon` INTEGER NOT NULL, `countryCode` TEXT, `countryName` TEXT, `regionName` TEXT, `city` TEXT, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`gridLat`, `gridLon`))",
+        "fields": [
+          {
+            "fieldPath": "gridLat",
+            "columnName": "gridLat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridLon",
+            "columnName": "gridLon",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "countryName",
+            "columnName": "countryName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "regionName",
+            "columnName": "regionName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "gridLat",
+            "gridLon"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "geocode_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gridLat` INTEGER NOT NULL, `gridLon` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `addedAt` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, PRIMARY KEY(`gridLat`, `gridLon`))",
+        "fields": [
+          {
+            "fieldPath": "gridLat",
+            "columnName": "gridLat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridLon",
+            "columnName": "gridLon",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "gridLat",
+            "gridLon"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "geocode_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`carId` INTEGER NOT NULL, `totalLocations` INTEGER NOT NULL, `processedLocations` INTEGER NOT NULL, `lastUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`carId`))",
+        "fields": [
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalLocations",
+            "columnName": "totalLocations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processedLocations",
+            "columnName": "processedLocations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "carId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sentry_alert_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `carId` INTEGER NOT NULL, `detectedAt` INTEGER NOT NULL, `sessionStartedAt` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `address` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detectedAt",
+            "columnName": "detectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionStartedAt",
+            "columnName": "sessionStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sentry_alert_log_carId_detectedAt",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "detectedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sentry_alert_log_carId_detectedAt` ON `${TABLE_NAME}` (`carId`, `detectedAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "trip_route_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripKey` TEXT NOT NULL, `segmentIndex` INTEGER NOT NULL, `segmentData` BLOB NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`tripKey`, `segmentIndex`))",
+        "fields": [
+          {
+            "fieldPath": "tripKey",
+            "columnName": "tripKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "segmentIndex",
+            "columnName": "segmentIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "segmentData",
+            "columnName": "segmentData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripKey",
+            "segmentIndex"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "trip_country_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripKey` TEXT NOT NULL, `countries` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`tripKey`))",
+        "fields": [
+          {
+            "fieldPath": "tripKey",
+            "columnName": "tripKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countries",
+            "columnName": "countries",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripKey"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "saved_trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `carId` INTEGER NOT NULL, `name` TEXT, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trips_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trips_carId` ON `${TABLE_NAME}` (`carId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "saved_trip_legs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripId` INTEGER NOT NULL, `position` INTEGER NOT NULL, `legType` TEXT NOT NULL, `legId` INTEGER NOT NULL, PRIMARY KEY(`tripId`, `position`), FOREIGN KEY(`tripId`) REFERENCES `saved_trips`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tripId",
+            "columnName": "tripId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legType",
+            "columnName": "legType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legId",
+            "columnName": "legId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripId",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trip_legs_legType_legId",
+            "unique": false,
+            "columnNames": [
+              "legType",
+              "legId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trip_legs_legType_legId` ON `${TABLE_NAME}` (`legType`, `legId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "saved_trips",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tripId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_trip_consumed_fingerprints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`savedTripId` INTEGER NOT NULL, `fingerprint` TEXT NOT NULL, PRIMARY KEY(`savedTripId`, `fingerprint`), FOREIGN KEY(`savedTripId`) REFERENCES `saved_trips`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "savedTripId",
+            "columnName": "savedTripId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fingerprint",
+            "columnName": "fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "savedTripId",
+            "fingerprint"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trip_consumed_fingerprints_fingerprint",
+            "unique": false,
+            "columnNames": [
+              "fingerprint"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trip_consumed_fingerprints_fingerprint` ON `${TABLE_NAME}` (`fingerprint`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "saved_trips",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "savedTripId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7b414d8436bade16528a84fa6f42a2e7')"
+    ]
+  }
+}

--- a/app/src/main/java/com/matedroid/data/local/StatsDatabase.kt
+++ b/app/src/main/java/com/matedroid/data/local/StatsDatabase.kt
@@ -10,6 +10,7 @@ import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.local.dao.GeocodeCacheDao
 import com.matedroid.data.local.dao.GeocodeProgressDao
 import com.matedroid.data.local.dao.GeocodeQueueDao
+import com.matedroid.data.local.dao.SavedTripDao
 import com.matedroid.data.local.dao.SentryAlertLogDao
 import com.matedroid.data.local.dao.SyncStateDao
 import com.matedroid.data.local.dao.TripCountryCacheDao
@@ -21,6 +22,9 @@ import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.data.local.entity.GeocodeCache
 import com.matedroid.data.local.entity.GeocodeProgress
 import com.matedroid.data.local.entity.GeocodeQueueItem
+import com.matedroid.data.local.entity.SavedTrip
+import com.matedroid.data.local.entity.SavedTripConsumedFingerprint
+import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.local.entity.SentryAlertLog
 import com.matedroid.data.local.entity.SyncState
 import com.matedroid.data.local.entity.TripCountryCache
@@ -50,9 +54,12 @@ import com.matedroid.data.local.entity.TripRouteCache
         GeocodeProgress::class,
         SentryAlertLog::class,
         TripRouteCache::class,
-        TripCountryCache::class
+        TripCountryCache::class,
+        SavedTrip::class,
+        SavedTripLeg::class,
+        SavedTripConsumedFingerprint::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = true
 )
 abstract class StatsDatabase : RoomDatabase() {
@@ -67,6 +74,7 @@ abstract class StatsDatabase : RoomDatabase() {
     abstract fun sentryAlertLogDao(): SentryAlertLogDao
     abstract fun tripRouteCacheDao(): TripRouteCacheDao
     abstract fun tripCountryCacheDao(): TripCountryCacheDao
+    abstract fun savedTripDao(): SavedTripDao
 
     companion object {
         const val DATABASE_NAME = "matedroid_stats.db"
@@ -254,6 +262,61 @@ abstract class StatsDatabase : RoomDatabase() {
             }
         }
 
-        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+        /**
+         * Migration from V11 to V12: Add saved trip persistence tables.
+         *
+         * - saved_trips: first-class trip entity (metrics derived from legs at read time)
+         * - saved_trip_legs: ordered DRIVE/CHARGE references per trip (ON DELETE CASCADE)
+         * - saved_trip_consumed_fingerprints: suppresses auto-detector output already
+         *   represented by a saved trip (ON DELETE CASCADE → releases when trip is deleted)
+         */
+        val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS saved_trips (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        carId INTEGER NOT NULL,
+                        name TEXT,
+                        source TEXT NOT NULL,
+                        createdAt INTEGER NOT NULL,
+                        updatedAt INTEGER NOT NULL
+                    )
+                """)
+                db.execSQL("""
+                    CREATE INDEX IF NOT EXISTS index_saved_trips_carId
+                    ON saved_trips (carId)
+                """)
+
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS saved_trip_legs (
+                        tripId INTEGER NOT NULL,
+                        position INTEGER NOT NULL,
+                        legType TEXT NOT NULL,
+                        legId INTEGER NOT NULL,
+                        PRIMARY KEY (tripId, position),
+                        FOREIGN KEY (tripId) REFERENCES saved_trips(id) ON DELETE CASCADE
+                    )
+                """)
+                db.execSQL("""
+                    CREATE INDEX IF NOT EXISTS index_saved_trip_legs_legType_legId
+                    ON saved_trip_legs (legType, legId)
+                """)
+
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS saved_trip_consumed_fingerprints (
+                        savedTripId INTEGER NOT NULL,
+                        fingerprint TEXT NOT NULL,
+                        PRIMARY KEY (savedTripId, fingerprint),
+                        FOREIGN KEY (savedTripId) REFERENCES saved_trips(id) ON DELETE CASCADE
+                    )
+                """)
+                db.execSQL("""
+                    CREATE INDEX IF NOT EXISTS index_saved_trip_consumed_fingerprints_fingerprint
+                    ON saved_trip_consumed_fingerprints (fingerprint)
+                """)
+            }
+        }
+
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
     }
 }

--- a/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
@@ -1,0 +1,50 @@
+package com.matedroid.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import com.matedroid.data.local.entity.SavedTrip
+import com.matedroid.data.local.entity.SavedTripConsumedFingerprint
+import com.matedroid.data.local.entity.SavedTripLeg
+import com.matedroid.data.local.entity.SavedTripWithLegs
+
+@Dao
+abstract class SavedTripDao {
+
+    @Transaction
+    @Query("SELECT * FROM saved_trips WHERE carId = :carId ORDER BY id ASC")
+    abstract suspend fun getAllWithLegs(carId: Int): List<SavedTripWithLegs>
+
+    @Transaction
+    @Query("SELECT * FROM saved_trips WHERE id = :tripId")
+    abstract suspend fun getWithLegs(tripId: Long): SavedTripWithLegs?
+
+    @Query("""
+        SELECT fp.fingerprint FROM saved_trip_consumed_fingerprints fp
+        INNER JOIN saved_trips st ON fp.savedTripId = st.id
+        WHERE st.carId = :carId
+    """)
+    abstract suspend fun getAllConsumedFingerprintsForCar(carId: Int): List<String>
+
+    @Insert
+    abstract suspend fun insertTrip(trip: SavedTrip): Long
+
+    @Insert
+    abstract suspend fun insertLegs(legs: List<SavedTripLeg>)
+
+    @Insert
+    abstract suspend fun insertConsumedFingerprints(rows: List<SavedTripConsumedFingerprint>)
+
+    /** Atomically insert a trip and its legs, returning the generated trip id. */
+    @Transaction
+    open suspend fun insertTripWithLegs(trip: SavedTrip, legs: (Long) -> List<SavedTripLeg>): Long {
+        val tripId = insertTrip(trip)
+        val resolved = legs(tripId)
+        if (resolved.isNotEmpty()) insertLegs(resolved)
+        return tripId
+    }
+
+    @Query("DELETE FROM saved_trips WHERE id = :tripId")
+    abstract suspend fun deleteTrip(tripId: Long)
+}

--- a/app/src/main/java/com/matedroid/data/local/entity/SavedTrip.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SavedTrip.kt
@@ -1,0 +1,36 @@
+package com.matedroid.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * A trip persisted as a first-class entity.
+ *
+ * Auto-detected trips are saved on first detection with source = AUTO_DETECTED.
+ * Once persisted, the trip acts as the source of truth for the trips list.
+ * Future user edits (adding legs, merging with another trip) transition the
+ * source to USER_EDITED or USER_MERGED.
+ *
+ * Metrics (distance, duration, energy, etc.) are NOT stored here — they are
+ * always derived from the referenced drive/charge legs at read time.
+ */
+@Entity(
+    tableName = "saved_trips",
+    indices = [Index(value = ["carId"])]
+)
+data class SavedTrip(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val carId: Int,
+    val name: String?,
+    val source: String,
+    val createdAt: Long,
+    val updatedAt: Long
+) {
+    companion object {
+        const val SOURCE_AUTO_DETECTED = "AUTO_DETECTED"
+        const val SOURCE_USER_EDITED = "USER_EDITED"
+        const val SOURCE_USER_MERGED = "USER_MERGED"
+    }
+}

--- a/app/src/main/java/com/matedroid/data/local/entity/SavedTripConsumedFingerprint.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SavedTripConsumedFingerprint.kt
@@ -1,0 +1,38 @@
+package com.matedroid.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Fingerprints of auto-detected trips that are now represented by a saved trip.
+ *
+ * When the user edits or merges trips, their original auto-detected fingerprints
+ * are stored here so TripDetector's output can be filtered — we don't want to
+ * re-emit a trip that the user has already folded into a saved one.
+ *
+ * Cascade delete means: removing a SavedTrip releases its consumed fingerprints,
+ * letting the auto-detector re-emit the originals on the next load. This gives
+ * us implicit undo for edits/merges.
+ *
+ * Unused in PR 1 (auto-detected saves don't need consumed entries — their own
+ * fingerprint equals the trip's current fingerprint). Populated by PR 2 when
+ * edits and merges land.
+ */
+@Entity(
+    tableName = "saved_trip_consumed_fingerprints",
+    primaryKeys = ["savedTripId", "fingerprint"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SavedTrip::class,
+            parentColumns = ["id"],
+            childColumns = ["savedTripId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index(value = ["fingerprint"])]
+)
+data class SavedTripConsumedFingerprint(
+    val savedTripId: Long,
+    val fingerprint: String
+)

--- a/app/src/main/java/com/matedroid/data/local/entity/SavedTripLeg.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SavedTripLeg.kt
@@ -1,0 +1,37 @@
+package com.matedroid.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * One leg of a SavedTrip: either a drive or a charge, referenced by id.
+ *
+ * Legs are ordered by [position] within the parent trip. The index on
+ * (legType, legId) allows efficient lookup of "which trips include drive/charge X",
+ * needed when the edit UI checks whether a leg is already part of another trip.
+ */
+@Entity(
+    tableName = "saved_trip_legs",
+    primaryKeys = ["tripId", "position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SavedTrip::class,
+            parentColumns = ["id"],
+            childColumns = ["tripId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index(value = ["legType", "legId"])]
+)
+data class SavedTripLeg(
+    val tripId: Long,
+    val position: Int,
+    val legType: String,
+    val legId: Int
+) {
+    companion object {
+        const val TYPE_DRIVE = "DRIVE"
+        const val TYPE_CHARGE = "CHARGE"
+    }
+}

--- a/app/src/main/java/com/matedroid/data/local/entity/SavedTripWithLegs.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SavedTripWithLegs.kt
@@ -1,0 +1,14 @@
+package com.matedroid.data.local.entity
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+/** A SavedTrip together with its ordered legs, loaded in a single query. */
+data class SavedTripWithLegs(
+    @Embedded val trip: SavedTrip,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "tripId"
+    )
+    val legs: List<SavedTripLeg>
+)

--- a/app/src/main/java/com/matedroid/di/DatabaseModule.kt
+++ b/app/src/main/java/com/matedroid/di/DatabaseModule.kt
@@ -9,6 +9,7 @@ import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.local.dao.GeocodeCacheDao
 import com.matedroid.data.local.dao.GeocodeProgressDao
 import com.matedroid.data.local.dao.GeocodeQueueDao
+import com.matedroid.data.local.dao.SavedTripDao
 import com.matedroid.data.local.dao.SentryAlertLogDao
 import com.matedroid.data.local.dao.SyncStateDao
 import com.matedroid.data.local.dao.TripCountryCacheDao
@@ -97,5 +98,11 @@ object DatabaseModule {
     @Singleton
     fun provideTripCountryCacheDao(database: StatsDatabase): TripCountryCacheDao {
         return database.tripCountryCacheDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideSavedTripDao(database: StatsDatabase): SavedTripDao {
+        return database.savedTripDao()
     }
 }

--- a/app/src/main/java/com/matedroid/domain/TripAggregator.kt
+++ b/app/src/main/java/com/matedroid/domain/TripAggregator.kt
@@ -1,0 +1,75 @@
+package com.matedroid.domain
+
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.domain.model.Trip
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+/**
+ * Assembles a Trip domain object from its constituent drive and charge legs.
+ *
+ * Shared by TripDetector (for newly detected trips) and TripRepository (for
+ * rebuilding persisted SavedTrips from their leg references). The aggregator
+ * itself enforces no detection rules — callers decide whether a given leg set
+ * is eligible (the detector applies the 300 km / 2-drive / 1-charge thresholds).
+ */
+object TripAggregator {
+
+    /**
+     * Build a Trip from chronologically-ordered legs.
+     * Returns null if [drives] is empty (a Trip's start/end metadata comes from the first/last drive).
+     */
+    fun buildTrip(drives: List<DriveSummary>, charges: List<ChargeSummary>): Trip? {
+        if (drives.isEmpty()) return null
+
+        val totalDistance = drives.sumOf { it.distance }
+        val totalDrivingMin = drives.sumOf { it.durationMin }
+        val firstStart = parseDateTime(drives.first().startDate)
+        val lastEnd = parseDateTime(drives.last().endDate)
+        val totalMin = if (firstStart != null && lastEnd != null) {
+            ChronoUnit.MINUTES.between(firstStart, lastEnd).toInt()
+        } else totalDrivingMin
+        val totalEnergyConsumed = drives.mapNotNull { it.energyConsumed }.sum()
+        val totalEnergyCharged = charges.sumOf { it.energyAdded }
+        val costs = charges.mapNotNull { it.cost }
+        val totalCost = if (costs.isNotEmpty()) costs.sum() else null
+        val maxSpeed = drives.maxOf { it.speedMax }
+        val avgEfficiency = if (totalDistance > 0) {
+            (totalEnergyConsumed * 1000.0) / totalDistance
+        } else null
+
+        return Trip(
+            drives = drives.toList(),
+            charges = charges.toList(),
+            totalDistance = totalDistance,
+            totalDrivingDurationMin = totalDrivingMin,
+            totalDurationMin = totalMin,
+            totalEnergyConsumed = totalEnergyConsumed,
+            totalEnergyCharged = totalEnergyCharged,
+            totalChargeCost = totalCost,
+            avgEfficiency = avgEfficiency,
+            maxSpeed = maxSpeed,
+            startAddress = drives.first().startAddress,
+            endAddress = drives.last().endAddress,
+            startDate = drives.first().startDate,
+            endDate = drives.last().endDate,
+            startBatteryLevel = drives.first().startBatteryLevel,
+            endBatteryLevel = drives.last().endBatteryLevel
+        )
+    }
+
+    private fun parseDateTime(dateStr: String): LocalDateTime? {
+        return try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (e: DateTimeParseException) {
+            try {
+                LocalDateTime.parse(dateStr.replace("Z", ""))
+            } catch (e2: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/domain/TripDetector.kt
+++ b/app/src/main/java/com/matedroid/domain/TripDetector.kt
@@ -122,44 +122,9 @@ class TripDetector @Inject constructor() {
         trips: MutableList<Trip>
     ) {
         if (drives.size < 2 || charges.isEmpty()) return
-
         val totalDistance = drives.sumOf { it.distance }
         if (totalDistance < MIN_TRIP_DISTANCE_KM) return
-        val totalDrivingMin = drives.sumOf { it.durationMin }
-        val firstStart = parseDateTime(drives.first().startDate)
-        val lastEnd = parseDateTime(drives.last().endDate)
-        val totalMin = if (firstStart != null && lastEnd != null) {
-            ChronoUnit.MINUTES.between(firstStart, lastEnd).toInt()
-        } else totalDrivingMin
-        val totalEnergyConsumed = drives.mapNotNull { it.energyConsumed }.sum()
-        val totalEnergyCharged = charges.sumOf { it.energyAdded }
-        val costs = charges.mapNotNull { it.cost }
-        val totalCost = if (costs.isNotEmpty()) costs.sum() else null
-        val maxSpeed = drives.maxOf { it.speedMax }
-        val avgEfficiency = if (totalDistance > 0) {
-            (totalEnergyConsumed * 1000.0) / totalDistance
-        } else null
-
-        trips.add(
-            Trip(
-                drives = drives.toList(),
-                charges = charges.toList(),
-                totalDistance = totalDistance,
-                totalDrivingDurationMin = totalDrivingMin,
-                totalDurationMin = totalMin,
-                totalEnergyConsumed = totalEnergyConsumed,
-                totalEnergyCharged = totalEnergyCharged,
-                totalChargeCost = totalCost,
-                avgEfficiency = avgEfficiency,
-                maxSpeed = maxSpeed,
-                startAddress = drives.first().startAddress,
-                endAddress = drives.last().endAddress,
-                startDate = drives.first().startDate,
-                endDate = drives.last().endDate,
-                startBatteryLevel = drives.first().startBatteryLevel,
-                endBatteryLevel = drives.last().endBatteryLevel
-            )
-        )
+        TripAggregator.buildTrip(drives, charges)?.let { trips.add(it) }
     }
 
     private fun parseDateTime(dateStr: String): LocalDateTime? {

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -1,0 +1,141 @@
+package com.matedroid.domain
+
+import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.local.dao.DriveSummaryDao
+import com.matedroid.data.local.dao.SavedTripDao
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.data.local.entity.SavedTrip
+import com.matedroid.data.local.entity.SavedTripLeg
+import com.matedroid.data.local.entity.SavedTripWithLegs
+import com.matedroid.domain.model.Trip
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single entry point for reading and persisting trips.
+ *
+ * Ingests raw drives + DC charges, runs [TripDetector] to find new trips, and
+ * silently persists them as [SavedTrip] rows on first detection. Subsequent calls
+ * read from the saved trips table, skipping any detected fingerprint that is
+ * already represented by a saved trip (either directly, or via the consumed set
+ * populated by future edit/merge operations).
+ *
+ * The trip fingerprint is a SHA-256 of the sorted drive IDs — same format used
+ * by [com.matedroid.data.local.entity.TripRouteCache] and
+ * [com.matedroid.data.local.entity.TripCountryCache] keys, so the existing
+ * caches remain valid.
+ */
+@Singleton
+class TripRepository @Inject constructor(
+    private val driveSummaryDao: DriveSummaryDao,
+    private val aggregateDao: AggregateDao,
+    private val savedTripDao: SavedTripDao,
+    private val tripDetector: TripDetector
+) {
+
+    /** Returns all trips for a car (saved + newly auto-detected this call), newest first. */
+    suspend fun getTrips(carId: Int): List<Trip> {
+        val drives = driveSummaryDao.getAllChronological(carId)
+        val dcCharges = aggregateDao.getDcChargeSummaries(carId)
+
+        autoPersistNewTrips(carId, drives, dcCharges)
+
+        val saved = savedTripDao.getAllWithLegs(carId)
+        return buildTripsFromSaved(saved, drives, dcCharges)
+            .sortedByDescending { it.startDate }
+    }
+
+    /** Fingerprint for a list of drive IDs. Stable regardless of order. */
+    fun computeFingerprint(driveIds: List<Int>): String {
+        val ids = driveIds.sorted().joinToString(",")
+        val digest = MessageDigest.getInstance("SHA-256").digest(ids.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    /** Convenience: fingerprint of a [Trip]. */
+    fun computeFingerprint(trip: Trip): String =
+        computeFingerprint(trip.drives.map { it.driveId })
+
+    /** Delete a saved trip. Cascade removes its legs and consumed fingerprints, letting the detector re-emit the originals. */
+    suspend fun deleteTrip(tripId: Long) {
+        savedTripDao.deleteTrip(tripId)
+    }
+
+    private suspend fun autoPersistNewTrips(
+        carId: Int,
+        drives: List<DriveSummary>,
+        dcCharges: List<ChargeSummary>
+    ) {
+        val existing = savedTripDao.getAllWithLegs(carId)
+        val existingFingerprints = existing.map { swl ->
+            computeFingerprint(swl.driveIds())
+        }.toSet()
+        val consumedFingerprints = savedTripDao.getAllConsumedFingerprintsForCar(carId).toSet()
+        val suppressed = existingFingerprints + consumedFingerprints
+
+        val detected = tripDetector.detectTrips(drives, dcCharges)
+        if (detected.isEmpty()) return
+
+        val now = System.currentTimeMillis()
+        for (trip in detected) {
+            val fp = computeFingerprint(trip)
+            if (fp in suppressed) continue
+
+            savedTripDao.insertTripWithLegs(
+                trip = SavedTrip(
+                    carId = carId,
+                    name = null,
+                    source = SavedTrip.SOURCE_AUTO_DETECTED,
+                    createdAt = now,
+                    updatedAt = now
+                ),
+                legs = { tripId -> buildChronologicalLegs(tripId, trip) }
+            )
+        }
+    }
+
+    private fun buildChronologicalLegs(tripId: Long, trip: Trip): List<SavedTripLeg> {
+        data class Event(val date: String, val type: String, val id: Int)
+
+        val events = buildList {
+            trip.drives.forEach { add(Event(it.startDate, SavedTripLeg.TYPE_DRIVE, it.driveId)) }
+            trip.charges.forEach { add(Event(it.startDate, SavedTripLeg.TYPE_CHARGE, it.chargeId)) }
+        }.sortedBy { it.date }
+
+        return events.mapIndexed { index, e ->
+            SavedTripLeg(tripId = tripId, position = index, legType = e.type, legId = e.id)
+        }
+    }
+
+    /**
+     * Resolve saved trip legs back into a Trip domain object.
+     *
+     * PR 1 scope: all saved trips are AUTO_DETECTED, so every charge leg is a DC charge
+     * and resolves via [dcCharges]. When PR 2 introduces AC charges in user-edited trips,
+     * this will need to consult the full charges_summary table.
+     */
+    private fun buildTripsFromSaved(
+        saved: List<SavedTripWithLegs>,
+        drives: List<DriveSummary>,
+        dcCharges: List<ChargeSummary>
+    ): List<Trip> {
+        val drivesById = drives.associateBy { it.driveId }
+        val chargesById = dcCharges.associateBy { it.chargeId }
+
+        return saved.mapNotNull { swl ->
+            val orderedLegs = swl.legs.sortedBy { it.position }
+            val tripDrives = orderedLegs
+                .filter { it.legType == SavedTripLeg.TYPE_DRIVE }
+                .mapNotNull { drivesById[it.legId] }
+            val tripCharges = orderedLegs
+                .filter { it.legType == SavedTripLeg.TYPE_CHARGE }
+                .mapNotNull { chargesById[it.legId] }
+            TripAggregator.buildTrip(tripDrives, tripCharges)
+        }
+    }
+
+    private fun SavedTripWithLegs.driveIds(): List<Int> =
+        legs.filter { it.legType == SavedTripLeg.TYPE_DRIVE }.map { it.legId }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -9,9 +9,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.CarImageOverride
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TripCountCache
-import com.matedroid.data.local.dao.AggregateDao
-import com.matedroid.data.local.dao.DriveSummaryDao
-import com.matedroid.domain.TripDetector
+import com.matedroid.domain.TripRepository
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.SentryStateRepository
@@ -74,9 +72,7 @@ class DashboardViewModel @Inject constructor(
     private val geocodingRepository: GeocodingRepository,
     private val settingsDataStore: SettingsDataStore,
     private val sentryStateRepository: SentryStateRepository,
-    private val driveSummaryDao: DriveSummaryDao,
-    private val aggregateDao: AggregateDao,
-    private val tripDetector: TripDetector,
+    private val tripRepository: TripRepository,
     private val tripCountCache: TripCountCache
 ) : ViewModel() {
 
@@ -321,10 +317,8 @@ class DashboardViewModel @Inject constructor(
             tripCountCache.get(carId)?.let { cached ->
                 _uiState.update { it.copy(totalTrips = cached) }
             }
-            // Recompute in background and update cache
-            val drives = driveSummaryDao.getAllChronological(carId)
-            val dcCharges = aggregateDao.getDcChargeSummaries(carId)
-            val count = tripDetector.detectTrips(drives, dcCharges).size
+            // Recompute in background and update cache (also auto-persists new saved trips)
+            val count = tripRepository.getTrips(carId).size
             _uiState.update { it.copy(totalTrips = count) }
             tripCountCache.set(carId, count)
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.AggregateDao
-import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.local.dao.GeocodeCacheDao
 import com.matedroid.data.local.dao.TripCountryCacheDao
 import com.matedroid.data.local.dao.TripRouteCacheDao
@@ -16,7 +15,7 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.data.repository.countryCodeToFlag
 import com.matedroid.domain.RouteSimplifier
-import com.matedroid.domain.TripDetector
+import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -28,7 +27,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.nio.ByteBuffer
-import java.security.MessageDigest
 import javax.inject.Inject
 
 data class TripRoutePoint(
@@ -69,12 +67,11 @@ data class TripDetailUiState(
 
 @HiltViewModel
 class TripDetailViewModel @Inject constructor(
-    private val driveSummaryDao: DriveSummaryDao,
     private val aggregateDao: AggregateDao,
     private val geocodeCacheDao: GeocodeCacheDao,
     private val tripRouteCacheDao: TripRouteCacheDao,
     private val tripCountryCacheDao: TripCountryCacheDao,
-    private val tripDetector: TripDetector,
+    private val tripRepository: TripRepository,
     private val tripCache: TripCache,
     private val repository: TeslamateRepository,
     private val settingsDataStore: SettingsDataStore
@@ -102,13 +99,9 @@ class TripDetailViewModel @Inject constructor(
                 _uiState.update { it.copy(currencySymbol = symbol) }
             }
 
-            // Fast path: use cached trip from list screen (avoids full re-detection)
-            val trip = tripCache.take(tripStartDate) ?: run {
-                val drives = driveSummaryDao.getAllChronological(carId)
-                val dcCharges = aggregateDao.getDcChargeSummaries(carId)
-                val trips = tripDetector.detectTrips(drives, dcCharges)
-                trips.find { it.startDate == tripStartDate }
-            }
+            // Fast path: use cached trip from list screen (avoids a repository round trip)
+            val trip = tripCache.take(tripStartDate)
+                ?: tripRepository.getTrips(carId).find { it.startDate == tripStartDate }
             if (trip == null) {
                 _uiState.update { it.copy(isLoading = false, isMapLoading = false) }
                 return@launch
@@ -341,12 +334,8 @@ class TripDetailViewModel @Inject constructor(
             .filter { it.points.isNotEmpty() }
     }
 
-    /** SHA-256 hash of sorted drive IDs, used as cache key. */
-    private fun computeTripKey(trip: Trip): String {
-        val ids = trip.drives.map { it.driveId }.sorted().joinToString(",")
-        val digest = MessageDigest.getInstance("SHA-256").digest(ids.toByteArray())
-        return digest.joinToString("") { "%02x".format(it) }
-    }
+    /** SHA-256 hash of sorted drive IDs, used as cache key. Delegates to [TripRepository]. */
+    private fun computeTripKey(trip: Trip): String = tripRepository.computeFingerprint(trip)
 
     /** Pack points as big-endian doubles: [lat0, lon0, lat1, lon1, ...] */
     private fun serializeSegment(segment: TripRouteSegment): ByteArray {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -3,11 +3,9 @@ package com.matedroid.ui.screens.trips
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.Units
-import com.matedroid.data.local.dao.AggregateDao
-import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
-import com.matedroid.domain.TripDetector
+import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,9 +35,7 @@ data class TripsUiState(
 
 @HiltViewModel
 class TripsViewModel @Inject constructor(
-    private val driveSummaryDao: DriveSummaryDao,
-    private val aggregateDao: AggregateDao,
-    private val tripDetector: TripDetector,
+    private val tripRepository: TripRepository,
     private val repository: TeslamateRepository,
     private val tripCache: TripCache
 ) : ViewModel() {
@@ -93,9 +89,7 @@ class TripsViewModel @Inject constructor(
 
     private fun loadTrips(carId: Int) {
         viewModelScope.launch {
-            val drives = driveSummaryDao.getAllChronological(carId)
-            val dcCharges = aggregateDao.getDcChargeSummaries(carId)
-            allTrips = tripDetector.detectTrips(drives, dcCharges).reversed()
+            allTrips = tripRepository.getTrips(carId)
 
             val years = allTrips.mapNotNull { parseYear(it.startDate) }
                 .distinct()

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -103,7 +103,7 @@ class DashboardViewModelTest {
     private fun createViewModel(): DashboardViewModel {
         return DashboardViewModel(
             repository, geocodingRepository, settingsDataStore, sentryStateRepository,
-            mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true)
+            mockk(relaxed = true), mockk(relaxed = true)
         )
     }
 


### PR DESCRIPTION
## Summary
- Foundation PR for the upcoming extend/merge/add-leg trip features. No visible changes for users.
- Adds 3 tables at DB v12: `saved_trips`, `saved_trip_legs` (ordered DRIVE/CHARGE references, cascade delete), `saved_trip_consumed_fingerprints` (suppresses auto-detector output already represented by a saved trip, cascade delete).
- New `TripRepository` becomes the single entry point for reading trips. On every read, it runs `TripDetector` and silently persists any newly detected trip as `source = AUTO_DETECTED`. Existing trips are skipped via fingerprint matching (SHA-256 of sorted drive IDs — same algorithm already used for route/country caches, so those remain valid).
- Extracts the Trip-building math from `TripDetector.emitTrip()` into a shared `TripAggregator.buildTrip()` so both the detector and the repository can construct `Trip` objects from a given set of legs.
- `TripsViewModel`, `TripDetailViewModel`, and `DashboardViewModel` all migrated from direct DAO + detector calls to `TripRepository.getTrips(carId)`.
- Cascade delete gives us implicit undo: deleting a merged/edited SavedTrip releases its consumed fingerprints, and the auto-detector re-emits the originals on next load. This is the semantic PR 2 will rely on for the confirmation-dialog flow.

## Test plan
- [ ] Build + lint pass (done locally)
- [ ] Install over the current release (v1.5.0 on DB v11) — migration runs cleanly, Trips screen shows the exact same list as before
- [ ] Open a trip detail — map, timeline, legs, countries all load identically
- [ ] Via `adb shell run-as com.matedroid.debug sqlite3 databases/matedroid_stats.db`:
  - `SELECT COUNT(*) FROM saved_trips;` matches visible trip count
  - `SELECT COUNT(*) FROM saved_trip_legs;` matches total legs across all trips
  - `SELECT COUNT(*) FROM saved_trip_consumed_fingerprints;` = 0 (no edits yet — populated by PR 2)
- [ ] Fresh install (clear app data) — trips rebuild from raw data, tables repopulate
- [ ] Dashboard trip count matches the Trips screen count

🤖 Generated with [Claude Code](https://claude.com/claude-code)