### PR TITLE
chore: add detekt + prune 338 lines of dead code

### DIFF
--- a/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
@@ -24,9 +24,6 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 
 /**
  * Background worker for syncing stats data from TeslamateApi.

--- a/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
@@ -13,7 +13,6 @@ import androidx.work.WorkerParameters
 import android.util.Log
 import com.matedroid.R
 import com.matedroid.data.local.dao.AggregateDao
-import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.entity.GeocodeCache
 import com.matedroid.data.repository.GeocodingRepository
 import dagger.assisted.Assisted
@@ -32,7 +31,6 @@ class GeocodeWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val geocodingRepository: GeocodingRepository,
     private val aggregateDao: AggregateDao,
-    private val chargeSummaryDao: ChargeSummaryDao,
     private val logCollector: SyncLogCollector
 ) : CoroutineWorker(appContext, workerParams) {
 

--- a/app/src/main/java/com/matedroid/notification/ChargingNotificationManager.kt
+++ b/app/src/main/java/com/matedroid/notification/ChargingNotificationManager.kt
@@ -13,7 +13,6 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
-import androidx.core.graphics.drawable.IconCompat
 import com.matedroid.R
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarStatus
@@ -176,10 +175,6 @@ class ChargingNotificationManager @Inject constructor(
                 val finishTime = java.util.Calendar.getInstance().apply {
                     add(java.util.Calendar.MINUTE, (hours * 60).toInt())
                 }
-                val timeFormat = android.text.format.DateFormat.getTimeFormat(context)
-                val formattedTime = timeFormat.format(finishTime.time)
-
-                // Determine relative day using DateUtils
                 val relativeDateTime = android.text.format.DateUtils.getRelativeDateTimeString(
                     context,
                     finishTime.timeInMillis,

--- a/app/src/main/java/com/matedroid/ui/components/InteractiveBarChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/InteractiveBarChart.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -69,7 +68,6 @@ fun InteractiveBarChart(
 
     val textMeasurer = rememberTextMeasurer()
     val maxValue = data.maxOfOrNull { it.value } ?: 1.0
-    val density = LocalDensity.current
 
     // Reset selection when data changes to avoid IndexOutOfBoundsException
     var selectedBarIndex by remember(data) { mutableStateOf<Int?>(null) }

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -2,7 +2,6 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
@@ -57,11 +57,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.matedroid.R

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -27,12 +27,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BatteryChargingFull
-import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Paid

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
@@ -16,8 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.OffsetDateTime
-import java.time.format.DateTimeParseException
 import javax.inject.Inject
 
 data class CurrentChargeUiState(

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,7 +34,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Battery5Bar
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.ElectricBolt
@@ -47,16 +45,11 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Bedtime
-import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Power
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.DriveEta
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Terrain
 import androidx.compose.material.icons.filled.Thermostat
-import androidx.compose.material.icons.filled.Timeline
-import androidx.compose.material.icons.filled.WbSunny
 import com.matedroid.ui.icons.CustomIcons
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -87,7 +80,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -2282,47 +2274,6 @@ private fun TirePressureItem(
                 maxLines = 1
             )
         }
-    }
-}
-
-@Composable
-private fun InfoItem(
-    label: String,
-    value: String,
-    icon: ImageVector,
-    modifier: Modifier = Modifier,
-    onClick: (() -> Unit)? = null
-) {
-    val innerModifier = if (onClick != null) {
-        Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .clickable(onClick = onClick)
-            .padding(8.dp)
-    } else {
-        Modifier.padding(8.dp)
-    }
-
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.then(innerModifier)
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = if (onClick != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = if (onClick != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-            color = if (onClick != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.graphics.Paint
 import android.net.Uri
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,8 +29,6 @@ import androidx.compose.material.icons.filled.LocationOn
 import com.matedroid.ui.icons.CustomIcons
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.TrendingDown
-import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
@@ -3,7 +3,6 @@ package com.matedroid.ui.screens.drives
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.DriveDetail
-import com.matedroid.data.api.models.DrivePosition
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.local.entity.SavedTripLeg

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BatteryChargingFull
-import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.LocationOn
 import com.matedroid.ui.icons.CustomIcons

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,14 +21,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.outlined.AllInclusive
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.outlined.BatteryChargingFull
-import androidx.compose.material.icons.outlined.Calculate
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
@@ -64,7 +61,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.isSystemInDarkTheme
 //import androidx.compose.material.icons.Icons
@@ -76,7 +72,6 @@ import com.matedroid.R
 import com.matedroid.data.api.models.DriveData
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.InteractiveBarChart
-import com.matedroid.ui.screens.drives.DriveDetailStats
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.ui.theme.StatusSuccess
@@ -788,7 +783,6 @@ private fun MonthSummaryCard(
     val avgDistance = if (driveCount > 0) totalDistance / driveCount else 0.0
     val totalBatteryUsage = monthData?.totalBatteryUsage ?: 0.0
     val totalEnergy = monthData?.totalEnergy ?: 0.0
-    val avgEnergy = if (driveCount > 0) totalEnergy / driveCount else 0.0
     val avgEfficiency = if (totalDistance > 0) (totalEnergy * 1000.0) / totalDistance else 0.0
 
     Card(

--- a/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -1,9 +1,5 @@
 package com.matedroid.ui.screens.stats
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.GradientDrawable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -58,7 +54,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -67,8 +62,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.repository.CountryBoundary
@@ -1124,57 +1117,3 @@ private fun getLocalizedCountryName(countryCode: String): String {
     }
 }
 
-/**
- * Create a steering wheel drawable for drive markers on the map.
- * Draws a circular background with a simple steering wheel shape.
- */
-private fun createSteeringWheelDrawable(
-    context: android.content.Context,
-    color: Int,
-    size: Int = 36
-): android.graphics.drawable.Drawable {
-    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-    val canvas = Canvas(bitmap)
-    val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-
-    val center = size / 2f
-    val radius = size / 2f - 2f
-
-    // Draw white circle background with border
-    paint.color = android.graphics.Color.WHITE
-    paint.style = Paint.Style.FILL
-    canvas.drawCircle(center, center, radius, paint)
-
-    // Draw colored border
-    paint.color = color
-    paint.style = Paint.Style.STROKE
-    paint.strokeWidth = 3f
-    canvas.drawCircle(center, center, radius - 1.5f, paint)
-
-    // Draw steering wheel shape
-    paint.style = Paint.Style.STROKE
-    paint.strokeWidth = 2.5f
-    paint.strokeCap = Paint.Cap.ROUND
-
-    // Outer ring
-    val wheelRadius = radius * 0.6f
-    canvas.drawCircle(center, center, wheelRadius, paint)
-
-    // Center hub
-    paint.style = Paint.Style.FILL
-    canvas.drawCircle(center, center, radius * 0.15f, paint)
-
-    // Three spokes at 90°, 210°, 330°
-    paint.style = Paint.Style.STROKE
-    val spokeLength = wheelRadius - radius * 0.15f
-    for (angle in listOf(270.0, 150.0, 30.0)) {
-        val rad = Math.toRadians(angle)
-        val startX = center + (radius * 0.15f * kotlin.math.cos(rad)).toFloat()
-        val startY = center + (radius * 0.15f * kotlin.math.sin(rad)).toFloat()
-        val endX = center + (wheelRadius * kotlin.math.cos(rad)).toFloat()
-        val endY = center + (wheelRadius * kotlin.math.sin(rad)).toFloat()
-        canvas.drawLine(startX, startY, endX, endY, paint)
-    }
-
-    return BitmapDrawable(context.resources, bitmap)
-}

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -28,13 +28,9 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DirectionsCar
-import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Sync
-import androidx.compose.material.icons.filled.Terrain
 import androidx.compose.material.icons.filled.Thermostat
