### PR TITLE
chore: dependency bump (phase 1 — AGP-8-compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Dependency bump (phase 1)**: Kotlin 2.0.21 → 2.2.21, AGP 8.7.2 → 8.13.2, Gradle 8.9 → 8.14.4, Compose BOM 2024.11 → 2026.03, Room 2.6.1 → 2.8.4 (new `androidx.room` Gradle plugin for schema export), lifecycle 2.8.7 → 2.9.4, activity-compose 1.9.3 → 1.11.0, navigation-compose 2.8.4 → 2.9.7, Hilt 2.56 → 2.58 (held on AGP-8-compatible line), hilt-navigation-compose 1.2.0 → 1.3.0, retrofit 2.11.0 → 2.12.0, moshi 1.15.1 → 1.15.2, datastore 1.1.1 → 1.1.7, security-crypto 1.1.0-alpha06 → 1.1.0, osmdroid 6.1.18 → 6.1.20, detekt 1.23.7 → 1.23.8, coroutines-test 1.9.0 → 1.10.2, mockk 1.13.13 → 1.14.9, turbine 1.2.0 → 1.2.1. All deprecation warnings fixed at the source (no `@Suppress`): `hiltViewModel` moved to `androidx.hilt.lifecycle.viewmodel.compose`, `rememberPlainTooltipPositionProvider` → `rememberTooltipPositionProvider(TooltipAnchorPosition.Above)`, deprecated `Locale(String, String)` → `Locale.Builder().setRegion(...)`, `fallbackToDestructiveMigration()` → explicit `dropAllTables` overload, osmdroid `Polygon.fillColor/strokeColor/strokeWidth` → `fillPaint`/`outlinePaint`, osmdroid `setBuiltInZoomControls(false)` → `zoomController.setVisibility(NEVER)`, `LocalLifecycleOwner` moved to `androidx.lifecycle.compose`, `kotlinOptions` DSL → `kotlin { compilerOptions { … } }` with the new `-Xannotation-default-target=param-property` flag (Kotlin 2.2 KT-73255). Deferred to next iteration: AGP 9.x / Gradle 9.x / Hilt 2.59+, Retrofit 3.x, OkHttp 5.x, WorkManager 2.10+ (requires test-mocking refactor for `WorkManager.getInstance` — currently pinned at 2.9.1), migration off deprecated `security-crypto`, Moshi code-gen appearing as a kapt processor in the Hilt Java compile (harmless upstream warning).
+
 ## [1.6.0-beta1] - 2026-04-20
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,14 +1,23 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.room)
 }
 
