### PR TITLE
fix: don't show DC unplug warning for AC charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Trip persistence**: Trips are now stored as first-class database entities. Auto-detected trips are silently persisted on first detection, unlocking the ability to edit and merge trips in a future update. No visible change for users.
 
+### Fixed
+- **DC unplug warning mis-firing on AC**: The warning to unplug after a DC session was also showing after AC sessions completed while plugged in. TeslaMate reports `charger_phases=null` after any session, so the old heuristic "null phases = DC" misclassified AC completions. The DC session type is now persisted while the session is active and reused after completion.
+
 ## [1.5.0] - 2026-04-15
 
 ### Added

--- a/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
+++ b/app/src/main/java/com/matedroid/data/api/models/CarModels.kt
@@ -103,7 +103,14 @@ data class CarStatus(
     val chargeCurrentRequestMax: Int? get() = chargingDetails?.chargeCurrentRequestMax
     val isDcCharging: Boolean get() = chargingDetails?.isDcCharging ?: false
     val isChargeComplete: Boolean get() = chargingState?.lowercase() == "complete"
-    val isDcFinishedPluggedIn: Boolean get() = isChargeComplete && pluggedIn == true && isDcCharging
+    /**
+     * True when a session has completed and the cable is still plugged in.
+     * Whether that session was DC (and therefore whether to show the unplug
+     * warning) can't be determined from this snapshot alone — callers must
+     * combine this with a persistent DC-session flag, since `charger_phases`
+     * is null after any completion regardless of charge type.
+     */
+    val isChargeCompletePluggedIn: Boolean get() = isChargeComplete && pluggedIn == true
     val timeToFullCharge: Double? get() = chargingDetails?.timeToFullCharge
 
     /** Parse stateSince ISO timestamp to epoch milliseconds. */
@@ -212,11 +219,13 @@ data class ChargingDetails(
     @Json(name = "time_to_full_charge") val timeToFullCharge: Double? = null
 ) {
     /**
-     * Detect if this is DC charging using Teslamate's logic:
-     * DC charging has charger_phases = 0 or null (bypasses onboard charger)
+     * True only while *actively* DC charging. The TeslaMate API reports
+     * `charger_phases=0` during an active DC session; AC reports 1, 2, or 3.
+     * After any session completes `charger_phases` goes to null — don't treat
+     * null as DC, or AC completions get misclassified.
      */
     val isDcCharging: Boolean
-        get() = chargerPhases == null || chargerPhases == 0
+        get() = chargerPhases == 0
     /**
      * Actual number of AC phases:
      * 1 -> monophase

--- a/app/src/main/java/com/matedroid/data/local/ChargeSessionStateDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/ChargeSessionStateDataStore.kt
@@ -1,0 +1,51 @@
+package com.matedroid.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.chargeSessionDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "charge_session_state"
+)
+
+/**
+ * Persists whether a car's most recent *active* charging session was DC.
+ *
+ * TeslaMate only reports `charger_phases = 0` while actively DC charging; after
+ * completion `charger_phases` goes to null regardless of charge type, so we
+ * can't distinguish an AC completion from a DC completion from a single
+ * status snapshot. This store remembers the last active session's type so
+ * the "DC finished, cable plugged in" warning only fires for real DC sessions.
+ *
+ * Callers should:
+ *  - set `dcActive = true` when a status shows `isCharging && isDcCharging`
+ *  - set `dcActive = false` (clear) once the cable is unplugged
+ */
+@Singleton
+class ChargeSessionStateDataStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private fun wasDcKey(carId: Int) = booleanPreferencesKey("was_dc_$carId")
+
+    suspend fun wasLastSessionDc(carId: Int): Boolean {
+        return context.chargeSessionDataStore.data
+            .map { it[wasDcKey(carId)] ?: false }
+            .first()
+    }
+
+    suspend fun setLastSessionDc(carId: Int, isDc: Boolean) {
+        context.chargeSessionDataStore.edit { it[wasDcKey(carId)] = isDc }
+    }
+
+    suspend fun clear(carId: Int) {
+        context.chargeSessionDataStore.edit { it.remove(wasDcKey(carId)) }
+    }
+}

--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -12,6 +12,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.SentryEvent
@@ -40,7 +41,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val chargingNotificationManager: ChargingNotificationManager,
     private val sentryStateRepository: SentryStateRepository,
-    private val sentryNotificationManager: SentryNotificationManager
+    private val sentryNotificationManager: SentryNotificationManager,
+    private val chargeSessionStateDataStore: ChargeSessionStateDataStore
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -198,6 +200,17 @@ class ChargingNotificationWorker @AssistedInject constructor(
 
         val status = statusData.status ?: return
 
+        // Persist whether the active session is DC; this is the only moment we can
+        // tell (post-completion `charger_phases` is null regardless of charge type).
+        if (status.isCharging && status.isDcCharging) {
+            chargeSessionStateDataStore.setLastSessionDc(carId, true)
+        } else if (status.pluggedIn == false) {
+            chargeSessionStateDataStore.clear(carId)
+        }
+
+        val dcFinishedPluggedIn = status.isChargeCompletePluggedIn &&
+            chargeSessionStateDataStore.wasLastSessionDc(carId)
+
         // --- Charging ---
         if (status.isCharging) {
             Log.d(TAG, "Car $carId is charging at ${status.batteryLevel}%")
@@ -213,7 +226,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
                     chronometerBaseMs = status.stateSinceEpochMs
                 )
             }
-        } else if (status.isDcFinishedPluggedIn) {
+        } else if (dcFinishedPluggedIn) {
             // DC charge finished but cable still plugged — keep service alive
             Log.d(TAG, "Car $carId DC charge finished but still plugged in")
             try {

--- a/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
+++ b/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.matedroid.R
+import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
@@ -55,6 +56,7 @@ class ChargingMonitorService : Service() {
     @Inject lateinit var teslamateRepository: TeslamateRepository
     @Inject lateinit var settingsDataStore: SettingsDataStore
     @Inject lateinit var chargingNotificationManager: ChargingNotificationManager
+    @Inject lateinit var chargeSessionStateDataStore: ChargeSessionStateDataStore
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var monitorJob: Job? = null
@@ -62,8 +64,6 @@ class ChargingMonitorService : Service() {
     private val maxConsecutiveFailures = 3
     private var isMonitoring = false
     private val activeNotificationCarIds = mutableSetOf<Int>()
-    // Track which cars were DC charging (safety net for isDcCharging after completion)
-    private val dcChargingCarIds = mutableSetOf<Int>()
 
     override fun onCreate() {
         super.onCreate()
@@ -247,11 +247,21 @@ class ChargingMonitorService : Service() {
 
                 val notificationId = ChargingNotificationManager.NOTIFICATION_ID_BASE + car.carId
 
+                // Only `isCharging && phases == 0` confirms DC. After completion phases
+                // is null for any charge type, so we persist the in-session flag.
+                if (status.isCharging && status.isDcCharging) {
+                    chargeSessionStateDataStore.setLastSessionDc(car.carId, true)
+                } else if (status.pluggedIn == false) {
+                    chargeSessionStateDataStore.clear(car.carId)
+                }
+
+                val wasDcSession = chargeSessionStateDataStore.wasLastSessionDc(car.carId)
+                val dcFinishedPluggedIn = status.isChargeCompletePluggedIn && wasDcSession
+
                 when {
                     status.isCharging -> {
                         anyCharging = true
                         activeNotificationCarIds.add(car.carId)
-                        if (status.isDcCharging) dcChargingCarIds.add(car.carId) else dcChargingCarIds.remove(car.carId)
                         Log.d(TAG, "Car ${car.carId} charging at ${status.batteryLevel}%")
 
                         val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(car.carId)
@@ -262,7 +272,7 @@ class ChargingMonitorService : Service() {
                         updateForegroundNotification(notificationId, notification, car, status, liveChargeAvailable)
                     }
 
-                    status.isDcFinishedPluggedIn || (status.pluggedIn == true && status.isChargeComplete && dcChargingCarIds.contains(car.carId)) -> {
+                    dcFinishedPluggedIn -> {
                         // DC charge finished but cable still plugged — keep notification alive
                         anyCharging = true
                         activeNotificationCarIds.add(car.carId)
@@ -278,7 +288,6 @@ class ChargingMonitorService : Service() {
 
                     else -> {
                         activeNotificationCarIds.remove(car.carId)
-                        dcChargingCarIds.remove(car.carId)
                         chargingNotificationManager.cancelNotification(car.carId)
                     }
                 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.ChargePoint
 import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -38,7 +39,8 @@ data class CurrentChargeUiState(
 
 @HiltViewModel
 class CurrentChargeViewModel @Inject constructor(
-    private val repository: TeslamateRepository
+    private val repository: TeslamateRepository,
+    private val chargeSessionStateDataStore: ChargeSessionStateDataStore
 ) : ViewModel() {
 
     companion object {
@@ -93,14 +95,19 @@ class CurrentChargeViewModel @Inject constructor(
             is ApiResult.Success -> statusResult.data.status.isDcCharging
             is ApiResult.Error -> null  // No status data available -> assume AC
         }
-        val isDcFinishedPluggedIn = when (statusResult) {
-            is ApiResult.Success -> statusResult.data.status.isDcFinishedPluggedIn
-            is ApiResult.Error -> false
+        val status = (statusResult as? ApiResult.Success)?.data?.status
+
+        // Persist the DC flag while the session is still live; post-completion we can
+        // only tell whether a session was DC from this stored value.
+        if (status?.isCharging == true && status.isDcCharging) {
+            chargeSessionStateDataStore.setLastSessionDc(carId, true)
+        } else if (status?.pluggedIn == false) {
+            chargeSessionStateDataStore.clear(carId)
         }
-        val stateSince = when (statusResult) {
-            is ApiResult.Success -> statusResult.data.status.stateSince
-            is ApiResult.Error -> null
-        }
+
+        val wasDcSession = chargeSessionStateDataStore.wasLastSessionDc(carId)
+        val isDcFinishedPluggedIn = status?.isChargeCompletePluggedIn == true && wasDcSession
+        val stateSince = status?.stateSince
 
         when (chargeResult) {
             is ApiResult.Success -> {

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -248,6 +248,7 @@ fun DashboardScreen(
                         carImageOverrides = uiState.carImageOverrides,
                         isCurrentChargeAvailable = uiState.isCurrentChargeAvailable,
                         sentryEventCount = uiState.sentryEventCount,
+                        dcFinishedPluggedIn = uiState.dcFinishedPluggedIn,
                         onNavigateToCharges = {
                             uiState.selectedCarId?.let { carId ->
                                 onNavigateToCharges(carId, uiState.selectedCarExterior?.exteriorColor)
@@ -451,6 +452,7 @@ private fun DashboardContent(
     carImageOverrides: Map<Int, CarImageOverride> = emptyMap(),
     isCurrentChargeAvailable: Boolean = false,
     sentryEventCount: Int = 0,
+    dcFinishedPluggedIn: Boolean = false,
     onNavigateToCharges: () -> Unit = {},
     onNavigateToDrives: () -> Unit = {},
     onNavigateToBattery: () -> Unit = {},
@@ -517,7 +519,7 @@ private fun DashboardContent(
         )
 
         // DC charge finished but still plugged in warning
-        if (status.isDcFinishedPluggedIn) {
+        if (dcFinishedPluggedIn) {
             DcUnplugWarningBanner(dcFinishedSince = status.stateSince)
         }
 

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -7,6 +7,7 @@ import com.matedroid.data.api.models.CarExterior
 import com.matedroid.data.api.models.CarStatus
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.CarImageOverride
+import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TripCountCache
 import com.matedroid.domain.TripRepository
@@ -42,7 +43,8 @@ data class DashboardUiState(
     val carImageOverrides: Map<Int, CarImageOverride> = emptyMap(),
     val isCurrentChargeAvailable: Boolean = false,
     val sentryEventCount: Int = 0,
-    val totalTrips: Int? = null
+    val totalTrips: Int? = null,
+    val dcFinishedPluggedIn: Boolean = false
 ) {
     private val selectedCar: CarData?
         get() = cars.find { it.carId == selectedCarId }
@@ -73,7 +75,8 @@ class DashboardViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val sentryStateRepository: SentryStateRepository,
     private val tripRepository: TripRepository,
-    private val tripCountCache: TripCountCache
+    private val tripCountCache: TripCountCache,
+    private val chargeSessionStateDataStore: ChargeSessionStateDataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DashboardUiState())
@@ -183,10 +186,12 @@ class DashboardViewModel @Inject constructor(
             when (val result = repository.getCarStatus(carId)) {
                 is ApiResult.Success -> {
                     val status = result.data.status
+                    val dcFinishedPluggedIn = trackAndComputeDcFinishedPluggedIn(carId, status)
                     _uiState.update {
                         it.copy(
                             carStatus = status,
                             units = result.data.units,
+                            dcFinishedPluggedIn = dcFinishedPluggedIn,
                             error = null
                         )
                     }
@@ -206,10 +211,12 @@ class DashboardViewModel @Inject constructor(
             when (val result = repository.getCarStatus(carId)) {
                 is ApiResult.Success -> {
                     val status = result.data.status
+                    val dcFinishedPluggedIn = trackAndComputeDcFinishedPluggedIn(carId, status)
                     _uiState.update {
                         it.copy(
                             carStatus = status,
                             units = result.data.units,
+                            dcFinishedPluggedIn = dcFinishedPluggedIn,
                             error = null
                         )
                     }
@@ -225,6 +232,20 @@ class DashboardViewModel @Inject constructor(
         }
         loadCounts(carId)
         startAutoRefresh(carId)
+    }
+
+    /**
+     * Persists the in-session DC flag so we can still identify the charge type
+     * after completion (when `charger_phases` is null for both AC and DC).
+     * Returns whether the unplug warning should be shown for this status.
+     */
+    private suspend fun trackAndComputeDcFinishedPluggedIn(carId: Int, status: CarStatus): Boolean {
+        if (status.isCharging && status.isDcCharging) {
+            chargeSessionStateDataStore.setLastSessionDc(carId, true)
+        } else if (status.pluggedIn == false) {
+            chargeSessionStateDataStore.clear(carId)
+        }
+        return status.isChargeCompletePluggedIn && chargeSessionStateDataStore.wasLastSessionDc(carId)
     }
 
     private fun loadCounts(carId: Int) {
@@ -276,10 +297,12 @@ class DashboardViewModel @Inject constructor(
                 when (val result = repository.getCarStatus(carId)) {
                     is ApiResult.Success -> {
                         val status = result.data.status
+                        val dcFinishedPluggedIn = trackAndComputeDcFinishedPluggedIn(carId, status)
                         _uiState.update {
                             it.copy(
                                 carStatus = status,
-                                units = result.data.units
+                                units = result.data.units,
+                                dcFinishedPluggedIn = dcFinishedPluggedIn
                             )
                         }
                         // Update address if location changed

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -103,7 +103,7 @@ class DashboardViewModelTest {
     private fun createViewModel(): DashboardViewModel {
         return DashboardViewModel(
             repository, geocodingRepository, settingsDataStore, sentryStateRepository,
-            mockk(relaxed = true), mockk(relaxed = true)
+            mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true)
         )
     }
 

--- a/app/src/test/java/com/matedroid/widget/CarWidgetDisplayDataTest.kt
+++ b/app/src/test/java/com/matedroid/widget/CarWidgetDisplayDataTest.kt
@@ -143,17 +143,34 @@ class CarWidgetDisplayDataTest {
     }
 
     @Test
-    fun dcCharging_isDcCharging_whenPhasesNull() {
+    fun dcCharging_isDcCharging_whenPhasesZero() {
         val car = buildFullCarData()
         val status = buildFullStatus().copy(
             chargingDetails = buildFullStatus().chargingDetails!!.copy(
-                chargerPhases = null   // DC charging: no phases
+                chargerPhases = 0   // Active DC charging reports phases=0
             )
         )
 
         val data = CarWidgetDisplayData.from(car, status)
 
         assertTrue(data.isDcCharging)
+        assertNull(data.acPhases)
+    }
+
+    @Test
+    fun notCharging_phasesNull_isNotDcCharging() {
+        // `charger_phases` is null both before charging starts and after any session
+        // completes, regardless of type — treating null as DC misclassifies AC completions.
+        val car = buildFullCarData()
+        val status = buildFullStatus().copy(
+            chargingDetails = buildFullStatus().chargingDetails!!.copy(
+                chargerPhases = null
+            )
+        )
+
+        val data = CarWidgetDisplayData.from(car, status)
+
+        assertTrue(!data.isDcCharging)
         assertNull(data.acPhases)
     }
 


### PR DESCRIPTION
## Summary
- Root cause: `ChargingDetails.isDcCharging` returned true when `charger_phases == null`, but TeslaMate reports `charger_phases=null` after any session completes (AC or DC). So an AC session completing with the cable still plugged in tripped `isDcFinishedPluggedIn` and showed the DC unplug warning.
- Narrowed `isDcCharging` to `charger_phases == 0` — the only reliable in-session DC signal.
- Added `ChargeSessionStateDataStore` to persist per-car "last observed active session was DC". The flag is written while the session is active and read after completion, since a single post-completion snapshot can't tell AC from DC.
- `Status.isDcFinishedPluggedIn` was removable (not derivable from a snapshot); replaced by `Status.isChargeCompletePluggedIn` plus the persistent flag. Callers updated: `ChargingMonitorService`, `ChargingNotificationWorker`, `CurrentChargeViewModel`, `DashboardViewModel`/`DashboardScreen`.

## Test plan
- [ ] Plug in with AC, let the charge complete, leave the cable plugged — warning should NOT appear (dashboard banner, current-charge screen, notification).
- [ ] Plug in with DC, let the charge complete, leave the cable plugged — warning should appear as before.
- [ ] Unplug after either AC or DC — warning clears and the persistent DC flag resets.
- [ ] Widget and notification AC/DC distinction still correct during active charging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)