-import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -57,8 +53,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.lazy.LazyColumn as LogLazyColumn
 import androidx.compose.foundation.lazy.items as logItems
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.TextButton
@@ -1396,46 +1390,6 @@ private fun RecordCard(
                     contentDescription = stringResource(R.string.view_details),
                     modifier = Modifier.size(18.dp),
                     tint = palette.onSurfaceVariant
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RecordItem(
-    emoji: String,
-    label: String,
-    value: String,
-    subtext: String
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = emoji,
-            style = MaterialTheme.typography.titleLarge
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = value,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-            if (subtext.isNotEmpty()) {
-                Text(
-                    text = subtext,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -3,7 +3,6 @@ package com.matedroid.ui.screens.trips
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -23,8 +21,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.clickable
@@ -34,15 +30,10 @@ import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Route
-import androidx.compose.material.icons.filled.Schedule
-import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -81,13 +72,9 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -790,9 +777,6 @@ private fun HorizontalEnergyFlow(
             .height(cardHeight)
     ) {
         val cardW = maxWidth
-        val batteryLeftX = (cardW - batteryW) / 2
-        val batteryRightX = batteryLeftX + batteryW
-        val batteryTopY = (cardHeight - batteryH) / 2
         val centerY = cardHeight / 2
 
         val cardWPx = with(density) { cardW.toPx() }
@@ -1060,95 +1044,6 @@ private fun HorizontalEnergyFlow(
                 )
             }
         }
-    }
-}
-
-// === Stats — StatsSectionCard pattern from DriveDetailScreen ===
-
-private data class StatItem(val label: String, val value: String)
-
-@Composable
-private fun StatsSectionCard(
-    title: String,
-    icon: ImageVector,
-    stats: List<StatItem>
-) {
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp
-    val columnCount = when {
-        screenWidth > 600 -> 4
-        screenWidth > 340 -> 3
-        else -> 2
-    }
-
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        )
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 12.dp)
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            val chunked = stats.chunked(columnCount)
-            chunked.forEachIndexed { index, row ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    row.forEach { stat ->
-                        StatItemView(
-                            label = stat.label,
-                            value = stat.value,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    val emptySlots = columnCount - row.size
-                    if (emptySlots > 0) {
-                        repeat(emptySlots) { Spacer(modifier = Modifier.weight(1f)) }
-                    }
-                }
-                if (index < chunked.size - 1) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun StatItemView(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Bold
-        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Card

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -21,9 +21,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.BatteryChargingFull
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.LocalParking
@@ -55,7 +52,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/app/src/main/java/com/matedroid/ui/theme/CarColorPalette.kt
+++ b/app/src/main/java/com/matedroid/ui/theme/CarColorPalette.kt
@@ -1,6 +1,5 @@
 package com.matedroid.ui.theme
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -415,7 +414,7 @@ object CarColorPalettes {
                 if (darkTheme) midnightCherryDarkPalette else midnightCherryLightPalette
 
             colorKey.contains("ultrared") || colorKey == "pr01" ->
-                if (darkTheme) ultraRedDarkPalette else ultraRedDarkPalette
+                if (darkTheme) ultraRedDarkPalette else ultraRedLightPalette
 
             colorKey.contains("red") || colorKey == "ppmr" ->
                 if (darkTheme) redDarkPalette else redLightPalette

--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -37,7 +37,6 @@ import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.appWidgetBackground
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
-import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -46,7 +45,6 @@ import androidx.glance.layout.Column
 import androidx.glance.layout.ContentScale
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
-import androidx.glance.layout.fillMaxHeight
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -13,16 +13,12 @@
 
     <!-- ==================== Dashboard Screen ==================== -->
     <!-- Dialog title when user has multiple vehicles and can choose one -->
-    <string name="select_vehicle">Selecciona vehicle</string>
 
     <!-- Fallback name for a car when no display name is set. %d is the car ID number -->
-    <string name="car_fallback_name">Cotxe %d</string>
 
     <!-- Content description for checkmark icon next to selected vehicle -->
-    <string name="selected">Seleccionat</string>
 
     <!-- Content description for dropdown arrow indicating car can be changed -->
-    <string name="select_car">Selecciona cotxe</string>
 
     <!-- Content description for settings gear icon in top bar -->
     <string name="settings">Configuració</string>
@@ -64,7 +60,6 @@
     <string name="online">En línia</string>
 
     <!-- Content description when sentry mode is active -->
-    <string name="sentry_mode_active">Mode sentinella actiu</string>
 
     <!-- Content description for inside temperature indicator -->
     <string name="inside_temp">Temperatura interior</string>
@@ -359,7 +354,6 @@
     <string name="battery_level">Nivell de bateria</string>
     <string name="elevation_profile">Perfil d\'altitud</string>
     <!-- Title for the speed distribution histogram in drive details -->
-    <string name="speed_distribution">Distribució de velocitat</string>
 
     <!-- Weather section -->
     <string name="weather_during_trip">Temps durant el viatge</string>
@@ -563,7 +557,6 @@
     <string name="stats_avg_efficiency">Eficiència Mitjana</string>
 
     <!-- Label for maximum speed recorded -->
-    <string name="stats_top_speed">Velocitat Màx</string>
 
     <!-- Label for average cost per 100 km. %1$s is the distance unit (km or mi) -->
     <string name="stats_cost_per_distance">Cost / 100 %1$s</string>
@@ -775,19 +768,13 @@
     <string name="regions_visited_title">Regions a %s</string>
 
     <!-- Plural for number of regions. %d is the count -->
-    <plurals name="format_regions_count">
-        <item quantity="one">%d regió</item>
-        <item quantity="other">%d regions</item>
-    </plurals>
 
     <!-- Empty state when no regions have been recorded -->
     <string name="no_regions_found">No hi ha regions registrades.</string>
 
     <!-- Header card title showing country totals -->
-    <string name="regions_country_summary">Resum del País</string>
 
     <!-- Map showing charge locations in the country -->
-    <string name="country_charge_map_title">Punts de Càrrega</string>
     <!-- Plural for number of charges on the map. %d is the count -->
     <plurals name="format_charges_on_map">
         <item quantity="one">%d càrrega</item>
@@ -795,7 +782,6 @@
     </plurals>
 
     <!-- Map showing drive start locations in the country -->
-    <string name="country_drives_map_title">Punts d\'Inici</string>
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
         <item quantity="one">%d viatge</item>
@@ -1054,18 +1040,13 @@
     <string name="nav_trips">Viatges</string>
     <string name="trips_title">Viatges</string>
     <string name="trips_empty">No s\'han detectat viatges.\nUn viatge requereix almenys 2 trajectes connectats per una càrrega DC.</string>
-    <string name="trips_sync_warning">Sincronització en curs — alguns viatges podrien no aparèixer fins que les dades de càrrega estiguin completament processades.</string>
     <string name="trip_detail_title">Detalls del viatge</string>
     <string name="trip_summary">Resum del viatge</string>
     <string name="trip_legs">Etapes del viatge</string>
-    <string name="trip_route_map">Mapa de ruta</string>
-    <string name="trip_charge_stops">Parades de càrrega</string>
     <string name="trip_no_stops">sense parades</string>
     <string name="trip_one_stop">1 parada</string>
     <string name="trip_n_stops">%1$d parades</string>
     <string name="trip_driving_time">Temps de conducció</string>
-    <string name="trip_total_time">Temps total</string>
-    <string name="trip_energy_consumed">Energia consumida</string>
     <string name="trip_energy_charged">Energia carregada</string>
     <string name="trip_charge_cost">Cost de càrrega</string>
     <string name="trip_leg_drive">Trajecte %1$d</string>
@@ -1116,10 +1097,8 @@
     <string name="car_picker_wheel_style">Estil de llantes</string>
 
     <!-- Button to confirm the car image selection -->
-    <string name="car_picker_confirm">Confirma selecció</string>
 
     <!-- Button to reset to automatic detection -->
-    <string name="car_picker_auto">Auto</string>
     <!-- Content description for reset to default button -->
     <string name="car_picker_reset_default">Restablir a valor detectat</string>
 
@@ -1166,7 +1145,6 @@
     <string name="widget_select_car_title">Selecciona un vehicle per a l\'estri</string>
     <string name="widget_loading">Carregant…</string>
     <string name="widget_error_configure">Toca per configurar</string>
-    <string name="widget_tap_to_open">Toca per obrir MateDroid</string>
 
     <!-- ==================== Diàleg de permís de notificacions ==================== -->
     <string name="notification_permission_title">Mantingues-te informat</string>
@@ -1181,9 +1159,6 @@
     <string name="where_was_i_charging">Carregant</string>
     <string name="where_was_i_parked">Aparcat</string>
     <string name="where_was_i_go">Anar!</string>
-    <string name="where_was_i_pick_date">Tria una data</string>
-    <string name="where_was_i_pick_time">Tria una hora</string>
-    <string name="where_was_i_tap_details">Toca per veure detalls</string>
     <string name="where_was_i_no_data">No hi ha dades disponibles per a aquesta data</string>
     <!-- Tooltip shown when tapping the map pin on the Where Was I screen -->
     <string name="you_were_here">Eres aquí!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,16 +13,12 @@
 
     <!-- ==================== Dashboard Screen ==================== -->
     <!-- Dialog title when user has multiple vehicles and can choose one -->
-    <string name="select_vehicle">Seleccionar vehículo</string>
 
     <!-- Fallback name for a car when no display name is set. %d is the car ID number -->
-    <string name="car_fallback_name">Coche %d</string>
 
     <!-- Content description for checkmark icon next to selected vehicle -->
-    <string name="selected">Seleccionado</string>
 
     <!-- Content description for dropdown arrow indicating car can be changed -->
-    <string name="select_car">Seleccionar coche</string>
 
     <!-- Content description for settings gear icon in top bar -->
     <string name="settings">Ajustes</string>
@@ -64,7 +60,6 @@
     <string name="online">En línea</string>
 
     <!-- Content description when sentry mode is active -->
-    <string name="sentry_mode_active">Modo centinela activo</string>
 
     <!-- Content description for inside temperature indicator -->
     <string name="inside_temp">Temperatura interior</string>
@@ -359,7 +354,6 @@
     <string name="battery_level">Nivel de batería</string>
     <string name="elevation_profile">Perfil de altitud</string>
     <!-- Title for the speed distribution histogram in drive details -->
-    <string name="speed_distribution">Distribución de velocidad</string>
 
     <!-- Weather section -->
     <string name="weather_during_trip">Clima durante el viaje</string>
@@ -563,7 +557,6 @@
     <string name="stats_avg_efficiency">Eficiencia Media</string>
 
     <!-- Label for maximum speed recorded -->
-    <string name="stats_top_speed">Velocidad Máx</string>
 
     <!-- Label for average cost per 100 km. %1$s is the distance unit (km or mi) -->
     <string name="stats_cost_per_distance">Coste / 100 %1$s</string>
@@ -775,19 +768,13 @@
     <string name="regions_visited_title">Regiones en %s</string>
 
     <!-- Plural for number of regions. %d is the count -->
-    <plurals name="format_regions_count">
-        <item quantity="one">%d región</item>
-        <item quantity="other">%d regiones</item>
-    </plurals>
 
     <!-- Empty state when no regions have been recorded -->
     <string name="no_regions_found">No hay regiones registradas.</string>
 
     <!-- Header card title showing country totals -->
-    <string name="regions_country_summary">Resumen del País</string>
 
     <!-- Map showing charge locations in the country -->
-    <string name="country_charge_map_title">Puntos de Carga</string>
     <!-- Plural for number of charges on the map. %d is the count -->
     <plurals name="format_charges_on_map">
         <item quantity="one">%d carga</item>
@@ -795,7 +782,6 @@
     </plurals>
 
     <!-- Map showing drive start locations in the country -->
-    <string name="country_drives_map_title">Puntos de Inicio</string>
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
         <item quantity="one">%d viaje</item>
@@ -1054,18 +1040,13 @@
     <string name="nav_trips">Viajes</string>
     <string name="trips_title">Viajes</string>
     <string name="trips_empty">No se detectaron viajes.\nUn viaje requiere al menos 2 trayectos conectados por una carga DC.</string>
-    <string name="trips_sync_warning">Sincronización en curso — algunos viajes podrían no aparecer hasta que los datos de carga estén completamente procesados.</string>
     <string name="trip_detail_title">Detalles del viaje</string>
     <string name="trip_summary">Resumen del viaje</string>
     <string name="trip_legs">Etapas del viaje</string>
-    <string name="trip_route_map">Mapa de ruta</string>
-    <string name="trip_charge_stops">Paradas de carga</string>
     <string name="trip_no_stops">sin paradas</string>
     <string name="trip_one_stop">1 parada</string>
     <string name="trip_n_stops">%1$d paradas</string>
     <string name="trip_driving_time">Tiempo de conducción</string>
-    <string name="trip_total_time">Tiempo total</string>
-    <string name="trip_energy_consumed">Energía consumida</string>
     <string name="trip_energy_charged">Energía cargada</string>
     <string name="trip_charge_cost">Coste de carga</string>
     <string name="trip_leg_drive">Trayecto %1$d</string>
@@ -1116,10 +1097,8 @@
     <string name="car_picker_wheel_style">Estilo de llantas</string>
 
     <!-- Button to confirm the car image selection -->
-    <string name="car_picker_confirm">Confirmar selección</string>
 
     <!-- Button to reset to automatic detection -->
-    <string name="car_picker_auto">Auto</string>
     <!-- Content description for reset to default button -->
     <string name="car_picker_reset_default">Restablecer a valor detectado</string>
 
@@ -1166,7 +1145,6 @@
     <string name="widget_select_car_title">Selecciona un vehículo para el widget</string>
     <string name="widget_loading">Cargando…</string>
     <string name="widget_error_configure">Toca para configurar</string>
-    <string name="widget_tap_to_open">Toca para abrir MateDroid</string>
 
     <!-- ==================== Diálogo de permiso de notificaciones ==================== -->
     <string name="notification_permission_title">Mantente informado</string>
@@ -1181,9 +1159,6 @@
     <string name="where_was_i_charging">Cargando</string>
     <string name="where_was_i_parked">Aparcado</string>
     <string name="where_was_i_go">Ir!</string>
-    <string name="where_was_i_pick_date">Elige una fecha</string>
-    <string name="where_was_i_pick_time">Elige una hora</string>
-    <string name="where_was_i_tap_details">Toca para ver detalles</string>
     <string name="where_was_i_no_data">No hay datos disponibles para esta fecha</string>
     <!-- Tooltip shown when tapping the map pin on the Where Was I screen -->
     <string name="you_were_here">¡Estabas aquí!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -13,16 +13,12 @@
 
     <!-- ==================== Dashboard Screen ==================== -->
     <!-- Dialog title when user has multiple vehicles and can choose one -->
-    <string name="select_vehicle">Seleziona veicolo</string>
 
     <!-- Fallback name for a car when no display name is set. %d is the car ID number -->
-    <string name="car_fallback_name">Auto %d</string>
 
     <!-- Content description for checkmark icon next to selected vehicle -->
-    <string name="selected">Selezionato</string>
 
     <!-- Content description for dropdown arrow indicating car can be changed -->
-    <string name="select_car">Seleziona auto</string>
 
     <!-- Content description for settings gear icon in top bar -->
     <string name="settings">Impostazioni</string>
@@ -64,7 +60,6 @@
     <string name="online">Online</string>
 
     <!-- Content description when sentry mode is active -->
-    <string name="sentry_mode_active">Modalità sentinella attiva</string>
 
     <!-- Content description for inside temperature indicator -->
     <string name="inside_temp">Temperatura interna</string>
@@ -359,7 +354,6 @@
     <string name="battery_level">Livello batteria</string>
     <string name="elevation_profile">Profilo altitudine</string>
     <!-- Title for the speed distribution histogram in drive details -->
-    <string name="speed_distribution">Distribuzione velocità</string>
 
     <!-- Weather section -->
     <string name="weather_during_trip">Meteo durante il viaggio</string>
@@ -563,7 +557,6 @@
     <string name="stats_avg_efficiency">Efficienza Media</string>
 
     <!-- Label for maximum speed recorded -->
-    <string name="stats_top_speed">Velocità Max</string>
 
     <!-- Label for average cost per 100 km. %1$s is the distance unit (km or mi) -->
     <string name="stats_cost_per_distance">Costo / 100 %1$s</string>
@@ -775,19 +768,13 @@
     <string name="regions_visited_title">Regioni in %s</string>
 
     <!-- Plural for number of regions. %d is the count -->
-    <plurals name="format_regions_count">
-        <item quantity="one">%d regione</item>
-        <item quantity="other">%d regioni</item>
-    </plurals>
 
     <!-- Empty state when no regions have been recorded -->
     <string name="no_regions_found">Nessuna regione registrata.</string>
 
     <!-- Header card title showing country totals -->
-    <string name="regions_country_summary">Riepilogo Paese</string>
 
     <!-- Map showing charge locations in the country -->
-    <string name="country_charge_map_title">Punti di Ricarica</string>
     <!-- Plural for number of charges on the map. %d is the count -->
     <plurals name="format_charges_on_map">
         <item quantity="one">%d ricarica</item>
@@ -795,7 +782,6 @@
     </plurals>
 
     <!-- Map showing drive start locations in the country -->
-    <string name="country_drives_map_title">Punti di Partenza</string>
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
         <item quantity="one">%d viaggio</item>
@@ -1054,18 +1040,13 @@
     <string name="nav_trips">Viaggi</string>
     <string name="trips_title">Viaggi</string>
     <string name="trips_empty">Nessun viaggio rilevato.\nUn viaggio richiede almeno 2 tratte collegate da una ricarica DC.</string>
-    <string name="trips_sync_warning">Sincronizzazione in corso — alcuni viaggi potrebbero non apparire fino al completamento dei dati di ricarica.</string>
     <string name="trip_detail_title">Dettagli viaggio</string>
     <string name="trip_summary">Riepilogo viaggio</string>
     <string name="trip_legs">Tappe del viaggio</string>
-    <string name="trip_route_map">Mappa del percorso</string>
-    <string name="trip_charge_stops">Soste di ricarica</string>
     <string name="trip_no_stops">nessuna sosta</string>
     <string name="trip_one_stop">1 sosta</string>
     <string name="trip_n_stops">%1$d soste</string>
     <string name="trip_driving_time">Tempo di guida</string>
-    <string name="trip_total_time">Tempo totale</string>
-    <string name="trip_energy_consumed">Energia consumata</string>
     <string name="trip_energy_charged">Energia ricaricata</string>
     <string name="trip_charge_cost">Costo ricarica</string>
     <string name="trip_leg_drive">Tratta %1$d</string>
@@ -1116,10 +1097,8 @@
     <string name="car_picker_wheel_style">Stile cerchi</string>
 
     <!-- Button to confirm the car image selection -->
-    <string name="car_picker_confirm">Conferma selezione</string>
 
     <!-- Button to reset to automatic detection -->
-    <string name="car_picker_auto">Auto</string>
     <!-- Content description for reset to default button -->
     <string name="car_picker_reset_default">Ripristina impostazione rilevata</string>
 
@@ -1166,7 +1145,6 @@
     <string name="widget_select_car_title">Seleziona un veicolo per il widget</string>
     <string name="widget_loading">Caricamento…</string>
     <string name="widget_error_configure">Tocca per configurare</string>
-    <string name="widget_tap_to_open">Tocca per aprire MateDroid</string>
 
     <!-- ==================== Finestra permesso notifiche ==================== -->
     <string name="notification_permission_title">Resta informato</string>
@@ -1181,9 +1159,6 @@
     <string name="where_was_i_charging">In ricarica</string>
     <string name="where_was_i_parked">Parcheggiato</string>
     <string name="where_was_i_go">Vai!</string>
-    <string name="where_was_i_pick_date">Scegli una data</string>
-    <string name="where_was_i_pick_time">Scegli un orario</string>
-    <string name="where_was_i_tap_details">Tocca per dettagli</string>
     <string name="where_was_i_no_data">Nessun dato disponibile per questa data</string>
     <!-- Tooltip shown when tapping the map pin on the Where Was I screen -->
     <string name="you_were_here">Eri qui!</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -13,16 +13,12 @@
 
     <!-- ==================== Dashboard Screen ==================== -->
     <!-- Dialog title when user has multiple vehicles and can choose one -->
-    <string name="select_vehicle">选择车辆</string>
 
     <!-- Fallback name for a car when no display name is set. %d is the car ID number -->
-    <string name="car_fallback_name">车辆 %d</string>
 
     <!-- Content description for checkmark icon next to selected vehicle -->
-    <string name="selected">已选择</string>
 
     <!-- Content description for dropdown arrow indicating car can be changed -->
-    <string name="select_car">选择车辆</string>
 
     <!-- Content description for settings gear icon in top bar -->
     <string name="settings">设置</string>
@@ -64,7 +60,6 @@
     <string name="online">在线</string>
 
     <!-- Content description when sentry mode is active -->
-    <string name="sentry_mode_active">哨兵模式已启用</string>
 
     <!-- Content description for inside temperature indicator -->
     <string name="inside_temp">车内温度</string>
@@ -359,7 +354,6 @@
     <string name="battery_level">电池电量</string>
     <string name="elevation_profile">海拔曲线</string>
     <!-- Title for the speed distribution histogram in drive details -->
-    <string name="speed_distribution">速度分布</string>
 
     <!-- Weather section -->
     <string name="weather_during_trip">旅程中的天气</string>
@@ -563,7 +557,6 @@
     <string name="stats_avg_efficiency">平均能效</string>
 
     <!-- Label for maximum speed recorded -->
-    <string name="stats_top_speed">最高速度</string>
 
     <!-- Label for average cost per 100 km. %1$s is the distance unit (km or mi) -->
     <string name="stats_cost_per_distance">费用 / 100 %1$s</string>
@@ -775,19 +768,13 @@
     <string name="regions_visited_title">%s 的地区</string>
 
     <!-- Plural for number of regions. %d is the count -->
-    <plurals name="format_regions_count">
-        <item quantity="one">%d 个地区</item>
-        <item quantity="other">%d 个地区</item>
-    </plurals>
 
     <!-- Empty state when no regions have been recorded -->
     <string name="no_regions_found">暂无地区记录。</string>
 
     <!-- Header card title showing country totals -->
-    <string name="regions_country_summary">国家概览</string>
 
     <!-- Map showing charge locations in the country -->
-    <string name="country_charge_map_title">充电位置</string>
     <!-- Plural for number of charges on the map. %d is the count -->
     <plurals name="format_charges_on_map">
         <item quantity="one">%d 次充电</item>
@@ -795,7 +782,6 @@
     </plurals>
 
     <!-- Map showing drive start locations in the country -->
-    <string name="country_drives_map_title">行程位置</string>
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
         <item quantity="one">%d 次行程</item>
@@ -1055,18 +1041,13 @@
     <string name="nav_trips">行程</string>
     <string name="trips_title">行程</string>
     <string name="trips_empty">尚未检测到公路旅行。\n行程需要至少 2 段驾驶和 1 次直流充电。</string>
-    <string name="trips_sync_warning">同步进行中 — 部分行程可能在充电数据完全处理后才会显示。</string>
     <string name="trip_detail_title">行程详情</string>
     <string name="trip_summary">行程概览</string>
     <string name="trip_legs">行程段落</string>
-    <string name="trip_route_map">路线地图</string>
-    <string name="trip_charge_stops">充电站</string>
     <string name="trip_no_stops">无停靠</string>
     <string name="trip_one_stop">1 个停靠</string>
     <string name="trip_n_stops">%1$d 个停靠</string>
     <string name="trip_driving_time">驾驶时间</string>
-    <string name="trip_total_time">总时间</string>
-    <string name="trip_energy_consumed">消耗能量</string>
     <string name="trip_energy_charged">充入能量</string>
     <string name="trip_charge_cost">充电费用</string>
     <string name="trip_leg_drive">行驶 %1$d</string>
@@ -1117,10 +1098,8 @@
     <string name="car_picker_wheel_style">轮毂样式</string>
 
     <!-- Button to confirm the car image selection -->
-    <string name="car_picker_confirm">确认选择</string>
 
     <!-- Button to reset to automatic detection -->
-    <string name="car_picker_auto">自动</string>
 
     <!-- Content description for reset to default button -->
     <string name="car_picker_reset_default">重置为自动检测</string>
@@ -1177,7 +1156,6 @@
     <string name="widget_error_configure">点击以配置</string>
 
     <!-- Tap hint shown on the widget (accessibility / tooltip) -->
-    <string name="widget_tap_to_open">点击打开 MateDroid</string>
 
     <!-- ==================== Notification Permission Dialog ==================== -->
     <!-- Title of the one-time dialog asking the user to enable notifications -->
@@ -1203,11 +1181,8 @@
     <!-- Button to confirm date/time selection -->
     <string name="where_was_i_go">查看！</string>
     <!-- Date picker dialog title -->
-    <string name="where_was_i_pick_date">选择日期</string>
     <!-- Time picker dialog title -->
-    <string name="where_was_i_pick_time">选择时间</string>
     <!-- Tap hint on driving/charging state cards -->
-    <string name="where_was_i_tap_details">点击查看详情</string>
     <!-- Error when no data available for the selected date -->
     <string name="where_was_i_no_data">该日期没有可用数据</string>
     <!-- Tooltip shown when tapping the map pin on the Where Was I screen -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Tesla-inspired colors -->
-    <color name="tesla_red">#E31937</color>
-    <color name="tesla_dark">#171A20</color>
-    <color name="tesla_blue">#3E6AE1</color>
-
-    <!-- Status colors -->
-    <color name="status_success">#4CAF50</color>
-    <color name="status_warning">#FF9800</color>
-    <color name="status_error">#F44336</color>
-
     <!-- Adaptative icons -->
     <color name="ic_launcher_background">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,16 +13,12 @@
 
     <!-- ==================== Dashboard Screen ==================== -->
     <!-- Dialog title when user has multiple vehicles and can choose one -->
-    <string name="select_vehicle">Select Vehicle</string>
 
     <!-- Fallback name for a car when no display name is set. %d is the car ID number -->
-    <string name="car_fallback_name">Car %d</string>
 
     <!-- Content description for checkmark icon next to selected vehicle -->
-    <string name="selected">Selected</string>
 
     <!-- Content description for dropdown arrow indicating car can be changed -->
-    <string name="select_car">Select car</string>
 
     <!-- Content description for settings gear icon in top bar -->
     <string name="settings">Settings</string>
@@ -64,7 +60,6 @@
     <string name="online">Online</string>
 
     <!-- Content description when sentry mode is active -->
-    <string name="sentry_mode_active">Sentry mode active</string>
 
     <!-- Content description for inside temperature indicator -->
     <string name="inside_temp">Inside temperature</string>
@@ -360,7 +355,6 @@
     <string name="battery_level">Battery Level</string>
     <string name="elevation_profile">Elevation Profile</string>
     <!-- Title for the speed distribution histogram in drive details -->
-    <string name="speed_distribution">Speed Distribution</string>
 
     <!-- Weather section -->
     <string name="weather_during_trip">Weather during the trip</string>
@@ -564,7 +558,6 @@
     <string name="stats_avg_efficiency">Avg Efficiency</string>
 
     <!-- Label for maximum speed recorded -->
-    <string name="stats_top_speed">Top Speed</string>
 
     <!-- Label for average cost per 100 km. %1$s is the distance unit (km or mi) -->
     <string name="stats_cost_per_distance">Cost / 100 %1$s</string>
@@ -776,19 +769,13 @@
     <string name="regions_visited_title">Regions in %s</string>
 
     <!-- Plural for number of regions. %d is the count -->
-    <plurals name="format_regions_count">
-        <item quantity="one">%d region</item>
-        <item quantity="other">%d regions</item>
-    </plurals>
 
     <!-- Empty state when no regions have been recorded -->
     <string name="no_regions_found">No regions recorded yet.</string>
 
     <!-- Header card title showing country totals -->
-    <string name="regions_country_summary">Country Summary</string>
 
     <!-- Map showing charge locations in the country -->
-    <string name="country_charge_map_title">Charge Locations</string>
     <!-- Plural for number of charges on the map. %d is the count -->
     <plurals name="format_charges_on_map">
         <item quantity="one">%d charge</item>
@@ -796,7 +783,6 @@
     </plurals>
 
     <!-- Map showing drive start locations in the country -->
-    <string name="country_drives_map_title">Drive Locations</string>
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
         <item quantity="one">%d drive</item>
@@ -1069,7 +1055,6 @@
     <!-- Empty state when no trips detected -->
     <string name="trips_empty">No road trips detected yet.\nA trip requires at least 2 drives connected by a DC charge stop.</string>
     <!-- Warning when deep sync is incomplete -->
-    <string name="trips_sync_warning">Sync in progress — some trips may not appear until charge data is fully processed.</string>
     <!-- Trip detail screen title -->
     <string name="trip_detail_title">Trip Details</string>
     <!-- Trip summary section header -->
@@ -1077,9 +1062,7 @@
     <!-- Trip legs section header -->
     <string name="trip_legs">Trip Legs</string>
     <!-- Trip route map header -->
-    <string name="trip_route_map">Route Map</string>
     <!-- Number of charge stops -->
-    <string name="trip_charge_stops">Charge stops</string>
     <!-- Trip list row: no charge stops -->
     <string name="trip_no_stops">no stops</string>
     <!-- Trip list row: exactly one charge stop -->
@@ -1089,9 +1072,7 @@
     <!-- Driving time label -->
     <string name="trip_driving_time">Driving time</string>
     <!-- Total time (wall clock) label -->
-    <string name="trip_total_time">Total time</string>
     <!-- Energy consumed label -->
-    <string name="trip_energy_consumed">Energy used</string>
     <!-- Energy charged label -->
     <string name="trip_energy_charged">Energy charged</string>
     <!-- Charge cost label -->
@@ -1202,10 +1183,8 @@
     <string name="car_picker_wheel_style">Wheel Style</string>
 
     <!-- Button to confirm the car image selection -->
-    <string name="car_picker_confirm">Confirm Selection</string>
 
     <!-- Button to reset to automatic detection -->
-    <string name="car_picker_auto">Auto</string>
 
     <!-- Content description for reset to default button -->
     <string name="car_picker_reset_default">Reset to detected default</string>
@@ -1262,7 +1241,6 @@
     <string name="widget_error_configure">Tap to configure</string>
 
     <!-- Tap hint shown on the widget (accessibility / tooltip) -->
-    <string name="widget_tap_to_open">Tap to open MateDroid</string>
 
     <!-- ==================== Notification Permission Dialog ==================== -->
     <!-- Title of the one-time dialog asking the user to enable notifications -->
@@ -1288,11 +1266,8 @@
     <!-- Button to confirm date/time selection -->
     <string name="where_was_i_go">Go!</string>
     <!-- Date picker dialog title -->
-    <string name="where_was_i_pick_date">Pick a date</string>
     <!-- Time picker dialog title -->
-    <string name="where_was_i_pick_time">Pick a time</string>
     <!-- Tap hint on driving/charging state cards -->
-    <string name="where_was_i_tap_details">Tap for details</string>
     <!-- Error when no data available for the selected date -->
     <string name="where_was_i_no_data">No data available for this date</string>
     <!-- Tooltip shown when tapping the map pin on the Where Was I screen -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,14 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.detekt)
+}
+
+// Minimal detekt setup — only the rules that catch actual dead code, to keep the signal high
+// and the noise low. The config file is a tiny allow-list; everything else is off.
+detekt {
+    config.setFrom(files("$rootDir/detekt.yml"))
+    buildUponDefaultConfig = true
+    parallel = true
+    source.setFrom(files("app/src/main/java"))
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,90 @@
+# detekt configuration — minimal, dead-code oriented.
+# We build upon the default config but turn OFF every rule set, then opt back in
+# to only the specific rules that catch genuinely unused code. Keeps the signal
+# high, avoids stylistic-noise spam in CI.
+
+build:
+  maxIssues: 0
+
+config:
+  # We keep buildUponDefaultConfig = true for sensible defaults, but disable
+  # validation so our pared-down config doesn't need to exhaustively mirror every
+  # rule name in the defaults.
+  validation: false
+  warningsAsErrors: false
+
+comments:
+  active: false
+complexity:
+  active: false
+coroutines:
+  active: false
+empty-blocks:
+  active: false
+exceptions:
+  active: false
+naming:
+  active: false
+performance:
+  active: false
+potential-bugs:
+  active: false
+
+style:
+  active: true
+  # Dead-code rules (the whole reason we added detekt)
+  UnusedImports:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    # Compose @Preview functions are used by the IDE preview tool, not by runtime code.
+    # Allow any private function whose name ends in "Preview" so detekt skips them.
+    allowedNames: '(_|ignored|expected|serialVersionUID|.*Preview.*)'
+  UnusedPrivateProperty:
+    active: true
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+  UnusedParameter:
+    active: false  # too noisy on Compose lambdas / DI constructors
+  FunctionOnlyReturningConstant:
+    active: false
+  LoopWithTooManyJumpStatements:
+    active: false
+  # Everything else in the style set: off — we don't want nitpick noise.
+  ReturnCount:
+    active: false
+  MagicNumber:
+    active: false
+  WildcardImport:
+    active: false
+  MaxLineLength:
+    active: false
+  NewLineAtEndOfFile:
+    active: false
+  NoTabs:
+    active: false
+  UnnecessaryAbstractClass:
+    active: false
+  UnnecessaryApply:
+    active: false
+  UnnecessaryLet:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
+  MayBeConst:
+    active: false
+  VarCouldBeVal:
+    active: false
+  ModifierOrder:
+    active: false
+  ForbiddenComment:
+    active: false
+  SerialVersionUIDInSerializableClass:
+    active: false
+  UseDataClass:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  UtilityClassWithPublicConstructor:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ room = "2.6.1"
 workManager = "2.9.1"
 hiltWork = "1.2.0"
 glance = "1.1.1"
+detekt = "1.23.7"
 
 [libraries]
 # Core Android
@@ -93,3 +94,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
## Summary

Adds [detekt](https://detekt.dev) as a permanent Gradle plugin so unused imports / members can't silently accumulate again. The config is deliberately minimal — only three dead-code rules are enabled (UnusedImports, UnusedPrivateMember, UnusedPrivateProperty) so CI doesn't get noisy with stylistic opinions.

### Real bug detekt caught

**\`CarColorPalettes.forExteriorColor\`** returned the **dark** ultra-red palette in both branches of its light/dark ternary, so light-theme "Ultra Red" cars were rendering with the dark palette. The unused \`ultraRedLightPalette\` private property was the smoking gun — it should've been the else branch.

### Dead code pruned

- **69 unused Kotlin imports** across 22 files
- **11 unused private members**: \`InfoItem\`, \`RecordItem\`, \`StatsSectionCard\`, \`StatItem\`, \`StatItemView\`, \`createSteeringWheelDrawable\`, plus 5 unused private properties left behind by earlier refactors
- **21 unused string resources** across all 5 locales (en/it/es/ca/zh)
- **6 unused colors** (the \`tesla_*\` and \`status_*\` XML entries — the Compose code uses the Kotlin-side \`StatusError\` / \`StatusSuccess\` from \`ui/theme/Color.kt\`, not the XML duplicates)
- **1 unused plural** (\`format_regions_count\`)

Net: **-338 lines**.

### Not touched

Launcher-icon resources (\`ic_launcher_*\`) — lint flags them but touching them risks breaking the adaptive-icon tooling. Left alone.

## Test plan

- [ ] \`./gradlew detekt\` passes.
- [ ] \`./gradlew lintDebug\` passes (only 5 residual launcher-icon warnings remain, as expected).
- [ ] \`./gradlew testDebugUnitTest\` passes.
- [ ] Open an "Ultra Red" car in light theme — the bug fix means it should now use the light ultra-red palette instead of the dark one.