### PR TITLE
feat(trip-detail): cost/efficiency pills, horizontal battery flow, weather sparkline

### DIFF
--- a/app/src/main/java/com/matedroid/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/WeatherRepository.kt
@@ -9,6 +9,9 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.pow
@@ -340,4 +343,124 @@ class WeatherRepository @Inject constructor(
 
         return earthRadiusKm * c
     }
+
+    // ========================================================================
+    // Trip-level weather sampling (used by TripDetailScreen)
+    // ========================================================================
+
+    /**
+     * Fetches weather samples along a trip's drive timeline.
+     *
+     * Sampling: ~1 per hour of drive time, clamped to [3, 12]. Stationary periods
+     * (parking / charging) are skipped — we only sample actual driving.
+     *
+     * Timestamps for the route points are interpolated linearly between each drive's
+     * startDate/endDate since the cached route points don't carry per-point times.
+     *
+     * @param drives The trip's drives (chronological order, same order as route segments)
+     * @param routeSegments One segment per drive (may be empty on cache miss)
+     * @return Samples with fetched weather, or empty list on total failure.
+     */
+    suspend fun getWeatherAlongTrip(
+        drives: List<com.matedroid.data.local.entity.DriveSummary>,
+        routeSegments: List<com.matedroid.ui.screens.trips.TripRouteSegment>
+    ): List<TripWeatherPoint> {
+        if (drives.isEmpty() || routeSegments.isEmpty()) return emptyList()
+
+        // Build a (timestamp, lat, lon) list across all drive points, with timestamps
+        // interpolated evenly between each drive's startDate/endDate.
+        data class TimedPoint(val epochMillis: Long, val lat: Double, val lon: Double)
+        val allPoints = mutableListOf<TimedPoint>()
+        drives.forEachIndexed { driveIdx, drive ->
+            val segment = routeSegments.getOrNull(driveIdx) ?: return@forEachIndexed
+            val pts = segment.points
+            if (pts.isEmpty()) return@forEachIndexed
+            val ds = parseDateTime(drive.startDate)?.atZone(java.time.ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
+                ?: return@forEachIndexed
+            val de = parseDateTime(drive.endDate)?.atZone(java.time.ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
+                ?: return@forEachIndexed
+            val dur = (de - ds).coerceAtLeast(1L)
+            val n = pts.size
+            pts.forEachIndexed { i, pt ->
+                val t = if (n > 1) ds + (dur.toDouble() * i / (n - 1)).toLong() else ds
+                allPoints.add(TimedPoint(t, pt.latitude, pt.longitude))
+            }
+        }
+        if (allPoints.isEmpty()) return emptyList()
+
+        // Sample count: ~1 per hour of drive, clamped [3, 12]
+        val totalDriveMin = drives.sumOf { it.durationMin }
+        val hours = totalDriveMin / 60.0
+        val sampleCount = hours.toInt().coerceIn(3, 12)
+
+        // Evenly sample indices across allPoints
+        val samples = (0 until sampleCount).map { i ->
+            val denom = (sampleCount - 1).coerceAtLeast(1).toDouble()
+            val idx = ((i / denom) * (allPoints.size - 1)).toInt().coerceIn(0, allPoints.size - 1)
+            allPoints[idx]
+        }
+
+        // Fetch weather for each sample in parallel
+        return coroutineScope {
+            val deferreds = samples.map { sample ->
+                async { fetchTripWeatherAtSample(sample.epochMillis, sample.lat, sample.lon) }
+            }
+            deferreds.awaitAll().filterNotNull()
+        }
+    }
+
+    private suspend fun fetchTripWeatherAtSample(
+        epochMillis: Long,
+        lat: Double,
+        lon: Double
+    ): TripWeatherPoint? {
+        val dt = java.time.Instant.ofEpochMilli(epochMillis)
+            .atZone(java.time.ZoneId.systemDefault())
+            .toLocalDateTime()
+        val dateStr = dt.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        val hour = dt.hour
+        return try {
+            val response = openMeteoApi.getHistoricalWeather(
+                latitude = lat,
+                longitude = lon,
+                startDate = dateStr,
+                endDate = dateStr
+            )
+            if (!response.isSuccessful) return null
+            val body = response.body() ?: return null
+            val hourly = body.hourly ?: return null
+            val idx = hourly.time?.indexOfFirst { timeStr ->
+                try {
+                    LocalDateTime.parse(timeStr).hour == hour
+                } catch (_: Exception) { false }
+            } ?: -1
+            if (idx < 0) return null
+            val temp = hourly.temperature2m?.getOrNull(idx) ?: return null
+            val code = hourly.weatherCode?.getOrNull(idx) ?: 0
+            TripWeatherPoint(
+                timestamp = dt,
+                latitude = lat,
+                longitude = lon,
+                temperatureCelsius = temp,
+                weatherCode = code,
+                weatherCondition = WeatherCondition.fromWmoCode(code)
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Trip weather fetch failed at $lat,$lon", e)
+            null
+        }
+    }
 }
+
+/**
+ * A weather sample along a trip: when, where, temperature, and condition.
+ */
+@androidx.compose.runtime.Immutable
+data class TripWeatherPoint(
+    val timestamp: LocalDateTime,
+    val latitude: Double,
+    val longitude: Double,
+    val temperatureCelsius: Double,
+    val weatherCode: Int,
+    val weatherCondition: WeatherCondition
+)

--- a/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
@@ -1,0 +1,360 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.matedroid.R
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.repository.TripWeatherPoint
+import com.matedroid.data.repository.WeatherCondition
+import com.matedroid.ui.icons.CustomIcons
+import com.matedroid.ui.theme.CarColorPalette
+import androidx.compose.ui.res.stringResource
+import java.time.format.DateTimeFormatter
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * A temperature sparkline for a trip: temperature over time as a smoothed line with an
+ * area fill, weather condition icons floating on the line at each sample, and temp labels
+ * above each icon. Y-axis shows 3 temp ticks, X-axis shows start/end clock times.
+ *
+ * Hides itself if [samples] is empty.
+ */
+@Composable
+fun TripWeatherSparklineCard(
+    samples: List<TripWeatherPoint>,
+    palette: CarColorPalette,
+    units: Units?,
+    modifier: Modifier = Modifier
+) {
+    if (samples.isEmpty()) return
+
+    val isFahrenheit = units?.unitOfTemperature == "F"
+    val tempUnitLabel = if (isFahrenheit) "°F" else "°C"
+    fun displayTemp(c: Double): Double = if (isFahrenheit) c * 1.8 + 32 else c
+
+    // Derive Y-axis range with a small margin so the line never touches the top/bottom.
+    val displayedTemps = remember(samples, isFahrenheit) { samples.map { displayTemp(it.temperatureCelsius) } }
+    val minTemp = displayedTemps.min()
+    val maxTemp = displayedTemps.max()
+    val spanBase = (maxTemp - minTemp).coerceAtLeast(if (isFahrenheit) 10.0 else 6.0)
+    val padY = spanBase * 0.18
+    val axisMin = minTemp - padY
+    val axisMax = maxTemp + padY
+    val axisSpan = (axisMax - axisMin).coerceAtLeast(1.0)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = CustomIcons.WeatherPartlyCloudy,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.weather_during_trip),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+
+            Sparkline(
+                samples = samples,
+                displayedTemps = displayedTemps,
+                axisMin = axisMin,
+                axisSpan = axisSpan,
+                tempUnitLabel = tempUnitLabel,
+                palette = palette
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            // Endpoints row — first and last sample times for context
+            val first = samples.first()
+            val last = samples.last()
+            val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = first.timestamp.format(timeFmt),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = last.timestamp.format(timeFmt),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Sparkline(
+    samples: List<TripWeatherPoint>,
+    displayedTemps: List<Double>,
+    axisMin: Double,
+    axisSpan: Double,
+    tempUnitLabel: String,
+    palette: CarColorPalette
+) {
+    val chartHeight = 120.dp
+    val labelHeight = 22.dp  // reserved above the chart for temp labels
+    val totalHeight = chartHeight + labelHeight
+    val yAxisWidth = 28.dp
+    val chartRightPad = 6.dp
+
+    val density = LocalDensity.current
+    val axisColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f)
+    val gridColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)
+    val lineColor = palette.accent
+    val textMeasurer = rememberTextMeasurer()
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(totalHeight)
+    ) {
+        val totalW = maxWidth
+        val chartRegionLeftDp = yAxisWidth
+        val chartRegionWidthDp = totalW - yAxisWidth - chartRightPad
+
+        val yAxisWidthPx = with(density) { yAxisWidth.toPx() }
+        val chartRightPadPx = with(density) { chartRightPad.toPx() }
+        val labelHeightPx = with(density) { labelHeight.toPx() }
+
+        // Normalized [0..1] position of each sample along x and y.
+        val xs = remember(samples) {
+            if (samples.size <= 1) listOf(0.5f) else samples.indices.map { it.toFloat() / (samples.size - 1) }
+        }
+        val ys = remember(displayedTemps, axisMin, axisSpan) {
+            displayedTemps.map { t ->
+                val frac = ((t - axisMin) / axisSpan).toFloat().coerceIn(0f, 1f)
+                1f - frac  // invert — higher temp → lower y (drawn near top)
+            }
+        }
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val chartLeftPx = yAxisWidthPx
+            val chartTopPx = labelHeightPx
+            val chartRightPx = size.width - chartRightPadPx
+            val chartBottomPx = size.height
+            val chartWPx = chartRightPx - chartLeftPx
+            val chartHPx = chartBottomPx - chartTopPx
+
+            // Y-axis gridlines (top, middle, bottom)
+            for (frac in listOf(0f, 0.5f, 1f)) {
+                val y = chartTopPx + chartHPx * frac
+                drawLine(
+                    color = gridColor,
+                    start = Offset(chartLeftPx, y),
+                    end = Offset(chartRightPx, y),
+                    strokeWidth = 1f
+                )
+            }
+
+            // Y-axis labels (max, mid, min) — rendered right-aligned into the y-axis gutter
+            val axisMax = axisMin + axisSpan
+            val axisMid = axisMin + axisSpan / 2.0
+            fun drawYAxisLabel(value: Double, y: Float, alignTop: Boolean) {
+                val text = "${value.toInt()}$tempUnitLabel"
+                val layout = textMeasurer.measure(
+                    text = text,
+                    style = TextStyle(fontSize = 9.sp, textAlign = TextAlign.End)
+                )
+                val yOffset = if (alignTop) 0f else -layout.size.height.toFloat()
+                drawText(
+                    textLayoutResult = layout,
+                    color = axisColor,
+                    topLeft = Offset(
+                        x = chartLeftPx - 6.dp.toPx() - layout.size.width,
+                        y = y + yOffset
+                    )
+                )
+            }
+            drawYAxisLabel(axisMax, chartTopPx, alignTop = true)
+            drawYAxisLabel(axisMid, chartTopPx + chartHPx / 2f, alignTop = true)
+            drawYAxisLabel(axisMin, chartTopPx + chartHPx, alignTop = false)
+
+            // Build the smoothed line through (xs, ys) via Catmull-Rom-like cubic bezier tangents.
+            val pointsPx = xs.zip(ys) { xNorm, yNorm ->
+                Offset(
+                    chartLeftPx + chartWPx * xNorm,
+                    chartTopPx + chartHPx * yNorm
+                )
+            }
+            if (pointsPx.isEmpty()) return@Canvas
+
+            val linePath = Path()
+            val areaPath = Path()
+            linePath.moveTo(pointsPx.first().x, pointsPx.first().y)
+            areaPath.moveTo(pointsPx.first().x, chartBottomPx)
+            areaPath.lineTo(pointsPx.first().x, pointsPx.first().y)
+
+            if (pointsPx.size == 1) {
+                // Single point: nothing to stroke. Still draw the marker later.
+                linePath.lineTo(pointsPx.first().x, pointsPx.first().y)
+                areaPath.lineTo(pointsPx.first().x, chartBottomPx)
+            } else {
+                val tension = 0.35f // how curvy the line is
+                for (i in 0 until pointsPx.size - 1) {
+                    val p0 = pointsPx.getOrNull(i - 1) ?: pointsPx[i]
+                    val p1 = pointsPx[i]
+                    val p2 = pointsPx[i + 1]
+                    val p3 = pointsPx.getOrNull(i + 2) ?: p2
+                    val c1 = Offset(
+                        p1.x + (p2.x - p0.x) * tension,
+                        p1.y + (p2.y - p0.y) * tension
+                    )
+                    val c2 = Offset(
+                        p2.x - (p3.x - p1.x) * tension,
+                        p2.y - (p3.y - p1.y) * tension
+                    )
+                    linePath.cubicTo(c1.x, c1.y, c2.x, c2.y, p2.x, p2.y)
+                    areaPath.cubicTo(c1.x, c1.y, c2.x, c2.y, p2.x, p2.y)
+                }
+                areaPath.lineTo(pointsPx.last().x, chartBottomPx)
+                areaPath.close()
+            }
+
+            // Area fill (accent gradient fading down)
+            drawPath(
+                areaPath,
+                brush = Brush.verticalGradient(
+                    colors = listOf(lineColor.copy(alpha = 0.35f), lineColor.copy(alpha = 0f)),
+                    startY = chartTopPx,
+                    endY = chartBottomPx
+                )
+            )
+            // Line stroke
+            drawPath(
+                linePath,
+                color = lineColor,
+                style = Stroke(width = 2.dp.toPx())
+            )
+        }
+
+        // Overlay: weather icons + temp labels at each sample point
+        samples.forEachIndexed { i, sample ->
+            val xNorm = xs[i]
+            val yNorm = ys[i]
+
+            val iconSize = 26.dp
+            val centerX = chartRegionLeftDp + chartRegionWidthDp * xNorm
+            val centerY = labelHeight + chartHeight * yNorm
+            // Offset so the icon is centered on (centerX, centerY)
+            val iconLeftDp = centerX - iconSize / 2
+            val iconTopDp = centerY - iconSize / 2
+
+            // Icon disc (surface bg matches card so the line "dips under" the icon cleanly)
+            val condColor = colorForCondition(sample.weatherCondition)
+            Box(
+                modifier = Modifier
+                    .offset(x = iconLeftDp, y = iconTopDp)
+                    .size(iconSize)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = iconForCondition(sample.weatherCondition),
+                    contentDescription = null,
+                    tint = condColor,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+
+            // Temp label above the icon
+            val tempStr = "${displayedTemps[i].toInt()}$tempUnitLabel"
+            val labelW = 36.dp
+            Box(
+                modifier = Modifier
+                    .offset(
+                        x = centerX - labelW / 2,
+                        y = (iconTopDp - 18.dp).coerceAtLeast(0.dp)
+                    )
+                    .width(labelW)
+            ) {
+                Text(
+                    text = tempStr,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+private fun iconForCondition(c: WeatherCondition): ImageVector = when (c) {
+    WeatherCondition.CLEAR -> CustomIcons.WeatherSunny
+    WeatherCondition.PARTLY_CLOUDY -> CustomIcons.WeatherPartlyCloudy
+    WeatherCondition.FOG -> CustomIcons.WeatherFog
+    WeatherCondition.DRIZZLE -> CustomIcons.WeatherDrizzle
+    WeatherCondition.RAIN -> CustomIcons.WeatherRain
+    WeatherCondition.SNOW -> CustomIcons.WeatherSnow
+    WeatherCondition.THUNDERSTORM -> CustomIcons.WeatherThunderstorm
+}
+
+private fun colorForCondition(c: WeatherCondition): Color = when (c) {
+    WeatherCondition.CLEAR -> Color(0xFFFFC107)
+    WeatherCondition.PARTLY_CLOUDY -> Color(0xFF8BAEE8)
+    WeatherCondition.FOG -> Color(0xFF90A4AE)
+    WeatherCondition.DRIZZLE -> Color(0xFF64B5F6)
+    WeatherCondition.RAIN -> Color(0xFF1E88E5)
+    WeatherCondition.SNOW -> Color(0xFF42A5F5)
+    WeatherCondition.THUNDERSTORM -> Color(0xFF7E57C2)
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -102,6 +102,7 @@ import com.matedroid.ui.components.computeCostShades
 import com.matedroid.ui.components.TripEditActions
 import com.matedroid.ui.components.TripTimeline
 import com.matedroid.ui.components.TripTimelineCountry
+import com.matedroid.ui.components.TripWeatherSparklineCard
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.components.createZapMarkerDrawable
 import com.matedroid.ui.theme.CarColorPalette
@@ -233,6 +234,7 @@ fun TripDetailScreen(
                         palette = palette,
                         dcChargeIds = uiState.dcChargeIds,
                         canEdit = uiState.savedTripId != null,
+                        weatherPoints = uiState.weatherPoints,
                         onDriveClick = onNavigateToDriveDetail,
                         onChargeClick = onNavigateToChargeDetail,
                         onCountryClick = onNavigateToCountryStats,
@@ -296,6 +298,7 @@ private fun TripDetailContent(
     palette: CarColorPalette,
     dcChargeIds: Set<Int>,
     canEdit: Boolean,
+    weatherPoints: List<com.matedroid.data.repository.TripWeatherPoint>,
     onDriveClick: (driveId: Int) -> Unit,
     onChargeClick: (chargeId: Int) -> Unit,
     onCountryClick: (countryCode: String) -> Unit,
@@ -473,6 +476,12 @@ private fun TripDetailContent(
                 }
             }
         }
+
+        TripWeatherSparklineCard(
+            samples = weatherPoints,
+            palette = palette,
+            units = units
+        )
 
         if (canEdit) {
             TripEditActions(

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1,13 +1,17 @@
 package com.matedroid.ui.screens.trips
 
 import android.graphics.Paint
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -67,15 +71,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -350,16 +362,11 @@ private fun TripDetailContent(
             )
         }
 
-        StatsSectionCard(
-            title = stringResource(R.string.battery),
-            icon = Icons.Filled.BatteryChargingFull,
-            stats = listOfNotNull(
-                StatItem(stringResource(R.string.trip_energy_consumed), "%.1f kWh".format(trip.totalEnergyConsumed)),
-                StatItem(stringResource(R.string.trip_energy_charged), "%.1f kWh".format(trip.totalEnergyCharged)),
-                trip.avgEfficiency?.let {
-                    StatItem(stringResource(R.string.efficiency), "%.0f %s".format(it, UnitFormatter.getEfficiencyUnit(units)))
-                }
-            )
+        BatteryEnergyFlowCard(
+            trip = trip,
+            dcChargeIds = dcChargeIds,
+            palette = palette,
+            units = units
         )
 
         val legs = remember(trip) { buildLegList(trip) }
@@ -559,33 +566,38 @@ private fun ChargeCostCard(
                     palette = palette,
                     currencySymbol = currencySymbol
                 )
+
+                // Always-visible efficiency pills below the donut — the "at-a-glance verdict"
+                // on how expensive the trip was per distance / per energy.
+                val distanceUnit = UnitFormatter.getDistanceUnit(units)
+                val per100 = trip.totalChargeCost?.takeIf { trip.totalDistance > 0.0 }
+                    ?.let { it / trip.totalDistance * 100.0 }
+                val perKwh = trip.totalChargeCost?.takeIf { trip.totalEnergyCharged > 0.0 }
+                    ?.let { it / trip.totalEnergyCharged }
+                if (per100 != null || perKwh != null) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+                    ) {
+                        per100?.let {
+                            EfficiencyPill(
+                                value = "%.2f %s".format(it, currencySymbol),
+                                unit = "/ 100 $distanceUnit",
+                                palette = palette
+                            )
+                        }
+                        perKwh?.let {
+                            EfficiencyPill(
+                                value = "%.2f %s".format(it, currencySymbol),
+                                unit = "/ kWh",
+                                palette = palette
+                            )
+                        }
+                    }
+                }
             }
 
             if (expanded) {
-                if (trip.totalDistance > 0.0 && trip.totalChargeCost != null) {
-                    val per100 = trip.totalChargeCost / trip.totalDistance * 100.0
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(R.string.trip_cost_per_100),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Text(
-                            text = "%.2f %s / 100 %s".format(
-                                per100,
-                                currencySymbol,
-                                UnitFormatter.getDistanceUnit(units)
-                            ),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
                 costCharges.forEachIndexed { index, charge ->
                     val shade = shades.getOrNull(index) ?: palette.accent
                     Card(
@@ -643,6 +655,400 @@ private fun ChargeCostCard(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+// === Efficiency pill — surfaces €/100km and €/kWh below the cost donut ===
+
+@Composable
+private fun EfficiencyPill(
+    value: String,
+    unit: String,
+    palette: CarColorPalette
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(palette.accent.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = palette.accent
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = unit,
+            style = MaterialTheme.typography.labelSmall,
+            color = palette.accent.copy(alpha = 0.75f)
+        )
+    }
+}
+
+// === Battery energy flow card — horizontal Sankey-style flow (DC+AC in → battery → Used out) ===
+
+@Composable
+private fun BatteryEnergyFlowCard(
+    trip: Trip,
+    dcChargeIds: Set<Int>,
+    palette: CarColorPalette,
+    units: Units?
+) {
+    val dcCharges = remember(trip, dcChargeIds) { trip.charges.filter { it.chargeId in dcChargeIds } }
+    val acCharges = remember(trip, dcChargeIds) { trip.charges.filter { it.chargeId !in dcChargeIds } }
+    val dcKwh = dcCharges.sumOf { it.energyAdded }
+    val acKwh = acCharges.sumOf { it.energyAdded }
+    val dcDurationMin = dcCharges.sumOf { it.durationMin }
+    val acDurationMin = acCharges.sumOf { it.durationMin }
+    val dcAvgKw = if (dcDurationMin > 0) dcKwh * 60.0 / dcDurationMin else 0.0
+    val acAvgKw = if (acDurationMin > 0) acKwh * 60.0 / acDurationMin else 0.0
+    val usedKwh = trip.totalEnergyConsumed
+    val efficiencyWhPerDist = trip.avgEfficiency
+        ?: trip.totalDistance.takeIf { it > 0.0 }?.let { usedKwh * 1000.0 / it }
+    val efficiencyUnit = UnitFormatter.getEfficiencyUnit(units)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.BatteryChargingFull,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.battery),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            HorizontalEnergyFlow(
+                dcKwh = dcKwh, dcAvgKw = dcAvgKw,
+                acKwh = acKwh, acAvgKw = acAvgKw,
+                usedKwh = usedKwh,
+                efficiencyWhPerDist = efficiencyWhPerDist,
+                efficiencyUnit = efficiencyUnit,
+                palette = palette
+            )
+        }
+    }
+}
+
+@Composable
+private fun HorizontalEnergyFlow(
+    dcKwh: Double, dcAvgKw: Double,
+    acKwh: Double, acAvgKw: Double,
+    usedKwh: Double,
+    efficiencyWhPerDist: Double?,
+    efficiencyUnit: String,
+    palette: CarColorPalette
+) {
+    val totalCharged = dcKwh + acKwh
+
+    // Layout constants (dp). A little taller so labels can sit above/below the thin leads
+    // without crowding the battery.
+    val cardHeight = 150.dp
+    val batteryW = 128.dp
+    val batteryH = 72.dp
+    val batteryTipW = 7.dp
+    val batteryTipH = 26.dp
+    // Very thin source thickness — leaves plenty of room for the labels.
+    val startT = 6.dp
+
+    // The stream stays at startT for 80% of its run, then expands to its proportional share
+    // over the last 20%. Inverse for the outflow (full-width for the first 20%, thin after).
+    val flatFraction = 0.80f
+
+    val density = LocalDensity.current
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(cardHeight)
+    ) {
+        val cardW = maxWidth
+        val batteryLeftX = (cardW - batteryW) / 2
+        val batteryRightX = batteryLeftX + batteryW
+        val batteryTopY = (cardHeight - batteryH) / 2
+        val centerY = cardHeight / 2
+
+        val cardWPx = with(density) { cardW.toPx() }
+        val cardHPx = with(density) { cardHeight.toPx() }
+        val batteryWPx = with(density) { batteryW.toPx() }
+        val batteryHPx = with(density) { batteryH.toPx() }
+        val batteryTipWPx = with(density) { batteryTipW.toPx() }
+        val batteryTipHPx = with(density) { batteryTipH.toPx() }
+        val batteryLeftXPx = (cardWPx - batteryWPx) / 2f
+        val batteryRightXPx = batteryLeftXPx + batteryWPx
+        val batteryTopYPx = (cardHPx - batteryHPx) / 2f
+        val batteryBottomYPx = batteryTopYPx + batteryHPx
+        val centerYPx = cardHPx / 2f
+        val startTPx = with(density) { startT.toPx() }
+        val dcShare = if (totalCharged > 0) dcKwh / totalCharged else 0.0
+        val splitYPx = batteryTopYPx + (dcShare * batteryHPx).toFloat()
+
+        val accent = palette.accent
+        val acColor = palette.acColor
+        val dcColor = palette.dcColor
+        val usedColor = StatusError
+
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val cornerPx = 10.dp.toPx()
+            val strokePx = 2.5.dp.toPx()
+
+            // x where the inflow transitions from flat-thin to widening
+            val inTransitionX = batteryLeftXPx * flatFraction
+            // x where the outflow ends its widening (mirror of inTransitionX relative to battery)
+            val outRegionWidth = cardWPx - batteryRightXPx
+            val outTransitionX = batteryRightXPx + outRegionWidth * (1f - flatFraction)
+
+            // Helper: build a Sankey-style inflow path. Stays at [topY..bottomY] (thickness startT)
+            // from x=0 to inTransitionX, then cubic-beziers to (batteryLeftXPx, [batteryTopYAt..
+            // batteryBotYAt]).
+            fun buildInPath(sourceTopY: Float, sourceBotY: Float, batteryTopYAt: Float, batteryBotYAt: Float): Path {
+                val ctrlX = (inTransitionX + batteryLeftXPx) / 2f
+                return Path().apply {
+                    moveTo(0f, sourceTopY)
+                    lineTo(inTransitionX, sourceTopY)
+                    cubicTo(
+                        ctrlX, sourceTopY,
+                        ctrlX, batteryTopYAt,
+                        batteryLeftXPx, batteryTopYAt
+                    )
+                    lineTo(batteryLeftXPx, batteryBotYAt)
+                    cubicTo(
+                        ctrlX, batteryBotYAt,
+                        ctrlX, sourceBotY,
+                        inTransitionX, sourceBotY
+                    )
+                    lineTo(0f, sourceBotY)
+                    close()
+                }
+            }
+
+            // === Inflow streams ===
+            when {
+                dcKwh > 0 && acKwh > 0 -> {
+                    // DC on top: from thin line above center → top portion of battery
+                    drawPath(
+                        buildInPath(
+                            sourceTopY = centerYPx - startTPx,
+                            sourceBotY = centerYPx,
+                            batteryTopYAt = batteryTopYPx,
+                            batteryBotYAt = splitYPx
+                        ),
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(dcColor, dcColor.copy(alpha = 0f)),
+                            startX = 0f, endX = batteryLeftXPx
+                        )
+                    )
+                    // AC on bottom
+                    drawPath(
+                        buildInPath(
+                            sourceTopY = centerYPx,
+                            sourceBotY = centerYPx + startTPx,
+                            batteryTopYAt = splitYPx,
+                            batteryBotYAt = batteryBottomYPx
+                        ),
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(acColor, acColor.copy(alpha = 0f)),
+                            startX = 0f, endX = batteryLeftXPx
+                        )
+                    )
+                }
+                dcKwh > 0 -> {
+                    drawPath(
+                        buildInPath(
+                            sourceTopY = centerYPx - startTPx,
+                            sourceBotY = centerYPx + startTPx,
+                            batteryTopYAt = batteryTopYPx,
+                            batteryBotYAt = batteryBottomYPx
+                        ),
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(dcColor, dcColor.copy(alpha = 0f)),
+                            startX = 0f, endX = batteryLeftXPx
+                        )
+                    )
+                }
+                acKwh > 0 -> {
+                    drawPath(
+                        buildInPath(
+                            sourceTopY = centerYPx - startTPx,
+                            sourceBotY = centerYPx + startTPx,
+                            batteryTopYAt = batteryTopYPx,
+                            batteryBotYAt = batteryBottomYPx
+                        ),
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(acColor, acColor.copy(alpha = 0f)),
+                            startX = 0f, endX = batteryLeftXPx
+                        )
+                    )
+                }
+            }
+
+            // === Outflow stream (inverse profile) ===
+            // Widens from battery height at batteryRightXPx to thin startT at outTransitionX,
+            // then stays thin to cardWPx.
+            run {
+                val ctrlX = (batteryRightXPx + outTransitionX) / 2f
+                val outPath = Path().apply {
+                    moveTo(batteryRightXPx, batteryTopYPx)
+                    cubicTo(
+                        ctrlX, batteryTopYPx,
+                        ctrlX, centerYPx - startTPx / 2f,
+                        outTransitionX, centerYPx - startTPx / 2f
+                    )
+                    lineTo(cardWPx, centerYPx - startTPx / 2f)
+                    lineTo(cardWPx, centerYPx + startTPx / 2f)
+                    lineTo(outTransitionX, centerYPx + startTPx / 2f)
+                    cubicTo(
+                        ctrlX, centerYPx + startTPx / 2f,
+                        ctrlX, batteryBottomYPx,
+                        batteryRightXPx, batteryBottomYPx
+                    )
+                    close()
+                }
+                drawPath(
+                    outPath,
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(usedColor.copy(alpha = 0f), usedColor),
+                        startX = batteryRightXPx, endX = cardWPx
+                    )
+                )
+            }
+
+            // === Battery body (drawn on top of the stream edges so seams are clean) ===
+            drawRoundRect(
+                color = accent.copy(alpha = 0.10f),
+                topLeft = Offset(batteryLeftXPx, batteryTopYPx),
+                size = Size(batteryWPx, batteryHPx),
+                cornerRadius = CornerRadius(cornerPx, cornerPx)
+            )
+            drawRoundRect(
+                color = accent,
+                topLeft = Offset(batteryLeftXPx, batteryTopYPx),
+                size = Size(batteryWPx, batteryHPx),
+                cornerRadius = CornerRadius(cornerPx, cornerPx),
+                style = Stroke(width = strokePx)
+            )
+
+            // Battery tip (positive terminal) on the right side — makes it unmistakably a battery
+            val tipCornerPx = 3.dp.toPx()
+            val tipY = batteryTopYPx + (batteryHPx - batteryTipHPx) / 2f
+            drawRoundRect(
+                color = accent,
+                topLeft = Offset(batteryRightXPx, tipY),
+                size = Size(batteryTipWPx, batteryTipHPx),
+                cornerRadius = CornerRadius(tipCornerPx, tipCornerPx)
+            )
+        }
+
+        // === Text overlays ===
+
+        // Battery center label: total charged kWh
+        Column(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (totalCharged > 0) {
+                Text(
+                    text = "%.1f".format(totalCharged),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = accent
+                )
+                Text(
+                    text = "kWh charged",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = accent.copy(alpha = 0.78f)
+                )
+            } else {
+                Text(
+                    text = "—",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+        }
+
+        // DC label (top-left) — above the thin DC stream
+        if (dcKwh > 0) {
+            Column(
+                modifier = Modifier.offset(
+                    x = 6.dp,
+                    y = centerY - startT - 40.dp
+                )
+            ) {
+                Text(
+                    text = "%.1f kWh".format(dcKwh),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = dcColor
+                )
+                Text(
+                    text = "%.0f kW avg".format(dcAvgKw),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // AC label (bottom-left) — below the thin AC stream
+        if (acKwh > 0) {
+            Column(
+                modifier = Modifier.offset(
+                    x = 6.dp,
+                    y = centerY + startT + 6.dp
+                )
+            ) {
+                Text(
+                    text = "%.1f kWh".format(acKwh),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = acColor
+                )
+                Text(
+                    text = "%.1f kW avg".format(acAvgKw),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // OUT label (right) — over the thin outflow section
+        Column(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .offset(y = -(startT + 20.dp))
+                .padding(end = 6.dp),
+            horizontalAlignment = Alignment.End
+        ) {
+            Text(
+                text = "%.1f kWh".format(usedKwh),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = usedColor
+            )
+            if (efficiencyWhPerDist != null) {
+                Text(
+                    text = "%.0f %s".format(efficiencyWhPerDist, efficiencyUnit),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -14,6 +14,8 @@ import com.matedroid.data.local.entity.TripRouteCache
 import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.data.repository.TripWeatherPoint
+import com.matedroid.data.repository.WeatherRepository
 import com.matedroid.data.repository.countryCodeToFlag
 import com.matedroid.domain.EligibleLegs
 import com.matedroid.domain.LegRef
@@ -83,7 +85,9 @@ data class TripDetailUiState(
     val eligibleLegs: EligibleLegs? = null,
     val adjacentTrips: List<Pair<Long, Trip>> = emptyList(),
     val pendingMergeTarget: Pair<Long, Trip>? = null,
-    val justDeleted: Boolean = false
+    val justDeleted: Boolean = false,
+
+    val weatherPoints: List<TripWeatherPoint> = emptyList()
 )
 
 @HiltViewModel
@@ -95,6 +99,7 @@ class TripDetailViewModel @Inject constructor(
     private val tripRepository: TripRepository,
     private val tripCache: TripCache,
     private val repository: TeslamateRepository,
+    private val weatherRepository: WeatherRepository,
     private val settingsDataStore: SettingsDataStore
 ) : ViewModel() {
 
@@ -509,6 +514,18 @@ class TripDetailViewModel @Inject constructor(
                     markers = markers,
                     isMapLoading = false
                 )
+            }
+
+            // Weather fetch kicks in after route data is ready — it needs per-drive GPS points
+            // to sample. Runs in the same viewModelScope so it's cancelled if the screen goes
+            // away. Only fetches if we don't already have samples (memory cache across reloads).
+            if (_uiState.value.weatherPoints.isEmpty() && simplified.isNotEmpty()) {
+                launch {
+                    val samples = weatherRepository.getWeatherAlongTrip(trip.drives, simplified)
+                    if (samples.isNotEmpty()) {
+                        _uiState.update { it.copy(weatherPoints = samples) }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -362,7 +362,7 @@
     <string name="speed_distribution">Distribució de velocitat</string>
 
     <!-- Weather section -->
-    <string name="weather_along_way">Temps al llarg del trajecte</string>
+    <string name="weather_during_trip">Temps durant el viatge</string>
 
     <!-- ==================== Charges Screen ==================== -->
     <!-- Top bar title -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1065,7 +1065,6 @@
     <string name="trip_energy_consumed">Energia consumida</string>
     <string name="trip_energy_charged">Energia carregada</string>
     <string name="trip_charge_cost">Cost de càrrega</string>
-    <string name="trip_cost_per_100">Cost mitjà per 100</string>
     <string name="trip_leg_drive">Trajecte %1$d</string>
     <string name="trip_leg_charge">Càrrega %1$d</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1065,7 +1065,6 @@
     <string name="trip_energy_consumed">Energía consumida</string>
     <string name="trip_energy_charged">Energía cargada</string>
     <string name="trip_charge_cost">Coste de carga</string>
-    <string name="trip_cost_per_100">Coste medio por 100</string>
     <string name="trip_leg_drive">Trayecto %1$d</string>
     <string name="trip_leg_charge">Carga %1$d</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -362,7 +362,7 @@
     <string name="speed_distribution">Distribución de velocidad</string>
 
     <!-- Weather section -->
-    <string name="weather_along_way">Clima en el trayecto</string>
+    <string name="weather_during_trip">Clima durante el viaje</string>
 
     <!-- ==================== Charges Screen ==================== -->
     <!-- Top bar title -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1065,7 +1065,6 @@
     <string name="trip_energy_consumed">Energia consumata</string>
     <string name="trip_energy_charged">Energia ricaricata</string>
     <string name="trip_charge_cost">Costo ricarica</string>
-    <string name="trip_cost_per_100">Costo medio per 100</string>
     <string name="trip_leg_drive">Tratta %1$d</string>
     <string name="trip_leg_charge">Ricarica %1$d</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -362,7 +362,7 @@
     <string name="speed_distribution">Distribuzione velocità</string>
 
     <!-- Weather section -->
-    <string name="weather_along_way">Meteo lungo il percorso</string>
+    <string name="weather_during_trip">Meteo durante il viaggio</string>
 
     <!-- ==================== Charges Screen ==================== -->
     <!-- Top bar title -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -362,7 +362,7 @@
     <string name="speed_distribution">速度分布</string>
 
     <!-- Weather section -->
-    <string name="weather_along_way">沿途天气</string>
+    <string name="weather_during_trip">旅程中的天气</string>
 
     <!-- ==================== Charges Screen ==================== -->
     <!-- Top bar title -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1066,7 +1066,6 @@
     <string name="trip_energy_consumed">消耗能量</string>
     <string name="trip_energy_charged">充入能量</string>
     <string name="trip_charge_cost">充电费用</string>
-    <string name="trip_cost_per_100">每 100 平均费用</string>
     <string name="trip_leg_drive">行驶 %1$d</string>
     <string name="trip_leg_charge">充电 %1$d</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,7 +363,7 @@
     <string name="speed_distribution">Speed Distribution</string>
 
     <!-- Weather section -->
-    <string name="weather_along_way">Weather along the way</string>
+    <string name="weather_during_trip">Weather during the trip</string>
 
     <!-- ==================== Charges Screen ==================== -->
     <!-- Top bar title -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1090,8 +1090,6 @@
     <string name="trip_energy_charged">Energy charged</string>
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Charge cost</string>
-    <!-- Average charge cost per 100 km/mi label -->
-    <string name="trip_cost_per_100">Avg cost per 100</string>
     <!-- Drive leg label with number -->
     <string name="trip_leg_drive">Drive %1$d</string>
     <!-- Charge leg label with number -->


### PR DESCRIPTION
## Summary

Two distinct additions to the trip detail screen, in two commits:

1. **Cost donut polish + horizontal battery energy flow** (`df2554d`)
   - Always-visible efficiency pills below the cost donut (€/100 km + €/kWh).
   - Total cost removed from the cost card header — already in the donut center.
   - Battery card redesigned as a horizontal Sankey-style flow: horizontal battery pictogram (body + tip), DC on top + AC on bottom inflows on the left, single red outflow on the right. Streams start very thin at the source (6dp), stay flat for 80% of their run, then cubic-bezier to their proportional share of battery height over the last 20%. Outflow is inverse (full battery height on the left, tapering to thin in the first 20%). Gradients fade out near the battery and in towards the ends.

2. **Weather during the trip sparkline** (`d96acb0`)
   - New card at the end of the trip detail. Temperature line chart with weather condition icons floating on the line at each sample, temp labels above, start/end clock times below.
   - Sampling: ~1 per hour of drive time, clamped to [3, 12]. Only drive GPS points are sampled (parking/charging gaps skipped naturally). Timestamps interpolated linearly from each drive's start/end.
   - Each sample = one Open-Meteo historical call. Fetches run in parallel.
   - Hides itself if no samples (network failure, or trip too recent for Open-Meteo's 2–5 day delay).
   - In-memory cache only for now; DB persistence is a follow-up.

## Test plan

- [ ] Cost donut: verify both pills appear always (collapsed/expanded); header has no more total amount.
- [ ] Battery flow: trip with both AC + DC charging → two inflow streams with proportional thicknesses at the battery; trip with only DC → single stream at full battery height.
- [ ] Battery outflow: taper is visible — thick at the battery, thin at the right end.
- [ ] Weather card: open an older trip — sparkline renders, icons + temps align with the curve, Fahrenheit honored when the units setting is imperial.
- [ ] Weather card: open a trip from today — card hides gracefully.