### PR TITLE
feat: add leg and merge trip actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Trip timeline**: Horizontal timeline bar on the trip detail screen, under the map, visualizing each drive, charge, and parking gap as a colored segment proportional to its duration. Drives use the car's accent color, charges use the established AC/DC palette (green/orange, harmonized with the car's theme), parking gaps use a muted neutral. Tap any segment to see its details; multi-day parking stretches are compressed with a sqrt curve so driving and charging stay readable.
+- **Edit trips**: Two new buttons below the trip legs — "Add leg" and "Merge trip". "Add leg" opens a bottom sheet listing drives and charges within ±2 days of the trip that aren't already in another saved trip. "Merge trip" opens a bottom sheet listing adjacent trips within ±14 days and, after confirmation, combines them into one trip — automatically rolling in all drives and charges (AC included) between them. Dashed line on the map connects legs that are geographically far apart (e.g., when the car was transported). Delete a trip via the top-bar overflow menu: the underlying auto-detected trips reappear automatically, which is the built-in way to undo a merge or edit.
 
 ### Changed
 - **Trip persistence**: Trips are now stored as first-class database entities. Auto-detected trips are silently persisted on first detection, unlocking the ability to edit and merge trips in a future update. No visible change for users.

--- a/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
@@ -23,6 +23,9 @@ interface ChargeSummaryDao {
     @Query("SELECT * FROM charges_summary WHERE carId = :carId ORDER BY startDate DESC")
     fun observeAll(carId: Int): Flow<List<ChargeSummary>>
 
+    @Query("SELECT * FROM charges_summary WHERE carId = :carId ORDER BY startDate ASC")
+    suspend fun getAllForCar(carId: Int): List<ChargeSummary>
+
     @Query("SELECT MAX(chargeId) FROM charges_summary WHERE carId = :carId")
     suspend fun getMaxChargeId(carId: Int): Int?
 

--- a/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
@@ -47,4 +47,30 @@ abstract class SavedTripDao {
 
     @Query("DELETE FROM saved_trips WHERE id = :tripId")
     abstract suspend fun deleteTrip(tripId: Long)
+
+    // === Edit/merge helpers (PR 2) ===
+
+    @Query("DELETE FROM saved_trip_legs WHERE tripId = :tripId")
+    abstract suspend fun deleteLegs(tripId: Long)
+
+    @Query("UPDATE saved_trips SET source = :source, updatedAt = :updatedAt WHERE id = :tripId")
+    abstract suspend fun updateSource(tripId: Long, source: String, updatedAt: Long)
+
+    @Query("SELECT fingerprint FROM saved_trip_consumed_fingerprints WHERE savedTripId = :tripId")
+    abstract suspend fun getConsumedFingerprints(tripId: Long): List<String>
+
+    /** Drive/charge IDs already referenced by any saved trip belonging to [carId]. */
+    @Query("""
+        SELECT DISTINCT legId FROM saved_trip_legs
+        WHERE legType = :legType
+          AND tripId IN (SELECT id FROM saved_trips WHERE carId = :carId)
+    """)
+    abstract suspend fun getUsedLegIds(carId: Int, legType: String): List<Int>
+
+    /** Atomically replace all legs of a trip. Used when adding legs (re-numbers positions). */
+    @Transaction
+    open suspend fun replaceLegs(tripId: Long, newLegs: List<SavedTripLeg>) {
+        deleteLegs(tripId)
+        if (newLegs.isNotEmpty()) insertLegs(newLegs)
+    }
 }

--- a/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/SavedTripDao.kt
@@ -56,6 +56,12 @@ abstract class SavedTripDao {
     @Query("UPDATE saved_trips SET source = :source, updatedAt = :updatedAt WHERE id = :tripId")
     abstract suspend fun updateSource(tripId: Long, source: String, updatedAt: Long)
 
+    @Query("SELECT name FROM saved_trips WHERE id = :tripId")
+    abstract suspend fun getName(tripId: Long): String?
+
+    @Query("UPDATE saved_trips SET name = :name, updatedAt = :updatedAt WHERE id = :tripId")
+    abstract suspend fun updateName(tripId: Long, name: String?, updatedAt: Long)
+
     @Query("SELECT fingerprint FROM saved_trip_consumed_fingerprints WHERE savedTripId = :tripId")
     abstract suspend fun getConsumedFingerprints(tripId: Long): List<String>
 

--- a/app/src/main/java/com/matedroid/domain/TripAggregator.kt
+++ b/app/src/main/java/com/matedroid/domain/TripAggregator.kt
@@ -21,8 +21,13 @@ object TripAggregator {
     /**
      * Build a Trip from chronologically-ordered legs.
      * Returns null if [drives] is empty (a Trip's start/end metadata comes from the first/last drive).
+     * [name] is carried through to [Trip.name] so saved trips' custom names reach the UI.
      */
-    fun buildTrip(drives: List<DriveSummary>, charges: List<ChargeSummary>): Trip? {
+    fun buildTrip(
+        drives: List<DriveSummary>,
+        charges: List<ChargeSummary>,
+        name: String? = null
+    ): Trip? {
         if (drives.isEmpty()) return null
 
         val totalDistance = drives.sumOf { it.distance }
@@ -57,7 +62,8 @@ object TripAggregator {
             startDate = drives.first().startDate,
             endDate = drives.last().endDate,
             startBatteryLevel = drives.first().startBatteryLevel,
-            endBatteryLevel = drives.last().endBatteryLevel
+            endBatteryLevel = drives.last().endBatteryLevel,
+            name = name
         )
     }
 

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -71,6 +71,15 @@ class TripRepository @Inject constructor(
         savedTripDao.deleteTrip(tripId)
     }
 
+    /** The user-chosen name for a trip, or null if the default (start → end) should be shown. */
+    suspend fun getTripName(tripId: Long): String? = savedTripDao.getName(tripId)
+
+    /** Set or clear a trip's custom name. Blank names are stored as null so the default is shown. */
+    suspend fun renameTrip(tripId: Long, name: String?) {
+        val normalized = name?.trim()?.takeIf { it.isNotEmpty() }
+        savedTripDao.updateName(tripId, normalized, System.currentTimeMillis())
+    }
+
     // === Edit/merge (PR 2) ===
 
     /**

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -365,6 +365,56 @@ class TripRepository @Inject constructor(
             .firstOrNull { computeFingerprint(it.driveIds()) == targetFp }
             ?.trip?.id
     }
+
+    /** The saved trip (if any) that currently includes the given drive/charge leg. */
+    suspend fun findTripContaining(carId: Int, legType: String, legId: Int): Pair<Long, Trip>? {
+        val all = savedTripDao.getAllWithLegs(carId)
+        val match = all.firstOrNull { swl ->
+            swl.legs.any { it.legType == legType && it.legId == legId }
+        } ?: return null
+
+        val drives = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+        val trip = TripAggregator.buildTrip(
+            tripDrivesIn(match, drives),
+            tripChargesIn(match, charges)
+        ) ?: return null
+        return match.trip.id to trip
+    }
+
+    /**
+     * Remove the given leg from the trip.
+     * - If the trip was AUTO_DETECTED, push its pre-edit fingerprint into the consumed set first.
+     * - If the last drive leg is removed (trip ends up with 0 drives), delete the whole saved trip
+     *   so the user doesn't end up with a ghost row that won't render.
+     */
+    suspend fun removeLegFromTrip(tripId: Long, ref: LegRef) {
+        val existing = savedTripDao.getWithLegs(tripId) ?: return
+
+        val remaining = existing.legs
+            .filterNot { it.legType == ref.type && it.legId == ref.id }
+            .sortedBy { it.position }
+            .mapIndexed { index, leg ->
+                SavedTripLeg(tripId = tripId, position = index, legType = leg.legType, legId = leg.legId)
+            }
+
+        val remainingDriveCount = remaining.count { it.legType == SavedTripLeg.TYPE_DRIVE }
+        if (remainingDriveCount == 0) {
+            savedTripDao.deleteTrip(tripId)
+            return
+        }
+
+        if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
+            val priorFingerprint = computeFingerprint(existing.driveIds())
+            savedTripDao.insertConsumedFingerprints(
+                listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
+            )
+            savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, System.currentTimeMillis())
+        } else {
+            savedTripDao.updateSource(tripId, existing.trip.source, System.currentTimeMillis())
+        }
+        savedTripDao.replaceLegs(tripId, remaining)
+    }
 }
 
 /** A reference to either a drive or a charge by id, used when editing or merging trips. */

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -1,15 +1,21 @@
 package com.matedroid.domain
 
 import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.local.dao.SavedTripDao
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.data.local.entity.SavedTrip
+import com.matedroid.data.local.entity.SavedTripConsumedFingerprint
 import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.local.entity.SavedTripWithLegs
 import com.matedroid.domain.model.Trip
 import java.security.MessageDigest
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +36,7 @@ import javax.inject.Singleton
 @Singleton
 class TripRepository @Inject constructor(
     private val driveSummaryDao: DriveSummaryDao,
+    private val chargeSummaryDao: ChargeSummaryDao,
     private val aggregateDao: AggregateDao,
     private val savedTripDao: SavedTripDao,
     private val tripDetector: TripDetector
@@ -39,11 +46,12 @@ class TripRepository @Inject constructor(
     suspend fun getTrips(carId: Int): List<Trip> {
         val drives = driveSummaryDao.getAllChronological(carId)
         val dcCharges = aggregateDao.getDcChargeSummaries(carId)
+        val allCharges = chargeSummaryDao.getAllForCar(carId)
 
         autoPersistNewTrips(carId, drives, dcCharges)
 
         val saved = savedTripDao.getAllWithLegs(carId)
-        return buildTripsFromSaved(saved, drives, dcCharges)
+        return buildTripsFromSaved(saved, drives, allCharges)
             .sortedByDescending { it.startDate }
     }
 
@@ -61,6 +69,223 @@ class TripRepository @Inject constructor(
     /** Delete a saved trip. Cascade removes its legs and consumed fingerprints, letting the detector re-emit the originals. */
     suspend fun deleteTrip(tripId: Long) {
         savedTripDao.deleteTrip(tripId)
+    }
+
+    // === Edit/merge (PR 2) ===
+
+    /**
+     * Extend [tripId] with [newLegs]. Drive/charge IDs already in the trip are ignored (dedup).
+     * Legs are re-sorted chronologically and positions renumbered 0..N-1.
+     * If the trip is currently AUTO_DETECTED, its original fingerprint is added to the consumed set
+     * (so the detector won't re-emit it) and the source transitions to USER_EDITED.
+     */
+    suspend fun extendTripWithLegs(tripId: Long, newLegs: List<LegRef>) {
+        if (newLegs.isEmpty()) return
+        val existing = savedTripDao.getWithLegs(tripId) ?: return
+        val carId = existing.trip.carId
+        val drives = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+
+        val combined = (existing.legs.map { LegRef(it.legType, it.legId) } + newLegs).distinct()
+        val sorted = combined.sortedBy { ref -> legStartDate(ref, drives, charges) ?: "" }
+        val legsToWrite = sorted.mapIndexed { index, ref ->
+            SavedTripLeg(tripId = tripId, position = index, legType = ref.type, legId = ref.id)
+        }
+
+        val now = System.currentTimeMillis()
+        if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
+            val priorFingerprint = computeFingerprint(existing.driveIds())
+            savedTripDao.insertConsumedFingerprints(
+                listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
+            )
+            savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, now)
+        } else {
+            savedTripDao.updateSource(tripId, existing.trip.source, now)
+        }
+        savedTripDao.replaceLegs(tripId, legsToWrite)
+    }
+
+    /**
+     * Merge [consumedTripId] into [keptTripId], creating a new USER_MERGED trip and deleting both originals.
+     * Auto-fills all drives and charges that occurred between the two trips' date ranges.
+     * Preserves the suppression set by inheriting both sources' fingerprints (current + previously consumed)
+     * into the new trip's consumed set.
+     */
+    suspend fun mergeTrips(keptTripId: Long, consumedTripId: Long, carId: Int): Long? {
+        val kept = savedTripDao.getWithLegs(keptTripId) ?: return null
+        val consumed = savedTripDao.getWithLegs(consumedTripId) ?: return null
+
+        val drives = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+
+        val keptRange = tripRange(kept, drives, charges) ?: return null
+        val consumedRange = tripRange(consumed, drives, charges) ?: return null
+        val gapStart = minOf(keptRange.second, consumedRange.second)
+        val gapEnd = maxOf(keptRange.first, consumedRange.first)
+
+        val usedDriveIds = (kept.legs + consumed.legs)
+            .filter { it.legType == SavedTripLeg.TYPE_DRIVE }
+            .map { it.legId }.toSet()
+        val usedChargeIds = (kept.legs + consumed.legs)
+            .filter { it.legType == SavedTripLeg.TYPE_CHARGE }
+            .map { it.legId }.toSet()
+
+        val gapDrives = drives.values.filter {
+            it.driveId !in usedDriveIds &&
+                compareDates(it.startDate, gapStart) >= 0 &&
+                compareDates(it.startDate, gapEnd) <= 0
+        }.map { LegRef(SavedTripLeg.TYPE_DRIVE, it.driveId) }
+
+        val gapCharges = charges.values.filter {
+            it.chargeId !in usedChargeIds &&
+                compareDates(it.startDate, gapStart) >= 0 &&
+                compareDates(it.startDate, gapEnd) <= 0
+        }.map { LegRef(SavedTripLeg.TYPE_CHARGE, it.chargeId) }
+
+        val allRefs = (
+            kept.legs.map { LegRef(it.legType, it.legId) } +
+                consumed.legs.map { LegRef(it.legType, it.legId) } +
+                gapDrives + gapCharges
+            ).distinct().sortedBy { ref -> legStartDate(ref, drives, charges) ?: "" }
+
+        val inheritedFingerprints = (
+            savedTripDao.getConsumedFingerprints(keptTripId) +
+                savedTripDao.getConsumedFingerprints(consumedTripId) +
+                computeFingerprint(kept.driveIds()) +
+                computeFingerprint(consumed.driveIds())
+            ).distinct()
+
+        val now = System.currentTimeMillis()
+        val newId = savedTripDao.insertTripWithLegs(
+            trip = SavedTrip(
+                carId = carId,
+                name = null,
+                source = SavedTrip.SOURCE_USER_MERGED,
+                createdAt = now,
+                updatedAt = now
+            ),
+            legs = { tripId ->
+                allRefs.mapIndexed { index, ref ->
+                    SavedTripLeg(tripId = tripId, position = index, legType = ref.type, legId = ref.id)
+                }
+            }
+        )
+        savedTripDao.insertConsumedFingerprints(
+            inheritedFingerprints.map { SavedTripConsumedFingerprint(savedTripId = newId, fingerprint = it) }
+        )
+        savedTripDao.deleteTrip(keptTripId)
+        savedTripDao.deleteTrip(consumedTripId)
+        return newId
+    }
+
+    /** Trips for [carId] whose date range is within [windowDays] of [tripId]'s range, excluding [tripId] itself. */
+    suspend fun getAdjacentTrips(tripId: Long, carId: Int, windowDays: Int = 14): List<Pair<Long, Trip>> {
+        val allSaved = savedTripDao.getAllWithLegs(carId)
+        val currentSwl = allSaved.find { it.trip.id == tripId } ?: return emptyList()
+        val drives = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+
+        val currentRange = tripRange(currentSwl, drives, charges) ?: return emptyList()
+        val candidates = mutableListOf<Pair<Long, Trip>>()
+        for (swl in allSaved) {
+            if (swl.trip.id == tripId) continue
+            val range = tripRange(swl, drives, charges) ?: continue
+            // Other trip starts after current ends, OR other trip ends before current starts
+            val afterGap = daysBetween(currentRange.second, range.first)
+            val beforeGap = daysBetween(range.second, currentRange.first)
+            val fitsAfter = afterGap != null && afterGap in 0..windowDays.toLong()
+            val fitsBefore = beforeGap != null && beforeGap in 0..windowDays.toLong()
+            if (!fitsAfter && !fitsBefore) continue
+            val trip = TripAggregator.buildTrip(
+                tripDrivesIn(swl, drives),
+                tripChargesIn(swl, charges)
+            ) ?: continue
+            candidates.add(swl.trip.id to trip)
+        }
+        return candidates.sortedBy { it.second.startDate }
+    }
+
+    /** Drives and charges near [tripId]'s time range, not already part of any saved trip on [carId]. */
+    suspend fun getEligibleNewLegs(tripId: Long, carId: Int, windowDays: Int = 2): EligibleLegs {
+        val swl = savedTripDao.getWithLegs(tripId) ?: return EligibleLegs(emptyList(), emptyList())
+        val allDrives = driveSummaryDao.getAllChronological(carId)
+        val allCharges = chargeSummaryDao.getAllForCar(carId)
+        val drivesById = allDrives.associateBy { it.driveId }
+        val chargesById = allCharges.associateBy { it.chargeId }
+
+        val range = tripRange(swl, drivesById, chargesById) ?: return EligibleLegs(emptyList(), emptyList())
+        val windowStart = shiftDate(range.first, -windowDays.toLong())
+        val windowEnd = shiftDate(range.second, windowDays.toLong())
+
+        val usedDriveIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_DRIVE).toSet()
+        val usedChargeIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_CHARGE).toSet()
+
+        val drives = allDrives.filter {
+            it.driveId !in usedDriveIds &&
+                compareDates(it.startDate, windowStart) >= 0 &&
+                compareDates(it.startDate, windowEnd) <= 0
+        }
+        val charges = allCharges.filter {
+            it.chargeId !in usedChargeIds &&
+                compareDates(it.startDate, windowStart) >= 0 &&
+                compareDates(it.startDate, windowEnd) <= 0
+        }
+        return EligibleLegs(drives, charges)
+    }
+
+    // === Helpers ===
+
+    private fun tripDrivesIn(swl: SavedTripWithLegs, drives: Map<Int, DriveSummary>): List<DriveSummary> =
+        swl.legs.filter { it.legType == SavedTripLeg.TYPE_DRIVE }.mapNotNull { drives[it.legId] }
+
+    private fun tripChargesIn(swl: SavedTripWithLegs, charges: Map<Int, ChargeSummary>): List<ChargeSummary> =
+        swl.legs.filter { it.legType == SavedTripLeg.TYPE_CHARGE }.mapNotNull { charges[it.legId] }
+
+    /** Returns (startDate, endDate) of a saved trip as ISO strings, derived from its legs. */
+    private fun tripRange(
+        swl: SavedTripWithLegs,
+        drives: Map<Int, DriveSummary>,
+        charges: Map<Int, ChargeSummary>
+    ): Pair<String, String>? {
+        val dates = mutableListOf<String>()
+        for (leg in swl.legs) {
+            when (leg.legType) {
+                SavedTripLeg.TYPE_DRIVE -> drives[leg.legId]?.let { dates += it.startDate; dates += it.endDate }
+                SavedTripLeg.TYPE_CHARGE -> charges[leg.legId]?.let { dates += it.startDate; dates += it.endDate }
+            }
+        }
+        val start = dates.minOrNull() ?: return null
+        val end = dates.maxOrNull() ?: return null
+        return start to end
+    }
+
+    private fun legStartDate(
+        ref: LegRef,
+        drives: Map<Int, DriveSummary>,
+        charges: Map<Int, ChargeSummary>
+    ): String? = when (ref.type) {
+        SavedTripLeg.TYPE_DRIVE -> drives[ref.id]?.startDate
+        SavedTripLeg.TYPE_CHARGE -> charges[ref.id]?.startDate
+        else -> null
+    }
+
+    private fun compareDates(a: String, b: String): Int = a.compareTo(b)
+
+    private fun parseDate(s: String): LocalDateTime? = try {
+        OffsetDateTime.parse(s).toLocalDateTime()
+    } catch (e: DateTimeParseException) {
+        try { LocalDateTime.parse(s.replace("Z", "")) } catch (e2: Exception) { null }
+    }
+
+    private fun daysBetween(a: String, b: String): Long? {
+        val pa = parseDate(a) ?: return null
+        val pb = parseDate(b) ?: return null
+        return ChronoUnit.DAYS.between(pa, pb)
+    }
+
+    private fun shiftDate(s: String, days: Long): String {
+        val parsed = parseDate(s) ?: return s
+        return parsed.plusDays(days).toString()
     }
 
     private suspend fun autoPersistNewTrips(
@@ -109,20 +334,14 @@ class TripRepository @Inject constructor(
         }
     }
 