-// Room schema export location for migrations
-ksp {
-    arg("room.schemaLocation", "$projectDir/schemas")
+room {
+    schemaDirectory("$projectDir/schemas")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
 }
 
 android {
@@ -68,10 +77,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -115,6 +120,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
 
     // Compose
@@ -130,6 +136,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.hilt.lifecycle.viewmodel.compose)
 
     // Networking
     implementation(libs.retrofit)

--- a/app/src/main/java/com/matedroid/di/DatabaseModule.kt
+++ b/app/src/main/java/com/matedroid/di/DatabaseModule.kt
@@ -36,7 +36,7 @@ object DatabaseModule {
             StatsDatabase.DATABASE_NAME
         )
             .addMigrations(*StatsDatabase.ALL_MIGRATIONS)
-            .fallbackToDestructiveMigration()  // Fallback for development
+            .fallbackToDestructiveMigration(dropAllTables = false)  // Fallback for development
             .build()
     }
 

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -706,7 +706,7 @@ fun NavGraph(
                     navController.navigate(Screen.ChargeDetail.createRoute(carId, chargeId, exteriorColor))
                 },
                 onNavigateToCountryStats = { countryCode ->
-                    val countryName = java.util.Locale("", countryCode).displayCountry
+                    val countryName = java.util.Locale.Builder().setRegion(countryCode).build().displayCountry
                     navController.navigate(Screen.RegionsVisited.createRoute(carId, countryCode, countryName, exteriorColor))
                 }
             )

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlin.math.roundToInt
 import com.matedroid.R
 import com.matedroid.data.api.models.ChargeDetail

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -71,7 +71,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.ChargeData
 import com.matedroid.ui.components.BarChartData

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.ChargePoint

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.TextButton
@@ -115,13 +116,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.local.CarImageOverride
 import com.matedroid.ui.components.CarImagePickerDialog
 import com.matedroid.ui.components.createPinMarkerDrawable
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import com.matedroid.data.api.models.BatteryDetails
@@ -747,7 +749,7 @@ private fun StatusIcon(
     val tooltipState = rememberTooltipState(isPersistent = true)
     val scope = rememberCoroutineScope()
     TooltipBox(
-        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
         tooltip = {
             PlainTooltip {
                 Text(tooltipText)
@@ -941,7 +943,7 @@ private fun StatusIndicatorsRow(
                 // Outside temp: "Ext:"
                 val extTooltipState = rememberTooltipState(isPersistent = true)
                 TooltipBox(
-                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
                     tooltip = { PlainTooltip { Text(climateTooltip) } },
                     state = extTooltipState
                 ) {
@@ -974,7 +976,7 @@ private fun StatusIndicatorsRow(
                 val intTooltipState = rememberTooltipState(isPersistent = true)
                 val intColor = if (isClimateOn) StatusSuccess else palette.onSurfaceVariant
                 TooltipBox(
-                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
                     tooltip = { PlainTooltip { Text(climateTooltip) } },
                     state = intTooltipState
                 ) {
@@ -1891,7 +1893,7 @@ private fun SmallLocationMap(
                     setMultiTouchControls(false)
 
                     // Disable all interactions for this small preview map
-                    setBuiltInZoomControls(false)
+                    zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
                     isClickable = false
                     isFocusable = false
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlin.math.roundToInt
 import com.matedroid.R
 import com.matedroid.data.api.models.DriveDetail

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.DriveData
 import com.matedroid.data.api.models.Units

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -67,7 +67,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.icons.filled.Battery5Bar
 import androidx.compose.material.icons.filled.EnergySavingsLeaf
 import androidx.compose.material.icons.outlined.EnergySavingsLeaf
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.DriveData
 import com.matedroid.ui.components.BarChartData

--- a/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.local.entity.SentryAlertLog
 import com.matedroid.ui.theme.CarColorPalette

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -72,7 +72,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.local.TirePosition
 import com.matedroid.data.model.Currency

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.CountryRecord
@@ -394,7 +394,7 @@ private fun EmptyState(palette: CarColorPalette) {
  */
 private fun getLocalizedCountryName(countryCode: String): String {
     return try {
-        Locale("", countryCode).getDisplayCountry(Locale.getDefault())
+        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
             .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
     } catch (e: Exception) {
         countryCode

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -62,7 +62,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.repository.CountryBoundary
 import com.matedroid.data.api.models.Units
@@ -926,15 +926,15 @@ private fun createCountryHighlightOverlays(boundary: CountryBoundary, accentColo
             points = ring.map { (lat, lon) -> GeoPoint(lat, lon) }
 
             // Light fill with the accent color (very subtle)
-            fillColor = android.graphics.Color.argb(25,
+            fillPaint.color = android.graphics.Color.argb(25,
                 android.graphics.Color.red(accentColor),
                 android.graphics.Color.green(accentColor),
                 android.graphics.Color.blue(accentColor)
             )
 
             // Visible stroke in accent color
-            strokeColor = accentColor
-            strokeWidth = 3f
+            outlinePaint.color = accentColor
+            outlinePaint.strokeWidth = 3f
         }
     }
 }
@@ -1110,7 +1110,7 @@ private fun formatDate(dateStr: String): String {
  */
 private fun getLocalizedCountryName(countryCode: String): String {
     return try {
-        Locale("", countryCode).getDisplayCountry(Locale.getDefault())
+        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
             .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
     } catch (e: Exception) {
         countryCode

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -76,7 +76,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.entity.DriveSummary

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
@@ -77,7 +77,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
@@ -55,7 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.InteractiveBarChart

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.repository.WeatherCondition
 import com.matedroid.data.repository.countryCodeToFlag
@@ -248,7 +248,7 @@ fun WhereWasIScreen(
                                         Spacer(modifier = Modifier.width(4.dp))
                                     }
                                     val localizedCountryName = loc.countryCode?.let { code ->
-                                        java.util.Locale("", code).getDisplayCountry(java.util.Locale.getDefault())
+                                        java.util.Locale.Builder().setRegion(code).build().getDisplayCountry(java.util.Locale.getDefault())
                                             .takeIf { it.isNotBlank() && it != code }
                                     } ?: loc.countryName ?: loc.countryCode
                                     val breadcrumbParts = listOfNotNull(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.room) apply false
     alias(libs.plugins.detekt)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,37 +1,38 @@
 [versions]
-agp = "8.7.2"
-kotlin = "2.0.21"
-ksp = "2.0.21-1.0.27"
-coreKtx = "1.16.0"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.11.00"
-navigationCompose = "2.8.4"
-hilt = "2.56"
-hiltNavigationCompose = "1.2.0"
-retrofit = "2.11.0"
+agp = "8.13.2"
+kotlin = "2.2.21"
+ksp = "2.2.21-2.0.5"
+coreKtx = "1.18.0"
+lifecycleRuntimeKtx = "2.9.4"
+activityCompose = "1.11.0"
+composeBom = "2026.03.01"
+navigationCompose = "2.9.7"
+hilt = "2.58"
+hiltNavigationCompose = "1.3.0"
+retrofit = "2.12.0"
 okhttp = "4.12.0"
-moshi = "1.15.1"
-datastore = "1.1.1"
-securityCrypto = "1.1.0-alpha06"
-osmdroid = "6.1.18"
+moshi = "1.15.2"
+datastore = "1.1.7"
+securityCrypto = "1.1.0"
+osmdroid = "6.1.20"
 junit = "4.13.2"
 junitExt = "1.2.1"
 espresso = "3.6.1"
-coroutinesTest = "1.9.0"
-mockk = "1.13.13"
-turbine = "1.2.0"
-room = "2.6.1"
+coroutinesTest = "1.10.2"
+mockk = "1.14.9"
+turbine = "1.2.1"
+room = "2.8.4"
 workManager = "2.9.1"
-hiltWork = "1.2.0"
+hiltWork = "1.3.0"
 glance = "1.1.1"
-detekt = "1.23.7"
+detekt = "1.23.8"
 
 [libraries]
 # Core Android
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 
 # Compose
@@ -50,6 +51,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose" }
 
 # Networking
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -94,4 +96,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+room = { id = "androidx.room", version.ref = "room" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Kotlin **2.0.21 → 2.2.21**, AGP **8.7.2 → 8.13.2**, Gradle **8.9 → 8.14.4**, Compose BOM **2024.11 → 2026.03**, Room **2.6.1 → 2.8.4** (new `androidx.room` Gradle plugin for schema export), plus lifecycle, activity-compose, navigation-compose, Hilt, Retrofit, Moshi, DataStore, security-crypto, osmdroid, detekt, coroutines-test, mockk, turbine — all bumped to latest AGP-8-compatible stable.
- All compiler deprecation warnings fixed at the source (no `@Suppress`): `hiltViewModel` package move, `rememberPlainTooltipPositionProvider` → `rememberTooltipPositionProvider(TooltipAnchorPosition.Above)`, `Locale(String, String)` → `Locale.Builder().setRegion(...)`, `fallbackToDestructiveMigration` overload, osmdroid `Polygon.fillColor`/`setBuiltInZoomControls`, `LocalLifecycleOwner` package move, `kotlinOptions` → `kotlin { compilerOptions { … } }`. Added `-Xannotation-default-target=param-property` for Kotlin 2.2 KT-73255.
- Deferred to phase 2 (bigger refactors): AGP 9.x / Gradle 9.x / Hilt 2.59+, Retrofit 3, OkHttp 5, WorkManager 2.10+ (needs DI-injection refactor so `SettingsViewModel`'s `WorkManager.getInstance(context)` call is mockable), migration off the now-deprecated `androidx.security:security-crypto`, upstream Moshi kapt-processor warning emitted from Hilt's Java compile step.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:assembleRelease` — both succeed, zero compiler warnings (except one upstream Moshi note about its own kapt support)
- [x] `./gradlew :app:testDebugUnitTest` — 63/63 pass
- [x] `./gradlew :app:lintDebug` — clean
- [x] `./gradlew detekt` — clean
- [ ] Smoke-test on device before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)