### PR TITLE
feat(trips): compact list rows with per-trip timeline fingerprint

### DIFF
--- a/app/src/main/java/com/matedroid/ui/components/TripFingerprintStrip.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripFingerprintStrip.kt
@@ -1,0 +1,107 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.matedroid.ui.theme.CarColorPalette
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/**
+ * A thin horizontal "fingerprint" of a trip for the trips list.
+ *
+ * Non-interactive — renders each [TripTimelineSegment] as a colored rectangle with a tiny
+ * 1 px gap between adjacent segments. Uses the same compression curve as the detail screen's
+ * timeline bar so a 6 h AC overnight doesn't squash the DC spikes into slivers. Meant to sit
+ * inline in a list row, not as a standalone card.
+ */
+@Composable
+fun TripFingerprintStrip(
+    segments: List<TripTimelineSegment>,
+    palette: CarColorPalette,
+    modifier: Modifier = Modifier
+) {
+    if (segments.isEmpty()) return
+
+    val parkingColor = MaterialTheme.colorScheme.surfaceVariant
+    val ratios = computeFingerprintRatios(segments)
+
+    Canvas(
+        modifier = modifier
+            .height(6.dp)
+            .clip(RoundedCornerShape(3.dp))
+            .fillMaxSize()
+    ) {
+        val total = size.width
+        val gapPx = 1.dp.toPx()
+        var x = 0f
+        ratios.forEachIndexed { idx, ratio ->
+            val segWidth = ratio * total
+            val isLast = idx == ratios.lastIndex
+            val drawWidth = if (isLast) segWidth else (segWidth - gapPx).coerceAtLeast(0f)
+            val color = fingerprintColorFor(segments[idx], palette, parkingColor)
+            drawRect(
+                color = color,
+                topLeft = Offset(x, 0f),
+                size = Size(drawWidth, size.height)
+            )
+            x += segWidth
+        }
+    }
+}
+
+private const val IDLE_LINEAR_THRESHOLD_MIN = 30f
+private const val IDLE_COMPRESSION_SCALE = 0.5f
+private const val MIN_SEGMENT_RATIO = 0.02f
+
+/** Mirrors the detail timeline's compression so silhouettes match between screens. */
+private fun computeFingerprintRatios(segments: List<TripTimelineSegment>): List<Float> {
+    if (segments.isEmpty()) return emptyList()
+    val weights = segments.map { seg ->
+        when (seg) {
+            is TripTimelineSegment.Parking -> compressIdle(seg.durationMin)
+            is TripTimelineSegment.Charge ->
+                if (seg.isDc) seg.durationMin.toFloat().coerceAtLeast(1f)
+                else compressIdle(seg.durationMin)
+            is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
+        }
+    }
+    val total = weights.sum().coerceAtLeast(1f)
+    val raw = weights.map { it / total }
+    val effectiveMin = MIN_SEGMENT_RATIO.coerceAtMost(1f / segments.size)
+    val lifted = raw.map { max(it, effectiveMin) }
+    val liftedSum = lifted.sum()
+    return lifted.map { it / liftedSum }
+}
+
+private fun compressIdle(durationMin: Int): Float {
+    val d = durationMin.toFloat().coerceAtLeast(1f)
+    return if (d <= IDLE_LINEAR_THRESHOLD_MIN) d
+    else IDLE_LINEAR_THRESHOLD_MIN +
+            sqrt((d - IDLE_LINEAR_THRESHOLD_MIN) * IDLE_LINEAR_THRESHOLD_MIN) * IDLE_COMPRESSION_SCALE
+}
+
+/** Alpha applied to every segment so the strip reads as a quiet accent, not a loud bar. */
+private const val FINGERPRINT_ALPHA = 0.4f
+
+private fun fingerprintColorFor(
+    seg: TripTimelineSegment,
+    palette: CarColorPalette,
+    parkingColor: Color
+): Color {
+    val base = when (seg) {
+        is TripTimelineSegment.Drive -> palette.accent
+        is TripTimelineSegment.Charge -> if (seg.isDc) palette.dcColor else palette.acColor
+        is TripTimelineSegment.Parking -> parkingColor
+    }
+    return base.copy(alpha = FINGERPRINT_ALPHA)
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -20,11 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.BatteryChargingFull
-import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
@@ -65,6 +61,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.DateRangePickerDialog
+import com.matedroid.ui.components.TripFingerprintStrip
 import com.matedroid.ui.components.formatShortDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
@@ -173,6 +170,7 @@ fun TripsScreen(
                         onCustomRangeSelected = { start, end -> viewModel.setCustomDateRange(start, end) },
                         units = uiState.units,
                         palette = palette,
+                        dcChargeIds = uiState.dcChargeIds,
                         onTripClick = { trip ->
                             viewModel.cacheTrip(trip)
                             onNavigateToTripDetail(trip.startDate)
@@ -199,6 +197,7 @@ private fun TripsContent(
     onCustomRangeSelected: (LocalDate, LocalDate) -> Unit,
     units: Units?,
     palette: CarColorPalette,
+    dcChargeIds: Set<Int>,
     onTripClick: (Trip) -> Unit
 ) {
     LazyColumn(
@@ -249,6 +248,8 @@ private fun TripsContent(
             TripItem(
                 trip = trip,
                 units = units,
+                palette = palette,
+                dcChargeIds = dcChargeIds,
                 onClick = { onTripClick(trip) }
             )
         }
@@ -352,8 +353,16 @@ private fun SummaryItem(
 private fun TripItem(
     trip: Trip,
     units: Units?,
+    palette: CarColorPalette,
+    dcChargeIds: Set<Int>,
     onClick: () -> Unit
 ) {
+    // Segments memoized per trip — pure computation on the in-memory Trip, cheap enough for
+    // every visible list row (LazyColumn composes ~10 at a time). Keys include dcChargeIds so
+    // the strip recolors if the DC set ever changes.
+    val segments = remember(trip, dcChargeIds) { buildTimelineSegments(trip, dcChargeIds) }
+    val chargeCount = trip.charges.size
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -363,145 +372,95 @@ private fun TripItem(
         )
     ) {
         Column(
-            modifier = Modifier.padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)
         ) {
-            // Route header — single line
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                )
-            ) {
-                Column(
+            // Top row: date chip + route + distance
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = formatDateChip(trip.startDate),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp)
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Default.LocationOn,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = trip.displayName(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.weight(1f),
-                            maxLines = 1
-                        )
-                    }
-                    val hasCustomName = !trip.name.isNullOrBlank()
-                    val subtitle = if (hasCustomName) {
-                        "${extractCity(trip.startAddress)} → ${extractCity(trip.endAddress)} · ${formatDate(trip.startDate)}"
-                    } else {
-                        formatDate(trip.startDate)
-                    }
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 28.dp, top = 4.dp),
-                        maxLines = 1,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-                    )
-                }
+                        .padding(end = 10.dp)
+                )
+                Text(
+                    text = trip.displayName(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = UnitFormatter.formatDistance(trip.totalDistance, units, decimals = 0),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = palette.accent
+                )
             }
 
-            // Stats — 2x2 grid, same DriveStatCard pattern
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                TripStatCard(
-                    icon = Icons.Filled.Speed,
-                    value = "%.1f".format(UnitFormatter.formatDistanceValue(trip.totalDistance, units)),
-                    unit = UnitFormatter.getDistanceUnit(units),
-                    label = stringResource(R.string.distance),
-                    modifier = Modifier.weight(1f)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Fingerprint
+            TripFingerprintStrip(
+                segments = segments,
+                palette = palette,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            // Meta row: duration · stops · kWh
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = formatDuration(trip.totalDurationMin),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
-                TripStatCard(
-                    icon = Icons.Filled.Schedule,
-                    value = formatDuration(trip.totalDurationMin),
-                    unit = "",
-                    label = stringResource(R.string.trip_total_time),
-                    modifier = Modifier.weight(1f)
+                Text(
+                    text = " · ",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                TripStatCard(
-                    icon = Icons.Filled.ElectricBolt,
-                    value = "${trip.charges.size}",
-                    unit = "",
-                    label = stringResource(R.string.trip_charge_stops),
-                    modifier = Modifier.weight(1f)
+                Text(
+                    text = if (chargeCount == 0) {
+                        stringResource(R.string.trip_no_stops)
+                    } else {
+                        pluralStopsLabel(chargeCount)
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                TripStatCard(
-                    icon = Icons.Filled.BatteryChargingFull,
-                    value = "%.1f".format(trip.totalEnergyConsumed),
-                    unit = "kWh",
-                    label = stringResource(R.string.trip_energy_consumed),
-                    modifier = Modifier.weight(1f)
-                )
+                if (trip.totalEnergyCharged > 0.0) {
+                    Text(
+                        text = " · %.1f kWh".format(trip.totalEnergyCharged),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-private fun TripStatCard(
-    icon: ImageVector,
-    value: String,
-    unit: String,
-    label: String,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Row(verticalAlignment = Alignment.Bottom) {
-                Text(
-                    text = value,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                if (unit.isNotEmpty()) {
-                    Spacer(modifier = Modifier.width(2.dp))
-                    Text(
-                        text = unit,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+private fun pluralStopsLabel(count: Int): String =
+    if (count == 1) stringResource(R.string.trip_one_stop)
+    else stringResource(R.string.trip_n_stops, count)
+
+private fun formatDateChip(dateStr: String): String {
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (_: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
         }
+        dt.format(DateTimeFormatter.ofPattern("d MMM")).uppercase()
+    } catch (_: Exception) {
+        dateStr
     }
 }
 
@@ -597,13 +556,3 @@ private fun formatDuration(minutes: Int): String {
     return if (h > 0) "${h}h ${m}m" else "${m}m"
 }
 
-private fun formatDate(dateStr: String): String {
-    return try {
-        val inputFormatter = DateTimeFormatter.ISO_DATE_TIME
-        val outputFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy HH:mm")
-        val dateTime = LocalDateTime.parse(dateStr, inputFormatter)
-        dateTime.format(outputFormatter)
-    } catch (e: Exception) {
-        dateStr
-    }
-}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -3,6 +3,7 @@ package com.matedroid.ui.screens.trips
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.TripRepository
@@ -30,14 +31,16 @@ data class TripsUiState(
     val isCustomDateFilter: Boolean = false,
     val customStartDate: LocalDate? = null,
     val customEndDate: LocalDate? = null,
-    val units: Units? = null
+    val units: Units? = null,
+    val dcChargeIds: Set<Int> = emptySet()
 )
 
 @HiltViewModel
 class TripsViewModel @Inject constructor(
     private val tripRepository: TripRepository,
     private val repository: TeslamateRepository,
-    private val tripCache: TripCache
+    private val tripCache: TripCache,
+    private val aggregateDao: AggregateDao
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TripsUiState())
@@ -52,6 +55,16 @@ class TripsViewModel @Inject constructor(
         carId = id
         loadTrips(id)
         loadUnits(id)
+        loadDcChargeIds(id)
+    }
+
+    private fun loadDcChargeIds(id: Int) {
+        viewModelScope.launch {
+            val ids = try {
+                aggregateDao.getDcChargeIds(id).toSet()
+            } catch (e: Exception) { emptySet() }
+            _uiState.update { it.copy(dcChargeIds = ids) }
+        }
     }
 
     /** Screen went to background (user navigated to a child). */

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1060,6 +1060,9 @@
     <string name="trip_legs">Etapes del viatge</string>
     <string name="trip_route_map">Mapa de ruta</string>
     <string name="trip_charge_stops">Parades de càrrega</string>
+    <string name="trip_no_stops">sense parades</string>
+    <string name="trip_one_stop">1 parada</string>
+    <string name="trip_n_stops">%1$d parades</string>
     <string name="trip_driving_time">Temps de conducció</string>
     <string name="trip_total_time">Temps total</string>
     <string name="trip_energy_consumed">Energia consumida</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1060,6 +1060,9 @@
     <string name="trip_legs">Etapas del viaje</string>
     <string name="trip_route_map">Mapa de ruta</string>
     <string name="trip_charge_stops">Paradas de carga</string>
+    <string name="trip_no_stops">sin paradas</string>
+    <string name="trip_one_stop">1 parada</string>
+    <string name="trip_n_stops">%1$d paradas</string>
     <string name="trip_driving_time">Tiempo de conducción</string>
     <string name="trip_total_time">Tiempo total</string>
     <string name="trip_energy_consumed">Energía consumida</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1060,6 +1060,9 @@
     <string name="trip_legs">Tappe del viaggio</string>
     <string name="trip_route_map">Mappa del percorso</string>
     <string name="trip_charge_stops">Soste di ricarica</string>
+    <string name="trip_no_stops">nessuna sosta</string>
+    <string name="trip_one_stop">1 sosta</string>
+    <string name="trip_n_stops">%1$d soste</string>
     <string name="trip_driving_time">Tempo di guida</string>
     <string name="trip_total_time">Tempo totale</string>
     <string name="trip_energy_consumed">Energia consumata</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1061,6 +1061,9 @@
     <string name="trip_legs">行程段落</string>
     <string name="trip_route_map">路线地图</string>
     <string name="trip_charge_stops">充电站</string>
+    <string name="trip_no_stops">无停靠</string>
+    <string name="trip_one_stop">1 个停靠</string>
+    <string name="trip_n_stops">%1$d 个停靠</string>
     <string name="trip_driving_time">驾驶时间</string>
     <string name="trip_total_time">总时间</string>
     <string name="trip_energy_consumed">消耗能量</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1080,6 +1080,12 @@
     <string name="trip_route_map">Route Map</string>
     <!-- Number of charge stops -->
     <string name="trip_charge_stops">Charge stops</string>
+    <!-- Trip list row: no charge stops -->
+    <string name="trip_no_stops">no stops</string>
+    <!-- Trip list row: exactly one charge stop -->
+    <string name="trip_one_stop">1 stop</string>
+    <!-- Trip list row: multiple charge stops. %1$d is the count -->
+    <string name="trip_n_stops">%1$d stops</string>
     <!-- Driving time label -->
     <string name="trip_driving_time">Driving time</string>
     <!-- Total time (wall clock) label -->


### PR DESCRIPTION
## Summary

Trip list rows are now about 60% of their previous height and carry a subtle 6dp timeline strip as a per-trip "fingerprint" so different trips are distinguishable at a glance — a multi-day with mixed DC + AC overnight, a daily commute with a parking gap, a single short drive all look different before you read any text.

### Layout
- Top row: date chip + route + distance.
- Middle: 6dp colored timeline strip (drive = accent, DC = orange, AC = green, parking = neutral).
- Bottom: small `duration · stops · kWh` meta row.
- Old 2x2 `TripStatCard` grid removed.

### Implementation
- New `TripFingerprintStrip` composable under `ui/components/`. Uses the same colored-segment + sqrt-compression logic as the detail screen's timeline bar, so silhouettes match between list and detail.
- Each segment renders at **0.4 alpha** so the strip reads as a quiet accent, not a loud bar.
- `TripsViewModel` loads `dcChargeIds` once per `carId` (single DB query) and exposes it through `TripsUiState`.
- `remember(trip, dcChargeIds) { buildTimelineSegments(...) }` memoizes per-row segment computation — pure on in-memory trip data, no extra I/O.

## Test plan
- [ ] Trip with DC + AC + parking (overnight road trip) — strip shows distinct colored regions with the AC chunk visually wider than the DC spikes.
- [ ] Commute with long office parking — strip shows two drive pills sandwiching a neutral gray block.
- [ ] Single drive, no charging — strip is a solid accent bar.
- [ ] Many DC stops (highway blast) — evenly-spaced orange blips interrupting long drives.
- [ ] Row height feels noticeably shorter than before.