-    /**
-     * Resolve saved trip legs back into a Trip domain object.
-     *
-     * PR 1 scope: all saved trips are AUTO_DETECTED, so every charge leg is a DC charge
-     * and resolves via [dcCharges]. When PR 2 introduces AC charges in user-edited trips,
-     * this will need to consult the full charges_summary table.
-     */
+    /** Resolve saved trip legs back into a Trip domain object, using the full charge set so AC legs resolve too. */
     private fun buildTripsFromSaved(
         saved: List<SavedTripWithLegs>,
         drives: List<DriveSummary>,
-        dcCharges: List<ChargeSummary>
+        allCharges: List<ChargeSummary>
     ): List<Trip> {
         val drivesById = drives.associateBy { it.driveId }
-        val chargesById = dcCharges.associateBy { it.chargeId }
+        val chargesById = allCharges.associateBy { it.chargeId }
 
         return saved.mapNotNull { swl ->
             val orderedLegs = swl.legs.sortedBy { it.position }
@@ -138,4 +357,21 @@ class TripRepository @Inject constructor(
 
     private fun SavedTripWithLegs.driveIds(): List<Int> =
         legs.filter { it.legType == SavedTripLeg.TYPE_DRIVE }.map { it.legId }
+
+    /** Look up the saved-trip id that matches this trip's current drive set. */
+    suspend fun findSavedTripId(carId: Int, trip: Trip): Long? {
+        val targetFp = computeFingerprint(trip)
+        return savedTripDao.getAllWithLegs(carId)
+            .firstOrNull { computeFingerprint(it.driveIds()) == targetFp }
+            ?.trip?.id
+    }
 }
+
+/** A reference to either a drive or a charge by id, used when editing or merging trips. */
+data class LegRef(val type: String, val id: Int)
+
+/** Result of [TripRepository.getEligibleNewLegs]. */
+data class EligibleLegs(
+    val drives: List<com.matedroid.data.local.entity.DriveSummary>,
+    val charges: List<com.matedroid.data.local.entity.ChargeSummary>
+)

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -165,10 +165,13 @@ class TripRepository @Inject constructor(
             ).distinct()
 
         val now = System.currentTimeMillis()
+        // Inherit the kept trip's custom name; fall back to the consumed trip's name if only the
+        // consumed one had been renamed. Either way, user-chosen names don't disappear at merge.
+        val inheritedName = kept.trip.name ?: consumed.trip.name
         val newId = savedTripDao.insertTripWithLegs(
             trip = SavedTrip(
                 carId = carId,
-                name = null,
+                name = inheritedName,
                 source = SavedTrip.SOURCE_USER_MERGED,
                 createdAt = now,
                 updatedAt = now
@@ -360,7 +363,7 @@ class TripRepository @Inject constructor(
             val tripCharges = orderedLegs
                 .filter { it.legType == SavedTripLeg.TYPE_CHARGE }
                 .mapNotNull { chargesById[it.legId] }
-            TripAggregator.buildTrip(tripDrives, tripCharges)
+            TripAggregator.buildTrip(tripDrives, tripCharges, name = swl.trip.name)
         }
     }
 

--- a/app/src/main/java/com/matedroid/domain/model/Trip.kt
+++ b/app/src/main/java/com/matedroid/domain/model/Trip.kt
@@ -23,5 +23,7 @@ data class Trip(
     val startDate: String,
     val endDate: String,
     val startBatteryLevel: Int,
-    val endBatteryLevel: Int
+    val endBatteryLevel: Int,
+    /** User-chosen name. Null means fall back to the default "startCity → endCity" label. */
+    val name: String? = null
 )

--- a/app/src/main/java/com/matedroid/ui/components/PartOfTripCard.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PartOfTripCard.kt
@@ -1,0 +1,137 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.ui.theme.StatusError
+
+/**
+ * Inline card shown on drive/charge detail screens when the entity belongs to a saved trip.
+ * Left half: tappable label + chevron, navigates to the trip detail.
+ * Right half: Remove button with its own confirmation dialog — detaches the leg from the trip.
+ */
+@Composable
+fun PartOfTripCard(
+    tripRoute: String,
+    onNavigateToTrip: () -> Unit,
+    onConfirmRemove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var showConfirm by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Card(
+            modifier = Modifier
+                .weight(1f)
+                .clickable(onClick = onNavigateToTrip),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            )
+        ) {
+            Row(
+                modifier = Modifier.padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Filled.Route,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Spacer(Modifier.width(10.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.part_of_trip, tripRoute),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        }
+
+        OutlinedButton(
+            onClick = { showConfirm = true }
+        ) {
+            Icon(
+                Icons.Filled.DeleteOutline,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(stringResource(R.string.part_of_trip_remove))
+        }
+    }
+
+    if (showConfirm) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.DeleteOutline,
+                    contentDescription = null,
+                    tint = StatusError,
+                    modifier = Modifier.size(32.dp)
+                )
+            },
+            title = { Text(stringResource(R.string.part_of_trip_remove_confirm_title)) },
+            text = { Text(stringResource(R.string.part_of_trip_remove_confirm_body, tripRoute)) },
+            confirmButton = {
+                Button(onClick = {
+                    showConfirm = false
+                    onConfirmRemove()
+                }) {
+                    Text(stringResource(R.string.part_of_trip_remove))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirm = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/TripEditActions.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripEditActions.kt
@@ -1,0 +1,49 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Merge
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+
+/** Row of two 50/50 outlined buttons: Add leg + Merge trip. Shown below the legs list. */
+@Composable
+fun TripEditActions(
+    onAddLeg: () -> Unit,
+    onMergeTrip: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        OutlinedButton(
+            onClick = onAddLeg,
+            modifier = Modifier.weight(1f)
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.trip_edit_add_leg))
+        }
+        OutlinedButton(
+            onClick = onMergeTrip,
+            modifier = Modifier.weight(1f)
+        ) {
+            Icon(Icons.Filled.Merge, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.trip_edit_merge_trip))
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -589,13 +589,21 @@ private fun Minimap(
             }
     ) {
         val minimapWidthPx = with(density) { maxWidth.toPx() }
-        val widthFrac by derivedStateOf {
-            if (totalDetailPx <= 0f) 1f
-            else (viewportPx / totalDetailPx).coerceIn(0.05f, 1f)
+        val widthFrac by remember(totalDetailPx, viewportPx) {
+            derivedStateOf {
+                if (totalDetailPx <= 0f) 1f
+                else (viewportPx / totalDetailPx).coerceIn(0.05f, 1f)
+            }
         }
-        val offsetFrac by derivedStateOf {
-            if (totalDetailPx <= 0f) 0f
-            else (scrollState.value / totalDetailPx).coerceIn(0f, 1f - widthFrac)
+        val offsetFrac by remember(totalDetailPx, viewportPx) {
+            derivedStateOf {
+                if (totalDetailPx <= 0f) 0f
+                else {
+                    val wFrac = if (totalDetailPx <= 0f) 1f
+                    else (viewportPx / totalDetailPx).coerceIn(0.05f, 1f)
+                    (scrollState.value / totalDetailPx).coerceIn(0f, 1f - wFrac)
+                }
+            }
         }
 
         // The compressed bar — vertically centered

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -564,10 +565,28 @@ private fun Minimap(
     val density = LocalDensity.current
 
     // Bar is 6dp tall; indicator is 2.5× that (15dp) centered vertically so it stands out
-    // above and below the bar. Outer container grows to accommodate the indicator.
+    // above and below the bar. Outer container grows to accommodate the indicator and captures
+    // taps + horizontal drags anywhere on the strip — both jump/slide the detail bar.
     BoxWithConstraints(
-        modifier = Modifier.fillMaxWidth().height(18.dp),
-        contentAlignment = Alignment.Center
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(18.dp)
+            .pointerInput(segments, totalDetailPx) {
+                detectTapGestures { offset ->
+                    val ratio = (offset.x / size.width).coerceIn(0f, 1f)
+                    val target = (ratio * totalDetailPx - viewportPx / 2f).toInt()
+                        .coerceAtLeast(0)
+                    coroutineScope.launch { scrollState.scrollTo(target) }
+                }
+            }
+            .pointerInput(totalDetailPx) {
+                detectHorizontalDragGestures { change, dragAmount ->
+                    change.consume()
+                    val minimapW = size.width.toFloat()
+                    if (minimapW <= 0f) return@detectHorizontalDragGestures
+                    scrollState.dispatchRawDelta(dragAmount * (totalDetailPx / minimapW))
+                }
+            }
     ) {
         val minimapWidthPx = with(density) { maxWidth.toPx() }
         val widthFrac by derivedStateOf {
@@ -579,20 +598,13 @@ private fun Minimap(
             else (scrollState.value / totalDetailPx).coerceIn(0f, 1f - widthFrac)
         }
 
-        // The compressed bar
+        // The compressed bar — vertically centered
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(6.dp)
+                .align(Alignment.Center)
                 .clip(RoundedCornerShape(3.dp))
-                .pointerInput(segments, totalDetailPx) {
-                    detectTapGestures { offset ->
-                        val ratio = (offset.x / size.width).coerceIn(0f, 1f)
-                        val target = (ratio * totalDetailPx - viewportPx / 2f).toInt()
-                            .coerceAtLeast(0)
-                        coroutineScope.launch { scrollState.scrollTo(target) }
-                    }
-                }
         ) {
             Canvas(modifier = Modifier.fillMaxSize()) {
                 var x = 0f
@@ -608,16 +620,17 @@ private fun Minimap(
             }
         }
 
-        // Viewport indicator — a filled translucent rectangle in the car's accent color,
-        // 2.5× the bar height so it visibly extends above and below the compressed bar.
+        // Viewport indicator — filled translucent rectangle in the car's accent color,
+        // 15dp tall (2.5× the bar). CenterStart alignment anchors the indicator's left edge
+        // to the container's left edge so `.offset` shifts it honestly from x=0.
         Box(
             modifier = Modifier
+                .align(Alignment.CenterStart)
                 .offset { IntOffset((offsetFrac * minimapWidthPx).toInt(), 0) }
                 .width(with(density) { (widthFrac * minimapWidthPx).toDp() })
                 .height(15.dp)
                 .clip(RoundedCornerShape(4.dp))
                 .background(palette.accent.copy(alpha = 0.55f))
-                .align(Alignment.Center)
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -563,7 +563,12 @@ private fun Minimap(
     val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current
 
-    BoxWithConstraints(modifier = Modifier.fillMaxWidth().height(14.dp)) {
+    // Bar is 6dp tall; indicator is 2.5× that (15dp) centered vertically so it stands out
+    // above and below the bar. Outer container grows to accommodate the indicator.
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxWidth().height(18.dp),
+        contentAlignment = Alignment.Center
+    ) {
         val minimapWidthPx = with(density) { maxWidth.toPx() }
         val widthFrac by derivedStateOf {
             if (totalDetailPx <= 0f) 1f
@@ -579,7 +584,6 @@ private fun Minimap(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(6.dp)
-                .align(Alignment.Center)
                 .clip(RoundedCornerShape(3.dp))
                 .pointerInput(segments, totalDetailPx) {
                     detectTapGestures { offset ->
@@ -604,15 +608,16 @@ private fun Minimap(
             }
         }
 
-        // Viewport indicator — a filled translucent rectangle overlaid on the minimap,
-        // so the segment colors still read through but the current slice pops out clearly.
+        // Viewport indicator — a filled translucent rectangle in the car's accent color,
+        // 2.5× the bar height so it visibly extends above and below the compressed bar.
         Box(
             modifier = Modifier
                 .offset { IntOffset((offsetFrac * minimapWidthPx).toInt(), 0) }
                 .width(with(density) { (widthFrac * minimapWidthPx).toDp() })
-                .fillMaxHeight()
+                .height(15.dp)
                 .clip(RoundedCornerShape(4.dp))
-                .background(Color.White.copy(alpha = 0.4f))
+                .background(palette.accent.copy(alpha = 0.55f))
+                .align(Alignment.Center)
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -2,13 +2,18 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
@@ -25,9 +31,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,8 +48,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 import com.matedroid.R
 import com.matedroid.ui.theme.CarColorPalette
 import java.time.LocalDateTime
@@ -401,8 +411,76 @@ private fun Endpoint(
     }
 }
 
+/** Minimum width per segment in the scrollable detail bar. */
+private val DETAIL_MIN_SEGMENT_DP = 28.dp
+
+/** Dp per minute of (compressed) weight when sizing the detail bar. Higher = wider. */
+private const val DETAIL_WEIGHT_TO_DP = 0.5f
+
 @Composable
 private fun TimelineBar(
+    segments: List<TripTimelineSegment>,
+    palette: CarColorPalette,
+    parkingColor: Color,
+    selectedIndex: Int?,
+    onSegmentTap: (Int) -> Unit
+) {
+    val density = LocalDensity.current
+
+    // Pixel widths each segment would occupy in the detail bar (not yet laid out).
+    val detailWidthsPx = remember(segments, density.density) {
+        val minPx = with(density) { DETAIL_MIN_SEGMENT_DP.toPx() }
+        val pxPerWeight = DETAIL_WEIGHT_TO_DP * density.density
+        segments.map { seg ->
+            val w = segmentWeight(seg)
+            max(w * pxPerWeight, minPx)
+        }
+    }
+    val totalDetailPx = detailWidthsPx.sum()
+
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val viewportPx = with(density) { maxWidth.toPx() }
+        // Overflow only when the detail bar genuinely won't fit. Short trips fall through to the
+        // single-bar rendering and look identical to the previous version.
+        val overflows = totalDetailPx > viewportPx + 1f
+
+        if (!overflows) {
+            SingleBar(
+                segments = segments,
+                palette = palette,
+                parkingColor = parkingColor,
+                selectedIndex = selectedIndex,
+                onSegmentTap = onSegmentTap
+            )
+        } else {
+            val scrollState = rememberScrollState()
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Minimap(
+                    segments = segments,
+                    palette = palette,
+                    parkingColor = parkingColor,
+                    totalDetailPx = totalDetailPx,
+                    viewportPx = viewportPx,
+                    scrollState = scrollState
+                )
+                Spacer(Modifier.height(8.dp))
+                ScrollableDetailBar(
+                    segments = segments,
+                    widthsPx = detailWidthsPx,
+                    palette = palette,
+                    parkingColor = parkingColor,
+                    selectedIndex = selectedIndex,
+                    onSegmentTap = onSegmentTap,
+                    scrollState = scrollState
+                )
+            }
+        }
+    }
+}
+
+/** Single horizontal bar filling the viewport — unchanged behaviour for short trips. */
+@Composable
+private fun SingleBar(
     segments: List<TripTimelineSegment>,
     palette: CarColorPalette,
     parkingColor: Color,
@@ -413,7 +491,6 @@ private fun TimelineBar(
     val barHeightPx = with(density) { 16.dp.toPx() }
     val selectedExtraPx = with(density) { 4.dp.toPx() }
     val gapPx = with(density) { 1.dp.toPx() }
-    val cornerRadiusPx = with(density) { 8.dp.toPx() }
 
     val ratios = remember(segments) { computeSegmentRatios(segments) }
 
@@ -453,12 +530,7 @@ private fun TimelineBar(
                     val isLast = idx == ratios.lastIndex
                     val drawWidth = if (isLast) segWidth else (segWidth - gapPx).coerceAtLeast(0f)
                     val seg = segments[idx]
-                    val color: Color = when (seg) {
-                        is TripTimelineSegment.Drive -> palette.accent
-                        is TripTimelineSegment.Charge ->
-                            if (seg.isDc) palette.dcColor else palette.acColor
-                        is TripTimelineSegment.Parking -> parkingColor
-                    }
+                    val color = colorForSegment(seg, palette, parkingColor)
                     val isSelected = idx == selectedIndex
                     val thisBarHeight = if (isSelected) barHeightPx + selectedExtraPx else barHeightPx
                     val y = (size.height - thisBarHeight) / 2f
@@ -469,26 +541,167 @@ private fun TimelineBar(
                     )
                     x += segWidth
                 }
-                // Redraw the rounded clip edges by overlaying small corner triangles? Not needed,
-                // the parent Box already clips to RoundedCornerShape. Ignore cornerRadiusPx.
-                @Suppress("UNUSED_EXPRESSION") cornerRadiusPx
             }
         }
     }
 }
 
+/**
+ * Compressed non-interactive overview of the full trip. The viewport rectangle tracks the
+ * scroll position of the paired [ScrollableDetailBar]. Tap anywhere to jump the detail bar.
+ */
+@Composable
+private fun Minimap(
+    segments: List<TripTimelineSegment>,
+    palette: CarColorPalette,
+    parkingColor: Color,
+    totalDetailPx: Float,
+    viewportPx: Float,
+    scrollState: androidx.compose.foundation.ScrollState
+) {
+    val ratios = remember(segments) { computeSegmentRatios(segments) }
+    val coroutineScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth().height(14.dp)) {
+        val minimapWidthPx = with(density) { maxWidth.toPx() }
+        val widthFrac by derivedStateOf {
+            if (totalDetailPx <= 0f) 1f
+            else (viewportPx / totalDetailPx).coerceIn(0.05f, 1f)
+        }
+        val offsetFrac by derivedStateOf {
+            if (totalDetailPx <= 0f) 0f
+            else (scrollState.value / totalDetailPx).coerceIn(0f, 1f - widthFrac)
+        }
+
+        // The compressed bar
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .align(Alignment.Center)
+                .clip(RoundedCornerShape(3.dp))
+                .pointerInput(segments, totalDetailPx) {
+                    detectTapGestures { offset ->
+                        val ratio = (offset.x / size.width).coerceIn(0f, 1f)
+                        val target = (ratio * totalDetailPx - viewportPx / 2f).toInt()
+                            .coerceAtLeast(0)
+                        coroutineScope.launch { scrollState.scrollTo(target) }
+                    }
+                }
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                var x = 0f
+                ratios.forEachIndexed { idx, ratio ->
+                    val w = ratio * size.width
+                    drawRect(
+                        color = colorForSegment(segments[idx], palette, parkingColor),
+                        topLeft = Offset(x, 0f),
+                        size = Size(w, size.height)
+                    )
+                    x += w
+                }
+            }
+        }
+
+        // Viewport indicator — an outlined rectangle overlaid on the minimap
+        Box(
+            modifier = Modifier
+                .offset { IntOffset((offsetFrac * minimapWidthPx).toInt(), 0) }
+                .width(with(density) { (widthFrac * minimapWidthPx).toDp() })
+                .fillMaxHeight()
+                .border(
+                    width = 2.dp,
+                    color = Color.White.copy(alpha = 0.85f),
+                    shape = RoundedCornerShape(4.dp)
+                )
+        )
+    }
+}
+
+@Composable
+private fun ScrollableDetailBar(
+    segments: List<TripTimelineSegment>,
+    widthsPx: List<Float>,
+    palette: CarColorPalette,
+    parkingColor: Color,
+    selectedIndex: Int?,
+    onSegmentTap: (Int) -> Unit,
+    scrollState: androidx.compose.foundation.ScrollState
+) {
+    val density = LocalDensity.current
+    val barHeightPx = with(density) { 20.dp.toPx() }
+    val selectedExtraPx = with(density) { 6.dp.toPx() }
+    val gapPx = with(density) { 1.dp.toPx() }
+    val totalDp = with(density) { widthsPx.sum().toDp() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .horizontalScroll(scrollState),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Canvas(
+            modifier = Modifier
+                .width(totalDp)
+                .height(44.dp)
+                .pointerInput(segments, widthsPx) {
+                    detectTapGestures { offset ->
+                        var accum = 0f
+                        for ((idx, w) in widthsPx.withIndex()) {
+                            if (offset.x <= accum + w) {
+                                onSegmentTap(idx)
+                                return@detectTapGestures
+                            }
+                            accum += w
+                        }
+                        onSegmentTap(widthsPx.lastIndex)
+                    }
+                }
+        ) {
+            var x = 0f
+            widthsPx.forEachIndexed { idx, w ->
+                val isLast = idx == widthsPx.lastIndex
+                val drawW = if (isLast) w else (w - gapPx).coerceAtLeast(0f)
+                val color = colorForSegment(segments[idx], palette, parkingColor)
+                val isSelected = idx == selectedIndex
+                val h = if (isSelected) barHeightPx + selectedExtraPx else barHeightPx
+                val y = (size.height - h) / 2f
+                drawRect(
+                    color = color,
+                    topLeft = Offset(x, y),
+                    size = Size(drawW, h)
+                )
+                x += w
+            }
+        }
+    }
+}
+
+private fun colorForSegment(
+    seg: TripTimelineSegment,
+    palette: CarColorPalette,
+    parkingColor: Color
+): Color = when (seg) {
+    is TripTimelineSegment.Drive -> palette.accent
+    is TripTimelineSegment.Charge -> if (seg.isDc) palette.dcColor else palette.acColor
+    is TripTimelineSegment.Parking -> parkingColor
+}
+
+/** Visual weight for one segment — drives and DC charges are honest, AC and parking are sqrt-compressed. */
+private fun segmentWeight(seg: TripTimelineSegment): Float = when (seg) {
+    is TripTimelineSegment.Parking -> compressIdle(seg.durationMin)
+    is TripTimelineSegment.Charge ->
+        if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
+        else compressIdle(seg.durationMin)
+    is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
+}
+
 /** Compute visual width ratios for each segment, with shared compression on idle segments. */
 private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
     if (segments.isEmpty()) return emptyList()
-    val weights = segments.map { seg ->
-        when (seg) {
-            is TripTimelineSegment.Parking -> compressIdle(seg.durationMin)
-            is TripTimelineSegment.Charge ->
-                if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
-                else compressIdle(seg.durationMin)
-            is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
-        }
-    }
+    val weights = segments.map { segmentWeight(it) }
     val total = weights.sum().coerceAtLeast(1f)
     val raw = weights.map { it / total }
     // Lift to minimum and renormalize (cap min so n * min <= 1)

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -80,18 +80,13 @@ data class TripTimelineCountry(
 )
 
 /**
- * Parking gaps stay linear up to 2h, then sqrt-compressed. Keeps short coffee stops honest
- * while preventing multi-day parking from dominating the bar.
+ * "Idle" segments (parking gaps and AC charges) share the same compression curve:
+ * linear up to 30 min, sqrt-compressed beyond, scaled 0.5× so multi-hour/day stretches
+ * stay visible without crushing the drives. DC sessions are left linear since they're
+ * naturally bounded (~1h) and their duration is useful signal.
  */
-private const val PARKING_LINEAR_THRESHOLD_MIN = 120f
-
-/**
- * AC charges compress earlier and harder than parking: plug-and-go sessions stay linear only
- * up to 30 min, and the compression factor is 0.3× so an 8h overnight charge is roughly twice
- * the width of a 30-min drive rather than ten times.
- */
-private const val AC_LINEAR_THRESHOLD_MIN = 30f
-private const val AC_COMPRESSION_SCALE = 0.3f
+private const val IDLE_LINEAR_THRESHOLD_MIN = 30f
+private const val IDLE_COMPRESSION_SCALE = 0.5f
 
 private const val MIN_SEGMENT_RATIO = 0.02f
 
@@ -482,18 +477,15 @@ private fun TimelineBar(
     }
 }
 
-/** Compute visual width ratios for each segment, with per-type compression on long segments. */
+/** Compute visual width ratios for each segment, with shared compression on idle segments. */
 private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
     if (segments.isEmpty()) return emptyList()
     val weights = segments.map { seg ->
         when (seg) {
-            is TripTimelineSegment.Parking -> compressParking(seg.durationMin)
+            is TripTimelineSegment.Parking -> compressIdle(seg.durationMin)
             is TripTimelineSegment.Charge ->
-                // DC sessions are bounded (~1h) so their relative duration is honest — linear.
-                // AC can run for hours (overnight, hotel) and needs harder compression than parking,
-                // otherwise an 8h charge overwhelms the bar.
                 if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
-                else compressAcCharge(seg.durationMin)
+                else compressIdle(seg.durationMin)
             is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
         }
     }
@@ -506,20 +498,12 @@ private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Floa
     return lifted.map { it / liftedSum }
 }
 
-/** Linear up to 2h, sqrt-compressed beyond. Keeps multi-day parking visible but not dominant. */
-private fun compressParking(durationMin: Int): Float {
+/** Linear up to 30min, then sqrt-compressed and scaled down. Used for both parking gaps and AC charges. */
+private fun compressIdle(durationMin: Int): Float {
     val d = durationMin.toFloat().coerceAtLeast(1f)
-    return if (d <= PARKING_LINEAR_THRESHOLD_MIN) d
-    else PARKING_LINEAR_THRESHOLD_MIN +
-            sqrt((d - PARKING_LINEAR_THRESHOLD_MIN) * PARKING_LINEAR_THRESHOLD_MIN)
-}
-
-/** Linear up to 30min, harsher sqrt compression beyond — overnight AC collapses to ~2× a short drive. */
-private fun compressAcCharge(durationMin: Int): Float {
-    val d = durationMin.toFloat().coerceAtLeast(1f)
-    return if (d <= AC_LINEAR_THRESHOLD_MIN) d
-    else AC_LINEAR_THRESHOLD_MIN +
-            sqrt((d - AC_LINEAR_THRESHOLD_MIN) * AC_LINEAR_THRESHOLD_MIN) * AC_COMPRESSION_SCALE
+    return if (d <= IDLE_LINEAR_THRESHOLD_MIN) d
+    else IDLE_LINEAR_THRESHOLD_MIN +
+            sqrt((d - IDLE_LINEAR_THRESHOLD_MIN) * IDLE_LINEAR_THRESHOLD_MIN) * IDLE_COMPRESSION_SCALE
 }
 
 private fun formatTimelineDuration(minutes: Int): String {

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -80,11 +80,19 @@ data class TripTimelineCountry(
 )
 
 /**
- * Duration threshold (minutes) above which "long idle" segments get sqrt-compressed.
- * Applies to parking gaps and AC charges, both of which can stretch for many hours/days
- * (overnight AC, multi-day parking) and would otherwise crush the drives into slivers.
+ * Parking gaps stay linear up to 2h, then sqrt-compressed. Keeps short coffee stops honest
+ * while preventing multi-day parking from dominating the bar.
  */
-private const val LONG_IDLE_THRESHOLD_MIN = 120f
+private const val PARKING_LINEAR_THRESHOLD_MIN = 120f
+
+/**
+ * AC charges compress earlier and harder than parking: plug-and-go sessions stay linear only
+ * up to 30 min, and the compression factor is 0.3× so an 8h overnight charge is roughly twice
+ * the width of a 30-min drive rather than ten times.
+ */
+private const val AC_LINEAR_THRESHOLD_MIN = 30f
+private const val AC_COMPRESSION_SCALE = 0.3f
+
 private const val MIN_SEGMENT_RATIO = 0.02f
 
 /**
@@ -474,18 +482,18 @@ private fun TimelineBar(
     }
 }
 
-/** Compute visual width ratios for each segment, with sqrt-compression on long idle segments. */
+/** Compute visual width ratios for each segment, with per-type compression on long segments. */
 private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
     if (segments.isEmpty()) return emptyList()
     val weights = segments.map { seg ->
         when (seg) {
-            is TripTimelineSegment.Parking -> compressLongIdle(seg.durationMin)
+            is TripTimelineSegment.Parking -> compressParking(seg.durationMin)
             is TripTimelineSegment.Charge ->
-                // AC charges are "idle-like" (hotel overnight, restaurant stop) and can stretch for
-                // hours, so they get the same treatment as parking. DC sessions are bounded (~1h)
-                // and stay linear so their relative duration is honest.
+                // DC sessions are bounded (~1h) so their relative duration is honest — linear.
+                // AC can run for hours (overnight, hotel) and needs harder compression than parking,
+                // otherwise an 8h charge overwhelms the bar.
                 if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
-                else compressLongIdle(seg.durationMin)
+                else compressAcCharge(seg.durationMin)
             is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
         }
     }
@@ -498,12 +506,20 @@ private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Floa
     return lifted.map { it / liftedSum }
 }
 
-/** Linear up to the threshold, sqrt-compressed beyond — keeps long stretches visible without dominating. */
-private fun compressLongIdle(durationMin: Int): Float {
+/** Linear up to 2h, sqrt-compressed beyond. Keeps multi-day parking visible but not dominant. */
+private fun compressParking(durationMin: Int): Float {
     val d = durationMin.toFloat().coerceAtLeast(1f)
-    return if (d <= LONG_IDLE_THRESHOLD_MIN) d
-    else LONG_IDLE_THRESHOLD_MIN +
-            sqrt((d - LONG_IDLE_THRESHOLD_MIN) * LONG_IDLE_THRESHOLD_MIN)
+    return if (d <= PARKING_LINEAR_THRESHOLD_MIN) d
+    else PARKING_LINEAR_THRESHOLD_MIN +
+            sqrt((d - PARKING_LINEAR_THRESHOLD_MIN) * PARKING_LINEAR_THRESHOLD_MIN)
+}
+
+/** Linear up to 30min, harsher sqrt compression beyond — overnight AC collapses to ~2× a short drive. */
+private fun compressAcCharge(durationMin: Int): Float {
+    val d = durationMin.toFloat().coerceAtLeast(1f)
+    return if (d <= AC_LINEAR_THRESHOLD_MIN) d
+    else AC_LINEAR_THRESHOLD_MIN +
+            sqrt((d - AC_LINEAR_THRESHOLD_MIN) * AC_LINEAR_THRESHOLD_MIN) * AC_COMPRESSION_SCALE
 }
 
 private fun formatTimelineDuration(minutes: Int): String {

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -79,7 +79,12 @@ data class TripTimelineCountry(
     val flagEmoji: String
 )
 
-private const val PARKING_LINEAR_THRESHOLD_MIN = 120f
+/**
+ * Duration threshold (minutes) above which "long idle" segments get sqrt-compressed.
+ * Applies to parking gaps and AC charges, both of which can stretch for many hours/days
+ * (overnight AC, multi-day parking) and would otherwise crush the drives into slivers.
+ */
+private const val LONG_IDLE_THRESHOLD_MIN = 120f
 private const val MIN_SEGMENT_RATIO = 0.02f
 
 /**
@@ -469,13 +474,19 @@ private fun TimelineBar(
     }
 }
 
-/** Compute visual width ratios for each segment, with parking sqrt-compression and a minimum visual width. */
+/** Compute visual width ratios for each segment, with sqrt-compression on long idle segments. */
 private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
     if (segments.isEmpty()) return emptyList()
     val weights = segments.map { seg ->
         when (seg) {
-            is TripTimelineSegment.Parking -> compressParkingWeight(seg.durationMin)
-            else -> seg.durationMin.toFloat().coerceAtLeast(1f)
+            is TripTimelineSegment.Parking -> compressLongIdle(seg.durationMin)
+            is TripTimelineSegment.Charge ->
+                // AC charges are "idle-like" (hotel overnight, restaurant stop) and can stretch for
+                // hours, so they get the same treatment as parking. DC sessions are bounded (~1h)
+                // and stay linear so their relative duration is honest.
+                if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
+                else compressLongIdle(seg.durationMin)
+            is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
         }
     }
     val total = weights.sum().coerceAtLeast(1f)
@@ -487,11 +498,12 @@ private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Floa
     return lifted.map { it / liftedSum }
 }
 
-private fun compressParkingWeight(durationMin: Int): Float {
+/** Linear up to the threshold, sqrt-compressed beyond — keeps long stretches visible without dominating. */
+private fun compressLongIdle(durationMin: Int): Float {
     val d = durationMin.toFloat().coerceAtLeast(1f)
-    return if (d <= PARKING_LINEAR_THRESHOLD_MIN) d
-    else PARKING_LINEAR_THRESHOLD_MIN +
-            sqrt((d - PARKING_LINEAR_THRESHOLD_MIN) * PARKING_LINEAR_THRESHOLD_MIN)
+    return if (d <= LONG_IDLE_THRESHOLD_MIN) d
+    else LONG_IDLE_THRESHOLD_MIN +
+            sqrt((d - LONG_IDLE_THRESHOLD_MIN) * LONG_IDLE_THRESHOLD_MIN)
 }
 
 private fun formatTimelineDuration(minutes: Int): String {

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -604,17 +604,15 @@ private fun Minimap(
             }
         }
 
-        // Viewport indicator — an outlined rectangle overlaid on the minimap
+        // Viewport indicator — a filled translucent rectangle overlaid on the minimap,
+        // so the segment colors still read through but the current slice pops out clearly.
         Box(
             modifier = Modifier
                 .offset { IntOffset((offsetFrac * minimapWidthPx).toInt(), 0) }
                 .width(with(density) { (widthFrac * minimapWidthPx).toDp() })
                 .fillMaxHeight()
-                .border(
-                    width = 2.dp,
-                    color = Color.White.copy(alpha = 0.85f),
-                    shape = RoundedCornerShape(4.dp)
-                )
+                .clip(RoundedCornerShape(4.dp))
+                .background(Color.White.copy(alpha = 0.4f))
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -357,7 +357,10 @@ fun NavGraph(
                 carId = carId,
                 chargeId = chargeId,
                 exteriorColor = exteriorColor,
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToTripDetail = { tripStartDate ->
+                    navController.navigate(Screen.TripDetail.createRoute(carId, tripStartDate, exteriorColor))
+                }
             )
         }
 
@@ -423,7 +426,10 @@ fun NavGraph(
                 carId = carId,
                 driveId = driveId,
                 exteriorColor = exteriorColor,
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToTripDetail = { tripStartDate ->
+                    navController.navigate(Screen.TripDetail.createRoute(carId, tripStartDate, exteriorColor))
+                }
             )
         }
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -91,6 +91,7 @@ fun ChargeDetailScreen(
     chargeId: Int,
     exteriorColor: String? = null,
     onNavigateBack: () -> Unit,
+    onNavigateToTripDetail: (tripStartDate: String) -> Unit = {},
     viewModel: ChargeDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -143,6 +144,9 @@ fun ChargeDetailScreen(
                     units = uiState.units,
                     currencySymbol = uiState.currencySymbol,
                     isDcCharge = uiState.isDcCharge,
+                    containingTrip = uiState.containingTrip,
+                    onNavigateToTripDetail = onNavigateToTripDetail,
+                    onRemoveFromTrip = viewModel::removeFromTrip,
                     modifier = Modifier.padding(padding)
                 )
             }
@@ -157,6 +161,9 @@ private fun ChargeDetailContent(
     units: Units?,
     currencySymbol: String,
     isDcCharge: Boolean,
+    containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
+    onNavigateToTripDetail: (String) -> Unit,
+    onRemoveFromTrip: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()
@@ -177,6 +184,16 @@ private fun ChargeDetailContent(
     ) {
         // Location header card
         LocationHeaderCard(detail = detail, currencySymbol = currencySymbol, isDcCharge = isDcCharge)
+
+        // Part-of-trip banner
+        if (containingTrip != null) {
+            val (_, trip) = containingTrip
+            com.matedroid.ui.components.PartOfTripCard(
+                tripRoute = "${com.matedroid.ui.screens.trips.extractCity(trip.startAddress)} → ${com.matedroid.ui.screens.trips.extractCity(trip.endAddress)}",
+                onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
+                onConfirmRemove = onRemoveFromTrip
+            )
+        }
 
         // Map showing charge location
         if (detail.latitude != null && detail.longitude != null) {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -74,6 +74,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.createPinMarkerDrawable
+import com.matedroid.ui.screens.trips.displayName
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
@@ -189,7 +190,7 @@ private fun ChargeDetailContent(
         if (containingTrip != null) {
             val (_, trip) = containingTrip
             com.matedroid.ui.components.PartOfTripCard(
-                tripRoute = "${com.matedroid.ui.screens.trips.extractCity(trip.startAddress)} → ${com.matedroid.ui.screens.trips.extractCity(trip.endAddress)}",
+                tripRoute = trip.displayName(),
                 onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
                 onConfirmRemove = onRemoveFromTrip
             )

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
@@ -5,9 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.LegRef
+import com.matedroid.domain.TripRepository
+import com.matedroid.domain.model.Trip
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +28,8 @@ data class ChargeDetailUiState(
     val units: Units? = null,
     val stats: ChargeDetailStats? = null,
     val currencySymbol: String = "€",
-    val isDcCharge: Boolean = false
+    val isDcCharge: Boolean = false,
+    val containingTrip: Pair<Long, Trip>? = null
 )
 
 data class ChargeDetailStats(
@@ -53,7 +58,8 @@ data class ChargeDetailStats(
 @HiltViewModel
 class ChargeDetailViewModel @Inject constructor(
     private val repository: TeslamateRepository,
-    private val settingsDataStore: SettingsDataStore
+    private val settingsDataStore: SettingsDataStore,
+    private val tripRepository: TripRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChargeDetailUiState())
@@ -81,6 +87,11 @@ class ChargeDetailViewModel @Inject constructor(
 
         this.carId = carId
         this.chargeId = chargeId
+
+        viewModelScope.launch {
+            val containing = tripRepository.findTripContaining(carId, SavedTripLeg.TYPE_CHARGE, chargeId)
+            _uiState.update { it.copy(containingTrip = containing) }
+        }
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
@@ -124,6 +135,16 @@ class ChargeDetailViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    /** Detach this charge from its containing saved trip (auto-transitions the trip to USER_EDITED). */
+    fun removeFromTrip() {
+        val tripId = _uiState.value.containingTrip?.first ?: return
+        val charge = chargeId ?: return
+        viewModelScope.launch {
+            tripRepository.removeLegFromTrip(tripId, LegRef(SavedTripLeg.TYPE_CHARGE, charge))
+            _uiState.update { it.copy(containingTrip = null) }
+        }
     }
 
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -77,6 +77,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.WeatherPoint
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
+import com.matedroid.ui.screens.trips.displayName
 import com.matedroid.ui.theme.CarColorPalettes
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.BoundingBox
@@ -198,7 +199,7 @@ private fun DriveDetailContent(
         if (containingTrip != null) {
             val (_, trip) = containingTrip
             com.matedroid.ui.components.PartOfTripCard(
-                tripRoute = "${com.matedroid.ui.screens.trips.extractCity(trip.startAddress)} → ${com.matedroid.ui.screens.trips.extractCity(trip.endAddress)}",
+                tripRoute = trip.displayName(),
                 onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
                 onConfirmRemove = onRemoveFromTrip
             )

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -96,6 +96,7 @@ fun DriveDetailScreen(
     driveId: Int,
     exteriorColor: String? = null,
     onNavigateBack: () -> Unit,
+    onNavigateToTripDetail: (tripStartDate: String) -> Unit = {},
     viewModel: DriveDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -151,6 +152,9 @@ fun DriveDetailScreen(
                     routeColor = palette.accent,
                     weatherPoints = uiState.weatherPoints,
                     isLoadingWeather = uiState.isLoadingWeather,
+                    containingTrip = uiState.containingTrip,
+                    onNavigateToTripDetail = onNavigateToTripDetail,
+                    onRemoveFromTrip = viewModel::removeFromTrip,
                     modifier = Modifier.padding(padding)
                 )
             }
@@ -166,6 +170,9 @@ private fun DriveDetailContent(
     routeColor: Color,
     weatherPoints: List<WeatherPoint>,
     isLoadingWeather: Boolean,
+    containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
+    onNavigateToTripDetail: (String) -> Unit,
+    onRemoveFromTrip: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()
@@ -186,6 +193,16 @@ private fun DriveDetailContent(
     ) {
         // Route header card
         RouteHeaderCard(detail = detail)
+
+        // Part-of-trip banner: link to the containing saved trip + detach action
+        if (containingTrip != null) {
+            val (_, trip) = containingTrip
+            com.matedroid.ui.components.PartOfTripCard(
+                tripRoute = "${com.matedroid.ui.screens.trips.extractCity(trip.startAddress)} → ${com.matedroid.ui.screens.trips.extractCity(trip.endAddress)}",
+                onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
+                onConfirmRemove = onRemoveFromTrip
+            )
+        }
 
         // Map showing the route
         if (!detail.positions.isNullOrEmpty()) {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
@@ -6,9 +6,13 @@ import com.matedroid.data.api.models.DriveDetail
 import com.matedroid.data.api.models.DrivePosition
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.data.repository.WeatherPoint
 import com.matedroid.data.repository.WeatherRepository
+import com.matedroid.domain.LegRef
+import com.matedroid.domain.TripRepository
+import com.matedroid.domain.model.Trip
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +28,8 @@ data class DriveDetailUiState(
     val units: Units? = null,
     val stats: DriveDetailStats? = null,
     val weatherPoints: List<WeatherPoint> = emptyList(),
-    val isLoadingWeather: Boolean = false
+    val isLoadingWeather: Boolean = false,
+    val containingTrip: Pair<Long, Trip>? = null
 )
 
 data class DriveDetailStats(
@@ -53,7 +58,8 @@ data class DriveDetailStats(
 @HiltViewModel
 class DriveDetailViewModel @Inject constructor(
     private val repository: TeslamateRepository,
-    private val weatherRepository: WeatherRepository
+    private val weatherRepository: WeatherRepository,
+    private val tripRepository: TripRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DriveDetailUiState())
@@ -69,6 +75,11 @@ class DriveDetailViewModel @Inject constructor(
 
         this.carId = carId
         this.driveId = driveId
+
+        viewModelScope.launch {
+            val containing = tripRepository.findTripContaining(carId, SavedTripLeg.TYPE_DRIVE, driveId)
+            _uiState.update { it.copy(containingTrip = containing) }
+        }
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
@@ -147,6 +158,16 @@ class DriveDetailViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    /** Detach this drive from its containing saved trip (auto-transitions the trip to USER_EDITED). */
+    fun removeFromTrip() {
+        val tripId = _uiState.value.containingTrip?.first ?: return
+        val drive = driveId ?: return
+        viewModelScope.launch {
+            tripRepository.removeLegFromTrip(tripId, LegRef(SavedTripLeg.TYPE_DRIVE, drive))
+            _uiState.update { it.copy(containingTrip = null) }
+        }
     }
 
     private fun calculateStats(detail: DriveDetail): DriveDetailStats {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -1,7 +1,8 @@
 package com.matedroid.ui.screens.trips
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,14 +18,23 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,9 +46,9 @@ import androidx.compose.ui.unit.dp
 import com.matedroid.R
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.domain.EligibleLegs
 import com.matedroid.domain.LegRef
-import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
 import java.time.LocalDateTime
@@ -46,16 +56,22 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AddLegSheet(
     eligible: EligibleLegs,
     dcChargeIds: Set<Int>,
     palette: CarColorPalette,
-    onPick: (LegRef) -> Unit,
+    onPickLegs: (List<LegRef>) -> Unit,
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var multiMode by remember { mutableStateOf(false) }
+    var selected by remember { mutableStateOf<Set<LegRef>>(emptySet()) }
+
+    val merged = remember(eligible) { buildCandidateList(eligible) }
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState
@@ -65,14 +81,24 @@ fun AddLegSheet(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Text(
-                text = stringResource(R.string.trip_edit_add_leg_title),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
+            // Static top bar — never scrolls
+            StaticHeader(
+                multiMode = multiMode,
+                selectedCount = selected.size,
+                onEnterMulti = { multiMode = true },
+                onCancelMulti = {
+                    multiMode = false
+                    selected = emptySet()
+                },
+                onConfirmMulti = {
+                    if (selected.isNotEmpty()) {
+                        onPickLegs(selected.toList())
+                    }
+                }
             )
-            Spacer(Modifier.height(12.dp))
 
-            val merged = buildCandidateList(eligible)
+            Spacer(Modifier.height(8.dp))
+
             if (merged.isEmpty()) {
                 Box(
                     modifier = Modifier
@@ -92,14 +118,75 @@ fun AddLegSheet(
                     contentPadding = PaddingValues(bottom = 24.dp)
                 ) {
                     items(merged) { candidate ->
+                        val ref = candidate.toRef()
                         CandidateRow(
                             candidate = candidate,
                             palette = palette,
                             isDc = candidate is Candidate.Charge && candidate.charge.chargeId in dcChargeIds,
-                            onClick = { onPick(candidate.toRef()) }
+                            multiMode = multiMode,
+                            isSelected = ref in selected,
+                            onTap = {
+                                if (multiMode) {
+                                    selected = if (ref in selected) selected - ref else selected + ref
+                                } else {
+                                    onPickLegs(listOf(ref))
+                                }
+                            },
+                            onLongPress = {
+                                if (!multiMode) {
+                                    multiMode = true
+                                    selected = setOf(ref)
+                                }
+                            }
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StaticHeader(
+    multiMode: Boolean,
+    selectedCount: Int,
+    onEnterMulti: () -> Unit,
+    onCancelMulti: () -> Unit,
+    onConfirmMulti: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (multiMode) {
+            TextButton(onClick = onCancelMulti) {
+                Text(stringResource(R.string.cancel))
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.trip_edit_selected_count, selectedCount),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            Button(
+                onClick = onConfirmMulti,
+                enabled = selectedCount > 0
+            ) {
+                Text(stringResource(R.string.add))
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.trip_edit_add_leg_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onEnterMulti) {
+                Icon(
+                    Icons.Filled.Checklist,
+                    contentDescription = stringResource(R.string.trip_edit_select_multiple)
+                )
             }
         }
     }
@@ -123,22 +210,40 @@ private fun buildCandidateList(eligible: EligibleLegs): List<Candidate> {
     return all
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun CandidateRow(
     candidate: Candidate,
     palette: CarColorPalette,
     isDc: Boolean,
-    onClick: () -> Unit
+    multiMode: Boolean,
+    isSelected: Boolean,
+    onTap: () -> Unit,
+    onLongPress: () -> Unit
 ) {
+    val rowBackground =
+        if (isSelected) palette.accent.copy(alpha = 0.15f)
+        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-            .clickable(onClick = onClick)
+            .background(rowBackground)
+            .combinedClickable(
+                onClick = onTap,
+                onLongClick = onLongPress
+            )
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        if (multiMode) {
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = { onTap() }
+            )
+            Spacer(Modifier.width(4.dp))
+        }
         when (candidate) {
             is Candidate.Drive -> {
                 Icon(

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -1,0 +1,257 @@
+package com.matedroid.ui.screens.trips
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.domain.EligibleLegs
+import com.matedroid.domain.LegRef
+import com.matedroid.data.local.entity.SavedTripLeg
+import com.matedroid.ui.icons.CustomIcons
+import com.matedroid.ui.theme.CarColorPalette
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddLegSheet(
+    eligible: EligibleLegs,
+    dcChargeIds: Set<Int>,
+    palette: CarColorPalette,
+    onPick: (LegRef) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.trip_edit_add_leg_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(12.dp))
+
+            val merged = buildCandidateList(eligible)
+            if (merged.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.trip_edit_add_leg_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(bottom = 24.dp)
+                ) {
+                    items(merged) { candidate ->
+                        CandidateRow(
+                            candidate = candidate,
+                            palette = palette,
+                            isDc = candidate is Candidate.Charge && candidate.charge.chargeId in dcChargeIds,
+                            onClick = { onPick(candidate.toRef()) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private sealed class Candidate(val startDate: String) {
+    class Drive(val drive: DriveSummary) : Candidate(drive.startDate)
+    class Charge(val charge: ChargeSummary) : Candidate(charge.startDate)
+
+    fun toRef(): LegRef = when (this) {
+        is Drive -> LegRef(SavedTripLeg.TYPE_DRIVE, drive.driveId)
+        is Charge -> LegRef(SavedTripLeg.TYPE_CHARGE, charge.chargeId)
+    }
+}
+
+private fun buildCandidateList(eligible: EligibleLegs): List<Candidate> {
+    val all = mutableListOf<Candidate>()
+    eligible.drives.forEach { all.add(Candidate.Drive(it)) }
+    eligible.charges.forEach { all.add(Candidate.Charge(it)) }
+    all.sortBy { it.startDate }
+    return all
+}
+
+@Composable
+private fun CandidateRow(
+    candidate: Candidate,
+    palette: CarColorPalette,
+    isDc: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            .clickable(onClick = onClick)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        when (candidate) {
+            is Candidate.Drive -> {
+                Icon(
+                    CustomIcons.SteeringWheel,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = palette.accent
+                )
+                Spacer(Modifier.width(10.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "${extractCity(candidate.drive.startAddress)} → ${extractCity(candidate.drive.endAddress)}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = formatCandidateDate(candidate.drive.startDate),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = "%.1f km".format(candidate.drive.distance),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = formatMinutes(candidate.drive.durationMin),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            is Candidate.Charge -> {
+                val chipColor = if (isDc) palette.dcColor else palette.acColor
+                Icon(
+                    Icons.Filled.ElectricBolt,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = chipColor
+                )
+                Spacer(Modifier.width(10.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = extractCity(candidate.charge.address),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = formatCandidateDate(candidate.charge.startDate),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                ChargeTypeChip(isDc = isDc, chipColor = chipColor)
+                Spacer(Modifier.width(8.dp))
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = "+%.1f kWh".format(candidate.charge.energyAdded),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Bold,
+                        color = chipColor
+                    )
+                    Text(
+                        text = formatMinutes(candidate.charge.durationMin),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChargeTypeChip(isDc: Boolean, chipColor: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(chipColor)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = if (isDc) "DC" else "AC",
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+private fun formatCandidateDate(dateStr: String): String {
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (e: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        }
+        dt.format(DateTimeFormatter.ofPattern("d MMM HH:mm"))
+    } catch (e: Exception) {
+        dateStr
+    }
+}
+
+private fun formatMinutes(minutes: Int): String {
+    val h = minutes / 60
+    val m = minutes % 60
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -1,0 +1,167 @@
+package com.matedroid.ui.screens.trips
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.domain.model.Trip
+import com.matedroid.ui.theme.CarColorPalette
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MergeTripSheet(
+    adjacentTrips: List<Pair<Long, Trip>>,
+    palette: CarColorPalette,
+    onPick: (tripId: Long, trip: Trip) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.trip_edit_merge_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(12.dp))
+
+            if (adjacentTrips.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.trip_edit_merge_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(bottom = 24.dp)
+                ) {
+                    items(adjacentTrips) { (id, trip) ->
+                        AdjacentTripRow(
+                            trip = trip,
+                            palette = palette,
+                            onClick = { onPick(id, trip) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdjacentTripRow(
+    trip: Trip,
+    palette: CarColorPalette,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            .clickable(onClick = onClick)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            Icons.Filled.Route,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = palette.accent
+        )
+        Spacer(Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = formatRange(trip.startDate, trip.endDate),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = "%.0f km".format(trip.totalDistance),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "${trip.drives.size + trip.charges.size} legs",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun formatRange(startIso: String, endIso: String): String {
+    val s = parseShort(startIso) ?: startIso
+    val e = parseShort(endIso) ?: endIso
+    return if (s == e) s else "$s → $e"
+}
+
+private fun parseShort(iso: String): String? {
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(iso).toLocalDateTime()
+        } catch (e: DateTimeParseException) {
+            LocalDateTime.parse(iso.replace("Z", ""))
+        }
+        dt.format(DateTimeFormatter.ofPattern("d MMM"))
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -120,7 +120,7 @@ private fun AdjacentTripRow(
         Spacer(Modifier.width(10.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}",
+                text = trip.displayName(),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -25,14 +25,18 @@ import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BatteryChargingFull
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -70,6 +74,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
+import com.matedroid.ui.components.TripEditActions
 import com.matedroid.ui.components.TripTimeline
 import com.matedroid.ui.components.TripTimelineCountry
 import com.matedroid.ui.components.createPinMarkerDrawable
@@ -103,6 +108,12 @@ fun TripDetailScreen(
 
     LaunchedEffect(carId, tripStartDate) { viewModel.loadTrip(carId, tripStartDate) }
 
+    LaunchedEffect(uiState.justDeleted) {
+        if (uiState.justDeleted) onNavigateBack()
+    }
+
+    var overflowOpen by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -113,6 +124,31 @@ fun TripDetailScreen(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.back)
                         )
+                    }
+                },
+                actions = {
+                    if (uiState.savedTripId != null) {
+                        IconButton(onClick = { overflowOpen = true }) {
+                            Icon(
+                                Icons.Filled.MoreVert,
+                                contentDescription = null
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = overflowOpen,
+                            onDismissRequest = { overflowOpen = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.trip_edit_delete)) },
+                                leadingIcon = {
+                                    Icon(Icons.Filled.DeleteOutline, contentDescription = null)
+                                },
+                                onClick = {
+                                    overflowOpen = false
+                                    viewModel.openDeleteConfirm()
+                                }
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -149,14 +185,49 @@ fun TripDetailScreen(
                         countries = uiState.countries,
                         units = uiState.units,
                         palette = palette,
+                        dcChargeIds = uiState.dcChargeIds,
+                        canEdit = uiState.savedTripId != null,
                         onDriveClick = onNavigateToDriveDetail,
                         onChargeClick = onNavigateToChargeDetail,
                         onCountryClick = onNavigateToCountryStats,
+                        onAddLeg = viewModel::openAddLegSheet,
+                        onMergeTrip = viewModel::openMergeSheet,
                         currencySymbol = uiState.currencySymbol
                     )
                 }
             }
         }
+    }
+
+    // Sheets and dialogs — rendered at top level so they overlay regardless of scroll position
+    if (uiState.showAddLegSheet && uiState.eligibleLegs != null) {
+        AddLegSheet(
+            eligible = uiState.eligibleLegs!!,
+            dcChargeIds = uiState.dcChargeIds,
+            palette = palette,
+            onPick = viewModel::pickLeg,
+            onDismiss = viewModel::closeAddLegSheet
+        )
+    }
+    if (uiState.showMergeSheet) {
+        MergeTripSheet(
+            adjacentTrips = uiState.adjacentTrips,
+            palette = palette,
+            onPick = viewModel::pickMergeTarget,
+            onDismiss = viewModel::closeMergeSheet
+        )
+    }
+    if (uiState.pendingMergeTarget != null) {
+        MergeConfirmDialog(
+            onConfirm = viewModel::confirmMergeTarget,
+            onDismiss = viewModel::cancelMergeTarget
+        )
+    }
+    if (uiState.showDeleteConfirm) {
+        DeleteTripConfirmDialog(
+            onConfirm = viewModel::confirmDelete,
+            onDismiss = viewModel::closeDeleteConfirm
+        )
     }
 }
 
@@ -169,9 +240,13 @@ private fun TripDetailContent(
     countries: List<TripCountry>,
     units: Units?,
     palette: CarColorPalette,
+    dcChargeIds: Set<Int>,
+    canEdit: Boolean,
     onDriveClick: (driveId: Int) -> Unit,
     onChargeClick: (chargeId: Int) -> Unit,
     onCountryClick: (countryCode: String) -> Unit,
+    onAddLeg: () -> Unit,
+    onMergeTrip: () -> Unit,
     currencySymbol: String,
     modifier: Modifier = Modifier
 ) {
@@ -191,7 +266,7 @@ private fun TripDetailContent(
         )
 
         TripTimeline(
-            segments = remember(trip) { buildTimelineSegments(trip) },
+            segments = remember(trip, dcChargeIds) { buildTimelineSegments(trip, dcChargeIds) },
             startDate = trip.startDate,
             endDate = trip.endDate,
             startCity = extractCity(trip.startAddress),
@@ -243,10 +318,21 @@ private fun TripDetailContent(
                 is TripLeg.Drive -> DriveLegCard(leg, units, palette) {
                     onDriveClick(leg.drive.driveId)
                 }
-                is TripLeg.Charge -> ChargeLegCard(leg, palette) {
+                is TripLeg.Charge -> ChargeLegCard(
+                    leg = leg,
+                    palette = palette,
+                    isDc = leg.charge.chargeId in dcChargeIds
+                ) {
                     onChargeClick(leg.charge.chargeId)
                 }
             }
+        }
+
+        if (canEdit) {
+            TripEditActions(
+                onAddLeg = onAddLeg,
+                onMergeTrip = onMergeTrip
+            )
         }
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -432,6 +518,8 @@ private fun StatItemView(
 
 // === Map ===
 
+private const val GEO_JUMP_THRESHOLD_METERS = 10_000.0
+
 @Composable
 private fun TripMapCard(
     routeSegments: List<TripRouteSegment>,
@@ -492,22 +580,44 @@ private fun TripMapCard(
                         // Clear previous overlays and redraw
                         mapView.overlays.clear()
 
+                        var previousEnd: GeoPoint? = null
                         routeSegments.forEachIndexed { index, segment ->
                             val geoPoints = segment.points.map {
                                 GeoPoint(it.latitude, it.longitude)
                             }
-                            if (geoPoints.size >= 2) {
-                                val polyline = Polyline().apply {
-                                    setPoints(geoPoints)
-                                    outlinePaint.color =
-                                        if (index % 2 == 0) oddLegColorArgb
-                                        else evenLegColorArgb
-                                    outlinePaint.strokeWidth = 8f
-                                    outlinePaint.strokeCap = Paint.Cap.ROUND
-                                    outlinePaint.strokeJoin = Paint.Join.ROUND
+                            if (geoPoints.size < 2) return@forEachIndexed
+
+                            // If there's a previous leg, check if this leg's start is geographically
+                            // far from the previous leg's end (car was transported, or between
+                            // non-contiguous trips that were merged). Draw a dashed connector.
+                            val firstPoint = geoPoints.first()
+                            val prev = previousEnd
+                            if (prev != null) {
+                                val distanceMeters = prev.distanceToAsDouble(firstPoint)
+                                if (distanceMeters > GEO_JUMP_THRESHOLD_METERS) {
+                                    val dashed = Polyline().apply {
+                                        setPoints(listOf(prev, firstPoint))
+                                        outlinePaint.color = oddLegColorArgb
+                                        outlinePaint.strokeWidth = 6f
+                                        outlinePaint.strokeCap = Paint.Cap.ROUND
+                                        outlinePaint.pathEffect =
+                                            android.graphics.DashPathEffect(floatArrayOf(20f, 15f), 0f)
+                                    }
+                                    mapView.overlays.add(dashed)
                                 }
-                                mapView.overlays.add(polyline)
                             }
+
+                            val polyline = Polyline().apply {
+                                setPoints(geoPoints)
+                                outlinePaint.color =
+                                    if (index % 2 == 0) oddLegColorArgb
+                                    else evenLegColorArgb
+                                outlinePaint.strokeWidth = 8f
+                                outlinePaint.strokeCap = Paint.Cap.ROUND
+                                outlinePaint.strokeJoin = Paint.Join.ROUND
+                            }
+                            mapView.overlays.add(polyline)
+                            previousEnd = geoPoints.last()
                         }
 
                         val mapCtx = mapView.context
@@ -699,14 +809,16 @@ private fun DriveLegCard(
 private fun ChargeLegCard(
     leg: TripLeg.Charge,
     palette: CarColorPalette,
+    isDc: Boolean,
     onClick: () -> Unit
 ) {
+    val chipColor = if (isDc) palette.dcColor else palette.acColor
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
-            containerColor = palette.dcColor.copy(alpha = 0.1f)
+            containerColor = chipColor.copy(alpha = 0.1f)
         )
     ) {
         Row(
@@ -717,15 +829,31 @@ private fun ChargeLegCard(
                 Icons.Filled.ElectricBolt,
                 contentDescription = null,
                 modifier = Modifier.size(18.dp),
-                tint = palette.dcColor
+                tint = chipColor
             )
             Spacer(modifier = Modifier.width(10.dp))
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.trip_leg_charge, leg.index),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(R.string.trip_leg_charge, leg.index),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(chipColor)
+                            .padding(horizontal = 5.dp, vertical = 1.dp)
+                    ) {
+                        Text(
+                            text = if (isDc) "DC" else "AC",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = androidx.compose.ui.graphics.Color.White,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
                 Text(
                     text = leg.charge.address,
                     style = MaterialTheme.typography.bodySmall,
@@ -738,7 +866,7 @@ private fun ChargeLegCard(
                     text = "+%.1f kWh".format(leg.charge.energyAdded),
                     style = MaterialTheme.typography.bodySmall,
                     fontWeight = FontWeight.Bold,
-                    color = palette.dcColor
+                    color = chipColor
                 )
                 Text(
                     text = formatDuration(leg.charge.durationMin),

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -135,7 +135,7 @@ fun TripDetailScreen(
         val customName = uiState.savedTripName?.takeIf { it.isNotBlank() }
         when {
             customName != null -> customName
-            trip != null -> "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}"
+            trip != null -> trip.displayName()
             else -> stringResource(R.string.trip_detail_title)
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -26,17 +26,15 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -132,12 +130,26 @@ fun TripDetailScreen(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    var overflowOpen by remember { mutableStateOf(false) }
+    val displayTitle = run {
+        val trip = uiState.trip
+        val customName = uiState.savedTripName?.takeIf { it.isNotBlank() }
+        when {
+            customName != null -> customName
+            trip != null -> "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}"
+            else -> stringResource(R.string.trip_detail_title)
+        }
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.trip_detail_title)) },
+                title = {
+                    Text(
+                        text = displayTitle,
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
@@ -148,25 +160,16 @@ fun TripDetailScreen(
                 },
                 actions = {
                     if (uiState.savedTripId != null) {
-                        IconButton(onClick = { overflowOpen = true }) {
+                        IconButton(onClick = viewModel::openRenameDialog) {
                             Icon(
-                                Icons.Filled.MoreVert,
-                                contentDescription = null
+                                Icons.Filled.Edit,
+                                contentDescription = stringResource(R.string.trip_rename_action)
                             )
                         }
-                        DropdownMenu(
-                            expanded = overflowOpen,
-                            onDismissRequest = { overflowOpen = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.trip_edit_delete)) },
-                                leadingIcon = {
-                                    Icon(Icons.Filled.DeleteOutline, contentDescription = null)
-                                },
-                                onClick = {
-                                    overflowOpen = false
-                                    viewModel.openDeleteConfirm()
-                                }
+                        IconButton(onClick = viewModel::openDeleteConfirm) {
+                            Icon(
+                                Icons.Filled.DeleteOutline,
+                                contentDescription = stringResource(R.string.trip_edit_delete)
                             )
                         }
                     }
@@ -247,6 +250,14 @@ fun TripDetailScreen(
         DeleteTripConfirmDialog(
             onConfirm = viewModel::confirmDelete,
             onDismiss = viewModel::closeDeleteConfirm
+        )
+    }
+    if (uiState.showRenameDialog) {
+        RenameTripDialog(
+            value = uiState.renameDraft,
+            onValueChange = viewModel::updateRenameDraft,
+            onConfirm = viewModel::confirmRename,
+            onDismiss = viewModel::closeRenameDialog
         )
     }
 }
@@ -574,19 +585,12 @@ private fun TripMapCard(
             containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.trip_route_map),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 12.dp)
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(250.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(320.dp)
+                .clip(RoundedCornerShape(12.dp))
+        ) {
                 AndroidView(
                     factory = { mapCtx ->
                         MapView(mapCtx).apply {
@@ -719,7 +723,6 @@ private fun TripMapCard(
                         }
                     }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -56,6 +57,9 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -110,6 +114,22 @@ fun TripDetailScreen(
 
     LaunchedEffect(uiState.justDeleted) {
         if (uiState.justDeleted) onNavigateBack()
+    }
+
+    // When the user returns from a child screen (e.g. a drive/charge detail where they may have
+    // removed a leg), reload so the trip reflects the current DB state. The ViewModel ignores the
+    // first ON_RESUME (on initial composition) by only reloading after at least one ON_PAUSE.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> viewModel.onScreenPaused()
+                Lifecycle.Event.ON_RESUME -> viewModel.onScreenResumed()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     var overflowOpen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -228,7 +228,7 @@ fun TripDetailScreen(
             eligible = uiState.eligibleLegs!!,
             dcChargeIds = uiState.dcChargeIds,
             palette = palette,
-            onPick = viewModel::pickLeg,
+            onPickLegs = viewModel::pickLegs,
             onDismiss = viewModel::closeAddLegSheet
         )
     }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -96,6 +96,7 @@ class TripDetailViewModel @Inject constructor(
     private var loaded = false
     private var currentCarId: Int = -1
     private var currentStartDate: String = ""
+    private var hasBeenPaused = false
 
     fun loadTrip(carId: Int, tripStartDate: String) {
         if (loaded) return
@@ -256,6 +257,22 @@ class TripDetailViewModel @Inject constructor(
         viewModelScope.launch {
             tripRepository.deleteTrip(tripId)
             _uiState.update { it.copy(showDeleteConfirm = false, justDeleted = true) }
+        }
+    }
+
+    /** Called by the screen on ON_PAUSE so we know the user navigated away. */
+    fun onScreenPaused() {
+        hasBeenPaused = true
+    }
+
+    /**
+     * Called by the screen on ON_RESUME. Reloads the trip if the user is returning from a child
+     * screen (e.g. a drive/charge detail) where they might have changed the trip's composition.
+     */
+    fun onScreenResumed() {
+        if (loaded && hasBeenPaused) {
+            hasBeenPaused = false
+            reloadTrip()
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -14,6 +14,8 @@ import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.data.repository.countryCodeToFlag
+import com.matedroid.domain.EligibleLegs
+import com.matedroid.domain.LegRef
 import com.matedroid.domain.RouteSimplifier
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
@@ -62,7 +64,18 @@ data class TripDetailUiState(
     val isMapLoading: Boolean = true,
     val countries: List<TripCountry> = emptyList(),
     val units: Units? = null,
-    val currencySymbol: String = "€"
+    val currencySymbol: String = "€",
+
+    // Edit / merge / delete (PR 2)
+    val savedTripId: Long? = null,
+    val dcChargeIds: Set<Int> = emptySet(),
+    val showAddLegSheet: Boolean = false,
+    val showMergeSheet: Boolean = false,
+    val showDeleteConfirm: Boolean = false,
+    val eligibleLegs: EligibleLegs? = null,
+    val adjacentTrips: List<Pair<Long, Trip>> = emptyList(),
+    val pendingMergeTarget: Pair<Long, Trip>? = null,
+    val justDeleted: Boolean = false
 )
 
 @HiltViewModel
@@ -81,10 +94,14 @@ class TripDetailViewModel @Inject constructor(
     val uiState: StateFlow<TripDetailUiState> = _uiState.asStateFlow()
 
     private var loaded = false
+    private var currentCarId: Int = -1
+    private var currentStartDate: String = ""
 
     fun loadTrip(carId: Int, tripStartDate: String) {
         if (loaded) return
         loaded = true
+        currentCarId = carId
+        currentStartDate = tripStartDate
 
         viewModelScope.launch {
             launch {
@@ -119,9 +136,21 @@ class TripDetailViewModel @Inject constructor(
                 )
             }
 
+            // Lookup savedTripId (for edit/merge/delete actions) and DC charge id set (for AC/DC visuals)
+            val savedId = tripRepository.findSavedTripId(carId, trip)
+            val dcIds = try {
+                aggregateDao.getDcChargeIds(carId).toSet()
+            } catch (e: Exception) { emptySet() }
+
             // Show trip info immediately — countries and map load in background
             _uiState.update {
-                it.copy(isLoading = false, trip = trip, markers = markers)
+                it.copy(
+                    isLoading = false,
+                    trip = trip,
+                    markers = markers,
+                    savedTripId = savedId,
+                    dcChargeIds = dcIds
+                )
             }
 
             // Resolve countries — try cache first, resolve in background if miss
@@ -150,6 +179,101 @@ class TripDetailViewModel @Inject constructor(
             // Fetch GPS positions for all drives in parallel (for the map)
             loadRoutePositions(carId, trip)
         }
+    }
+
+    // === Edit / merge / delete actions (PR 2) ===
+
+    fun openAddLegSheet() {
+        val tripId = _uiState.value.savedTripId ?: return
+        viewModelScope.launch {
+            val eligible = tripRepository.getEligibleNewLegs(tripId, currentCarId)
+            _uiState.update { it.copy(showAddLegSheet = true, eligibleLegs = eligible) }
+        }
+    }
+
+    fun closeAddLegSheet() {
+        _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
+    }
+
+    fun pickLeg(ref: LegRef) {
+        val tripId = _uiState.value.savedTripId ?: return
+        viewModelScope.launch {
+            tripRepository.extendTripWithLegs(tripId, listOf(ref))
+            _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
+            reloadTrip()
+        }
+    }
+
+    fun openMergeSheet() {
+        val tripId = _uiState.value.savedTripId ?: return
+        viewModelScope.launch {
+            val adjacent = tripRepository.getAdjacentTrips(tripId, currentCarId)
+            _uiState.update { it.copy(showMergeSheet = true, adjacentTrips = adjacent) }
+        }
+    }
+
+    fun closeMergeSheet() {
+        _uiState.update { it.copy(showMergeSheet = false, adjacentTrips = emptyList()) }
+    }
+
+    fun pickMergeTarget(otherId: Long, otherTrip: Trip) {
+        _uiState.update {
+            it.copy(showMergeSheet = false, pendingMergeTarget = otherId to otherTrip)
+        }
+    }
+
+    fun cancelMergeTarget() {
+        _uiState.update { it.copy(pendingMergeTarget = null) }
+    }
+
+    fun confirmMergeTarget() {
+        val keptId = _uiState.value.savedTripId ?: return
+        val (otherId, _) = _uiState.value.pendingMergeTarget ?: return
+        viewModelScope.launch {
+            val newId = tripRepository.mergeTrips(keptId, otherId, currentCarId) ?: return@launch
+            // The merged trip's startDate equals the earliest source's startDate.
+            // Re-derive currentStartDate so reloadTrip finds the merged trip.
+            val all = tripRepository.getTrips(currentCarId)
+            val merged = all.find { trip ->
+                tripRepository.findSavedTripId(currentCarId, trip) == newId
+            } ?: return@launch
+            currentStartDate = merged.startDate
+            _uiState.update { it.copy(pendingMergeTarget = null, adjacentTrips = emptyList()) }
+            reloadTrip()
+        }
+    }
+
+    fun openDeleteConfirm() {
+        _uiState.update { it.copy(showDeleteConfirm = true) }
+    }
+
+    fun closeDeleteConfirm() {
+        _uiState.update { it.copy(showDeleteConfirm = false) }
+    }
+
+    fun confirmDelete() {
+        val tripId = _uiState.value.savedTripId ?: return
+        viewModelScope.launch {
+            tripRepository.deleteTrip(tripId)
+            _uiState.update { it.copy(showDeleteConfirm = false, justDeleted = true) }
+        }
+    }
+
+    /** Clears the screen state and re-runs loadTrip with the currently viewed trip. */
+    private fun reloadTrip() {
+        loaded = false
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                trip = null,
+                routeSegments = emptyList(),
+                markers = emptyList(),
+                isMapLoading = true,
+                countries = emptyList(),
+                savedTripId = null
+            )
+        }
+        loadTrip(currentCarId, currentStartDate)
     }
 
     /**

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -68,10 +68,13 @@ data class TripDetailUiState(
 
     // Edit / merge / delete (PR 2)
     val savedTripId: Long? = null,
+    val savedTripName: String? = null,
     val dcChargeIds: Set<Int> = emptySet(),
     val showAddLegSheet: Boolean = false,
     val showMergeSheet: Boolean = false,
     val showDeleteConfirm: Boolean = false,
+    val showRenameDialog: Boolean = false,
+    val renameDraft: String = "",
     val eligibleLegs: EligibleLegs? = null,
     val adjacentTrips: List<Pair<Long, Trip>> = emptyList(),
     val pendingMergeTarget: Pair<Long, Trip>? = null,
@@ -139,6 +142,7 @@ class TripDetailViewModel @Inject constructor(
 
             // Lookup savedTripId (for edit/merge/delete actions) and DC charge id set (for AC/DC visuals)
             val savedId = tripRepository.findSavedTripId(carId, trip)
+            val savedName = savedId?.let { tripRepository.getTripName(it) }
             val dcIds = try {
                 aggregateDao.getDcChargeIds(carId).toSet()
             } catch (e: Exception) { emptySet() }
@@ -150,6 +154,7 @@ class TripDetailViewModel @Inject constructor(
                     trip = trip,
                     markers = markers,
                     savedTripId = savedId,
+                    savedTripName = savedName,
                     dcChargeIds = dcIds
                 )
             }
@@ -244,6 +249,33 @@ class TripDetailViewModel @Inject constructor(
         }
     }
 
+    fun openRenameDialog() {
+        _uiState.update {
+            it.copy(
+                showRenameDialog = true,
+                renameDraft = it.savedTripName.orEmpty()
+            )
+        }
+    }
+
+    fun closeRenameDialog() {
+        _uiState.update { it.copy(showRenameDialog = false, renameDraft = "") }
+    }
+
+    fun updateRenameDraft(draft: String) {
+        _uiState.update { it.copy(renameDraft = draft) }
+    }
+
+    fun confirmRename() {
+        val tripId = _uiState.value.savedTripId ?: return
+        val draft = _uiState.value.renameDraft
+        viewModelScope.launch {
+            tripRepository.renameTrip(tripId, draft)
+            val updated = tripRepository.getTripName(tripId)
+            _uiState.update { it.copy(showRenameDialog = false, savedTripName = updated, renameDraft = "") }
+        }
+    }
+
     fun openDeleteConfirm() {
         _uiState.update { it.copy(showDeleteConfirm = true) }
     }
@@ -287,7 +319,8 @@ class TripDetailViewModel @Inject constructor(
                 markers = emptyList(),
                 isMapLoading = true,
                 countries = emptyList(),
-                savedTripId = null
+                savedTripId = null,
+                savedTripName = null
             )
         }
         loadTrip(currentCarId, currentStartDate)

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -201,10 +201,11 @@ class TripDetailViewModel @Inject constructor(
         _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
     }
 
-    fun pickLeg(ref: LegRef) {
+    fun pickLegs(refs: List<LegRef>) {
+        if (refs.isEmpty()) return
         val tripId = _uiState.value.savedTripId ?: return
         viewModelScope.launch {
-            tripRepository.extendTripWithLegs(tripId, listOf(ref))
+            tripRepository.extendTripWithLegs(tripId, refs)
             _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
             reloadTrip()
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripEditDialogs.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripEditDialogs.kt
@@ -1,0 +1,78 @@
+package com.matedroid.ui.screens.trips
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.Merge
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.ui.theme.StatusError
+
+@Composable
+fun MergeConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.Merge,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = { Text(stringResource(R.string.trip_edit_merge_confirm_title)) },
+        text = { Text(stringResource(R.string.trip_edit_merge_confirm_body)) },
+        confirmButton = {
+            Button(onClick = { onConfirm(); onDismiss() }) {
+                Text(stringResource(R.string.trip_edit_merge_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun DeleteTripConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.DeleteForever,
+                contentDescription = null,
+                tint = StatusError,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = { Text(stringResource(R.string.trip_edit_delete_confirm_title)) },
+        text = { Text(stringResource(R.string.trip_edit_delete_confirm_body)) },
+        confirmButton = {
+            Button(onClick = { onConfirm(); onDismiss() }) {
+                Text(stringResource(R.string.delete))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripEditDialogs.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripEditDialogs.kt
@@ -1,13 +1,19 @@
 package com.matedroid.ui.screens.trips
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Merge
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -37,6 +43,54 @@ fun MergeConfirmDialog(
         confirmButton = {
             Button(onClick = { onConfirm(); onDismiss() }) {
                 Text(stringResource(R.string.trip_edit_merge_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun RenameTripDialog(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.Edit,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = { Text(stringResource(R.string.trip_rename_dialog_title)) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = onValueChange,
+                    label = { Text(stringResource(R.string.trip_rename_field_label)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.trip_rename_field_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onConfirm(); onDismiss() }) {
+                Text(stringResource(R.string.save))
             }
         },
         dismissButton = {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
@@ -15,11 +15,13 @@ private const val MIN_PARKING_GAP_MIN = 5L
  * Build a chronological list of TripTimelineSegments from a Trip.
  * Inserts Parking segments for any gap >= MIN_PARKING_GAP_MIN between consecutive legs.
  *
- * Note: auto-detected trips only include DC charges (see TripDetector), so every charge
- * here is marked isDc = true. When user-created trips land, this will need to consult
- * the fast-charger flag per charge.
+ * [dcChargeIds] is the set of charge IDs that are DC fast chargers, used to color the
+ * charge segments correctly (orange for DC, green for AC). For legs not in the set, AC is assumed.
  */
-fun buildTimelineSegments(trip: Trip): List<TripTimelineSegment> {
+fun buildTimelineSegments(
+    trip: Trip,
+    dcChargeIds: Set<Int> = emptySet()
+): List<TripTimelineSegment> {
     val allEvents = mutableListOf<Pair<String, Any>>()
     trip.drives.forEach { allEvents.add(it.startDate to it) }
     trip.charges.forEach { allEvents.add(it.startDate to it) }
@@ -61,7 +63,7 @@ fun buildTimelineSegments(trip: Trip): List<TripTimelineSegment> {
                         durationMin = event.durationMin,
                         index = chargeIdx,
                         energyKwh = event.energyAdded,
-                        isDc = true
+                        isDc = event.chargeId in dcChargeIds
                     )
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -42,12 +42,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -84,6 +88,22 @@ fun TripsScreen(
     val palette = CarColorPalettes.forExteriorColor(exteriorColor, isDarkTheme)
 
     LaunchedEffect(carId) { viewModel.setCarId(carId) }
+
+    // Reload trips when returning from a child screen — merges / edits in the trip detail
+    // invalidate this screen's cached list. The VM ignores the first ON_RESUME to avoid
+    // doubling up with setCarId's initial load.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> viewModel.onScreenPaused()
+                Lifecycle.Event.ON_RESUME -> viewModel.onScreenResumed()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -386,19 +386,28 @@ private fun TripItem(
                             tint = MaterialTheme.colorScheme.primary
                         )
                         Spacer(modifier = Modifier.width(8.dp))
+                        val customName = trip.name?.takeIf { it.isNotBlank() }
                         Text(
-                            text = "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}",
+                            text = customName ?: "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}",
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.weight(1f),
                             maxLines = 1
                         )
                     }
+                    val customName = trip.name?.takeIf { it.isNotBlank() }
+                    val subtitle = if (customName != null) {
+                        "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)} · ${formatDate(trip.startDate)}"
+                    } else {
+                        formatDate(trip.startDate)
+                    }
                     Text(
-                        text = formatDate(trip.startDate),
+                        text = subtitle,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 28.dp, top = 4.dp)
+                        modifier = Modifier.padding(start = 28.dp, top = 4.dp),
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                     )
                 }
             }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -386,17 +386,16 @@ private fun TripItem(
                             tint = MaterialTheme.colorScheme.primary
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        val customName = trip.name?.takeIf { it.isNotBlank() }
                         Text(
-                            text = customName ?: "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)}",
+                            text = trip.displayName(),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.weight(1f),
                             maxLines = 1
                         )
                     }
-                    val customName = trip.name?.takeIf { it.isNotBlank() }
-                    val subtitle = if (customName != null) {
+                    val hasCustomName = !trip.name.isNullOrBlank()
+                    val subtitle = if (hasCustomName) {
                         "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)} · ${formatDate(trip.startDate)}"
                     } else {
                         formatDate(trip.startDate)
@@ -580,6 +579,16 @@ private fun YearFilterChips(
 internal fun extractCity(address: String): String {
     val parts = address.split(", ")
     return if (parts.size >= 2) parts.last() else address
+}
+
+/**
+ * Canonical user-facing label for a trip.
+ * If the user set a custom name (non-blank), that wins everywhere — title bar, trips list,
+ * "Part of X" cards, merge sheet rows, etc. Falls back to "startCity → endCity" otherwise.
+ */
+internal fun Trip.displayName(): String {
+    val custom = name?.takeIf { it.isNotBlank() }
+    return custom ?: "${extractCity(startAddress)} → ${extractCity(endAddress)}"
 }
 
 private fun formatDuration(minutes: Int): String {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -45,12 +45,26 @@ class TripsViewModel @Inject constructor(
 
     private var carId: Int? = null
     private var allTrips: List<Trip> = emptyList()
+    private var hasBeenPaused = false
 
     fun setCarId(id: Int) {
         if (carId == id) return
         carId = id
         loadTrips(id)
         loadUnits(id)
+    }
+
+    /** Screen went to background (user navigated to a child). */
+    fun onScreenPaused() {
+        hasBeenPaused = true
+    }
+
+    /** Screen is resuming — reload trips if the user is returning from a child screen. */
+    fun onScreenResumed() {
+        val id = carId ?: return
+        if (!hasBeenPaused) return
+        hasBeenPaused = false
+        loadTrips(id)
     }
 
     /** Cache the trip before navigating to detail, avoiding re-detection. */

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1098,6 +1098,9 @@
     <string name="trip_rename_field_label">Nom del viatge</string>
     <string name="trip_rename_field_hint">Deixa-ho buit per usar el nom predeterminat</string>
     <string name="save">Desa</string>
+    <string name="add">Afegeix</string>
+    <string name="trip_edit_select_multiple">Selecciona\'n diversos</string>
+    <string name="trip_edit_selected_count">%d seleccionats</string>
 
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1088,6 +1088,11 @@
     <string name="trip_edit_delete_confirm_body">Això elimina els canvis. Els viatges detectats automàticament a dins reapareixeran.</string>
     <string name="delete">Elimina</string>
 
+    <string name="part_of_trip">Part de %s</string>
+    <string name="part_of_trip_remove">Treu</string>
+    <string name="part_of_trip_remove_confirm_title">Treure del viatge?</string>
+    <string name="part_of_trip_remove_confirm_body">Aquest tram ja no formarà part de %s.</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Selecciona l\'aspecte del cotxe</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1074,6 +1074,20 @@
     <string name="trip_timeline_charging_ac">Càrrega AC</string>
     <string name="trip_timeline_parked">Aparcat</string>
 
+    <string name="trip_edit_add_leg">Afegeix tram</string>
+    <string name="trip_edit_merge_trip">Uneix viatge</string>
+    <string name="trip_edit_add_leg_title">Afegeix a aquest viatge</string>
+    <string name="trip_edit_add_leg_empty">No hi ha trajectes o càrregues properes</string>
+    <string name="trip_edit_merge_title">Uneix un altre viatge</string>
+    <string name="trip_edit_merge_empty">Cap viatge en 2 setmanes</string>
+    <string name="trip_edit_merge_confirm_title">Unir els viatges?</string>
+    <string name="trip_edit_merge_confirm_body">Uneix aquests viatges en un. Pots desfer-ho eliminant el viatge unit.</string>
+    <string name="trip_edit_merge_confirm">Uneix</string>
+    <string name="trip_edit_delete">Elimina viatge</string>
+    <string name="trip_edit_delete_confirm_title">Eliminar aquest viatge?</string>
+    <string name="trip_edit_delete_confirm_body">Això elimina els canvis. Els viatges detectats automàticament a dins reapareixeran.</string>
+    <string name="delete">Elimina</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Selecciona l\'aspecte del cotxe</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1093,6 +1093,12 @@
     <string name="part_of_trip_remove_confirm_title">Treure del viatge?</string>
     <string name="part_of_trip_remove_confirm_body">Aquest tram ja no formarà part de %s.</string>
 
+    <string name="trip_rename_action">Canvia el nom</string>
+    <string name="trip_rename_dialog_title">Canvia el nom del viatge</string>
+    <string name="trip_rename_field_label">Nom del viatge</string>
+    <string name="trip_rename_field_hint">Deixa-ho buit per usar el nom predeterminat</string>
+    <string name="save">Desa</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Selecciona l\'aspecte del cotxe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1098,6 +1098,9 @@
     <string name="trip_rename_field_label">Nombre del viaje</string>
     <string name="trip_rename_field_hint">Deja vacío para usar el nombre predeterminado</string>
     <string name="save">Guardar</string>
+    <string name="add">Añadir</string>
+    <string name="trip_edit_select_multiple">Seleccionar varios</string>
+    <string name="trip_edit_selected_count">%d seleccionados</string>
 
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1093,6 +1093,12 @@
     <string name="part_of_trip_remove_confirm_title">¿Quitar del viaje?</string>
     <string name="part_of_trip_remove_confirm_body">Este tramo ya no formará parte de %s.</string>
 
+    <string name="trip_rename_action">Renombrar</string>
+    <string name="trip_rename_dialog_title">Renombrar viaje</string>
+    <string name="trip_rename_field_label">Nombre del viaje</string>
+    <string name="trip_rename_field_hint">Deja vacío para usar el nombre predeterminado</string>
+    <string name="save">Guardar</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleccionar aspecto del coche</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1088,6 +1088,11 @@
     <string name="trip_edit_delete_confirm_body">Esto elimina tus cambios. Los viajes detectados automáticamente dentro reaparecerán.</string>
     <string name="delete">Eliminar</string>
 
+    <string name="part_of_trip">Parte de %s</string>
+    <string name="part_of_trip_remove">Quitar</string>
+    <string name="part_of_trip_remove_confirm_title">¿Quitar del viaje?</string>
+    <string name="part_of_trip_remove_confirm_body">Este tramo ya no formará parte de %s.</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleccionar aspecto del coche</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1074,6 +1074,20 @@
     <string name="trip_timeline_charging_ac">Carga AC</string>
     <string name="trip_timeline_parked">Estacionado</string>
 
+    <string name="trip_edit_add_leg">Añadir tramo</string>
+    <string name="trip_edit_merge_trip">Combinar viaje</string>
+    <string name="trip_edit_add_leg_title">Añadir a este viaje</string>
+    <string name="trip_edit_add_leg_empty">Sin trayectos o cargas cercanos</string>
+    <string name="trip_edit_merge_title">Combinar otro viaje</string>
+    <string name="trip_edit_merge_empty">No hay viajes en 2 semanas</string>
+    <string name="trip_edit_merge_confirm_title">¿Combinar viajes?</string>
+    <string name="trip_edit_merge_confirm_body">Fusiona estos viajes en uno. Puedes deshacerlo eliminando el viaje combinado.</string>
+    <string name="trip_edit_merge_confirm">Combinar</string>
+    <string name="trip_edit_delete">Eliminar viaje</string>
+    <string name="trip_edit_delete_confirm_title">¿Eliminar este viaje?</string>
+    <string name="trip_edit_delete_confirm_body">Esto elimina tus cambios. Los viajes detectados automáticamente dentro reaparecerán.</string>
+    <string name="delete">Eliminar</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleccionar aspecto del coche</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1098,6 +1098,9 @@
     <string name="trip_rename_field_label">Nome viaggio</string>
     <string name="trip_rename_field_hint">Lascia vuoto per usare il nome predefinito</string>
     <string name="save">Salva</string>
+    <string name="add">Aggiungi</string>
+    <string name="trip_edit_select_multiple">Seleziona più tratte</string>
+    <string name="trip_edit_selected_count">%d selezionate</string>
 
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1088,6 +1088,11 @@
     <string name="trip_edit_delete_confirm_body">Questo annulla le modifiche. I viaggi rilevati automaticamente al suo interno riappariranno.</string>
     <string name="delete">Elimina</string>
 
+    <string name="part_of_trip">Parte di %s</string>
+    <string name="part_of_trip_remove">Rimuovi</string>
+    <string name="part_of_trip_remove_confirm_title">Rimuovere dal viaggio?</string>
+    <string name="part_of_trip_remove_confirm_body">Questa tratta non farà più parte di %s.</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleziona aspetto auto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1074,6 +1074,20 @@
     <string name="trip_timeline_charging_ac">Ricarica AC</string>
     <string name="trip_timeline_parked">In sosta</string>
 
+    <string name="trip_edit_add_leg">Aggiungi tratta</string>
+    <string name="trip_edit_merge_trip">Unisci viaggio</string>
+    <string name="trip_edit_add_leg_title">Aggiungi a questo viaggio</string>
+    <string name="trip_edit_add_leg_empty">Nessuna tratta o ricarica nelle vicinanze</string>
+    <string name="trip_edit_merge_title">Unisci un altro viaggio</string>
+    <string name="trip_edit_merge_empty">Nessun viaggio entro 2 settimane</string>
+    <string name="trip_edit_merge_confirm_title">Unire i viaggi?</string>
+    <string name="trip_edit_merge_confirm_body">Unisce questi viaggi in uno solo. Puoi annullare eliminando il viaggio unito.</string>
+    <string name="trip_edit_merge_confirm">Unisci</string>
+    <string name="trip_edit_delete">Elimina viaggio</string>
+    <string name="trip_edit_delete_confirm_title">Eliminare questo viaggio?</string>
+    <string name="trip_edit_delete_confirm_body">Questo annulla le modifiche. I viaggi rilevati automaticamente al suo interno riappariranno.</string>
+    <string name="delete">Elimina</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleziona aspetto auto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1093,6 +1093,12 @@
     <string name="part_of_trip_remove_confirm_title">Rimuovere dal viaggio?</string>
     <string name="part_of_trip_remove_confirm_body">Questa tratta non farà più parte di %s.</string>
 
+    <string name="trip_rename_action">Rinomina</string>
+    <string name="trip_rename_dialog_title">Rinomina viaggio</string>
+    <string name="trip_rename_field_label">Nome viaggio</string>
+    <string name="trip_rename_field_hint">Lascia vuoto per usare il nome predefinito</string>
+    <string name="save">Salva</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Seleziona aspetto auto</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1099,6 +1099,9 @@
     <string name="trip_rename_field_label">行程名称</string>
     <string name="trip_rename_field_hint">留空可使用默认名称</string>
     <string name="save">保存</string>
+    <string name="add">添加</string>
+    <string name="trip_edit_select_multiple">多选</string>
+    <string name="trip_edit_selected_count">已选 %d 项</string>
 
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1075,6 +1075,20 @@
     <string name="trip_timeline_charging_ac">AC 充电</string>
     <string name="trip_timeline_parked">已停车</string>
 
+    <string name="trip_edit_add_leg">添加行程段</string>
+    <string name="trip_edit_merge_trip">合并行程</string>
+    <string name="trip_edit_add_leg_title">添加到此行程</string>
+    <string name="trip_edit_add_leg_empty">附近没有驾驶或充电记录</string>
+    <string name="trip_edit_merge_title">合并另一个行程</string>
+    <string name="trip_edit_merge_empty">2 周内没有其他行程</string>
+    <string name="trip_edit_merge_confirm_title">合并行程？</string>
+    <string name="trip_edit_merge_confirm_body">将这些行程合并为一个。您可以通过删除合并后的行程来撤销。</string>
+    <string name="trip_edit_merge_confirm">合并</string>
+    <string name="trip_edit_delete">删除行程</string>
+    <string name="trip_edit_delete_confirm_title">删除此行程？</string>
+    <string name="trip_edit_delete_confirm_body">这将删除您的编辑。其中自动检测的行程将重新出现。</string>
+    <string name="delete">删除</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">选择车辆外观</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1089,6 +1089,11 @@
     <string name="trip_edit_delete_confirm_body">这将删除您的编辑。其中自动检测的行程将重新出现。</string>
     <string name="delete">删除</string>
 
+    <string name="part_of_trip">属于 %s</string>
+    <string name="part_of_trip_remove">移除</string>
+    <string name="part_of_trip_remove_confirm_title">从行程中移除？</string>
+    <string name="part_of_trip_remove_confirm_body">此行程段将不再属于 %s。</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">选择车辆外观</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1094,6 +1094,12 @@
     <string name="part_of_trip_remove_confirm_title">从行程中移除？</string>
     <string name="part_of_trip_remove_confirm_body">此行程段将不再属于 %s。</string>
 
+    <string name="trip_rename_action">重命名</string>
+    <string name="trip_rename_dialog_title">重命名行程</string>
+    <string name="trip_rename_field_label">行程名称</string>
+    <string name="trip_rename_field_hint">留空可使用默认名称</string>
+    <string name="save">保存</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">选择车辆外观</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1161,6 +1161,21 @@
     <!-- Dialog body explaining the consequence. %s is the trip route. -->
     <string name="part_of_trip_remove_confirm_body">This leg will no longer be part of %s.</string>
 
+    <!-- Content description and tooltip for the pencil icon that opens the rename dialog -->
+    <string name="trip_rename_action">Rename</string>
+
+    <!-- Title of the rename dialog -->
+    <string name="trip_rename_dialog_title">Rename trip</string>
+
+    <!-- Label/placeholder for the text field inside the rename dialog -->
+    <string name="trip_rename_field_label">Trip name</string>
+
+    <!-- Hint text below the rename text field explaining that clearing it restores the default label -->
+    <string name="trip_rename_field_hint">Leave empty to use the default name</string>
+
+    <!-- Generic Save button label used in dialogs -->
+    <string name="save">Save</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1110,6 +1110,45 @@
     <!-- Tooltip label for a parking gap segment on the trip timeline (time between legs when the car is idle) -->
     <string name="trip_timeline_parked">Parked</string>
 
+    <!-- Button label: opens a bottom sheet to add a drive or charge to this trip -->
+    <string name="trip_edit_add_leg">Add leg</string>
+
+    <!-- Button label: opens a bottom sheet to merge another trip into this one -->
+    <string name="trip_edit_merge_trip">Merge trip</string>
+
+    <!-- Bottom sheet title for picking a drive or charge to add -->
+    <string name="trip_edit_add_leg_title">Add to this trip</string>
+
+    <!-- Empty-state message when no eligible drives or charges are nearby -->
+    <string name="trip_edit_add_leg_empty">No nearby drives or charges</string>
+
+    <!-- Bottom sheet title for picking another trip to merge with -->
+    <string name="trip_edit_merge_title">Merge another trip</string>
+
+    <!-- Empty-state message when no adjacent trips exist within the 2-week window -->
+    <string name="trip_edit_merge_empty">No trips within 2 weeks</string>
+
+    <!-- Confirmation dialog title before merging two trips -->
+    <string name="trip_edit_merge_confirm_title">Merge trips?</string>
+
+    <!-- Confirmation dialog body — explains that the user can undo by deleting the merged trip -->
+    <string name="trip_edit_merge_confirm_body">Combine these trips into one. You can undo by deleting the merged trip.</string>
+
+    <!-- Primary action label on the merge confirmation dialog -->
+    <string name="trip_edit_merge_confirm">Merge</string>
+
+    <!-- Overflow menu action: delete the currently viewed trip -->
+    <string name="trip_edit_delete">Delete trip</string>
+
+    <!-- Confirmation dialog title before deleting a saved trip -->
+    <string name="trip_edit_delete_confirm_title">Delete this trip?</string>
+
+    <!-- Confirmation dialog body — explains that auto-detected originals will come back -->
+    <string name="trip_edit_delete_confirm_body">This removes your edits. Auto-detected trips inside will reappear.</string>
+
+    <!-- Generic delete button label -->
+    <string name="delete">Delete</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1149,6 +1149,18 @@
     <!-- Generic delete button label -->
     <string name="delete">Delete</string>
 
+    <!-- Card on drive/charge detail: informs the user this leg belongs to a saved trip. %s is the trip route like "Rome → Paris". -->
+    <string name="part_of_trip">Part of %s</string>
+
+    <!-- Button on the part-of-trip card: detach this leg from the trip -->
+    <string name="part_of_trip_remove">Remove</string>
+
+    <!-- Dialog title when the user taps Remove on the part-of-trip card -->
+    <string name="part_of_trip_remove_confirm_title">Remove from trip?</string>
+
+    <!-- Dialog body explaining the consequence. %s is the trip route. -->
+    <string name="part_of_trip_remove_confirm_body">This leg will no longer be part of %s.</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1176,6 +1176,15 @@
     <!-- Generic Save button label used in dialogs -->
     <string name="save">Save</string>
 
+    <!-- Generic Add button label used in selection UIs -->
+    <string name="add">Add</string>
+
+    <!-- Content description of the icon in the Add-leg sheet header that switches to multi-select mode -->
+    <string name="trip_edit_select_multiple">Select multiple</string>
+
+    <!-- Title shown in multi-select mode indicating how many legs are currently selected -->
+    <string name="trip_edit_selected_count">%d selected</string>
+
     <!-- ==================== Car Image Picker ==================== -->
     <!-- Dialog title for selecting car appearance (long-press on car image) -->
     <string name="car_picker_title">Select Car Appearance</string>


### PR DESCRIPTION
## Summary
Two new 50/50 buttons below the legs list on the trip detail screen:

- **Add leg** — bottom sheet listing drives and charges within ±2 days of the trip's edges that aren't already part of any saved trip. Pick one; it's inserted chronologically. Trip transitions to `USER_EDITED`, its pre-edit fingerprint moves to the consumed set.
- **Merge trip** — bottom sheet listing saved trips within ±14 days; after confirmation, combines them into a `USER_MERGED` trip with all drives and charges (AC included) between them auto-included. Both sources' fingerprints are inherited into the new trip's consumed set, then the originals are deleted.

Delete a trip via the top-bar overflow menu — cascade removes its consumed fingerprints, letting the auto-detector re-emit the originals (implicit undo).

Alongside:
- `TripRepository.getTrips` now loads the full charge table so AC legs resolve
- `TripTimelineBuilder` accepts the DC charge-id set, so AC charges render in green and DC in orange
- `ChargeLegCard` gets a small AC/DC chip using `palette.acColor`/`dcColor`
- Map draws a dashed connector between legs whose geographic gap > 10 km (transported cars / non-contiguous merged trips)
- 13 new strings in all 5 locales (en, it, es, ca, zh). AC/DC left untranslated per project convention.

## Test plan

### Add leg
- [ ] Open a trip. Tap "Add leg" → sheet opens with ±2-day candidates. Empty state when none.
- [ ] Pick a drive. Sheet closes; leg appears in the list and timeline immediately.
- [ ] Pick an AC charge. Its row and timeline segment are green (AC color).
- [ ] Relaunch app, trip still has the added leg.
- [ ] DB: `SELECT source FROM saved_trips WHERE id=X` → `USER_EDITED`; `SELECT COUNT(*) FROM saved_trip_consumed_fingerprints` increased by 1.

### Merge trip
- [ ] Open a trip with an adjacent (±14d) saved trip. Tap "Merge trip" → sheet lists the adjacent trip(s).
- [ ] Pick one → confirmation dialog. Cancel does nothing. Confirm merges and reloads the screen showing the combined trip.
- [ ] Trips list no longer shows either source; shows the merged one.
- [ ] DB: `source = USER_MERGED`; `saved_trip_consumed_fingerprints` includes both originals' fingerprints.

### Undo (delete)
- [ ] Open the merged trip → overflow → Delete → confirm. Navigates back to the trips list.
- [ ] Both original auto-detected trips reappear on next screen load (or immediately).
- [ ] DB: the `saved_trips` row is gone; cascaded `saved_trip_legs` and `saved_trip_consumed_fingerprints` also gone.

### Dashed connector
- [ ] Merge two geographically-distant trips (different cities, >10 km apart). Map shows a dashed line between the end of the earlier trip's GPS trail and the start of the later one's.
- [ ] Two trips from the same area: no dashed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)