### PR TITLE
fix(trips): prevent overlapping auto-detected trips (and composite LazyColumn key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Trips list crash on duplicate start timestamps (saved + auto-detected trips sharing a drive start).
+
 ### Changed
 - Internal dependency updates.
 

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -312,7 +312,17 @@ class TripRepository @Inject constructor(
         val consumedFingerprints = savedTripDao.getAllConsumedFingerprintsForCar(carId).toSet()
         val suppressed = existingFingerprints + consumedFingerprints
 
-        val detected = tripDetector.detectTrips(drives, dcCharges)
+        // Exclude drives/DC-charges already claimed by a saved trip so the detector
+        // cannot produce an auto-detected trip that overlaps with one. Without this,
+        // a trip [1,2] saved on a first run could reappear as [1,2,3] once drive 3
+        // arrives — both fingerprints differ, neither is suppressed, and the two saved
+        // trips end up sharing drive 1 (same startDate → duplicate LazyColumn key).
+        val usedDriveIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_DRIVE).toSet()
+        val usedChargeIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_CHARGE).toSet()
+        val freeDrives = drives.filter { it.driveId !in usedDriveIds }
+        val freeDcCharges = dcCharges.filter { it.chargeId !in usedChargeIds }
+
+        val detected = tripDetector.detectTrips(freeDrives, freeDcCharges)
         if (detected.isEmpty()) return
 
         val now = System.currentTimeMillis()

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -244,7 +244,15 @@ private fun TripsContent(
         }
 
         // Trip cards
-        itemsIndexed(trips, key = { _, trip -> trip.startDate }) { index, trip ->
+        // Composite key: startDate alone can collide when a saved trip and an auto-detected
+        // trip begin at the same drive timestamp. driveId is a stable per-car unique int, so
+        // combining it with startDate/endDate guarantees uniqueness for the LazyColumn.
+        itemsIndexed(
+            trips,
+            key = { _, trip ->
+                "${trip.startDate}|${trip.endDate}|${trip.drives.firstOrNull()?.driveId ?: 0}"
+            }
+        ) { index, trip ->
             TripItem(
                 trip = trip,
                 units = units,


### PR DESCRIPTION
## Summary

This PR fixes the 1.6.0-beta1 crash **in two layers**:

### 1. Root cause — `TripRepository.autoPersistNewTrips` can produce overlapping saved trips
The auto-detect path only suppressed a newly detected trip if its exact SHA fingerprint (of sorted drive IDs) was already saved or consumed. It never checked whether the detected trip's drives *overlap* with an already-saved trip.

Sequence that produces the bug (no user editing required):
1. First detection run: drives `[1,2]` + DC charge → detector emits trip `[1,2]`, persisted with fingerprint `FP_{1,2}`.
2. More drives sync in. Next run: detector sees `[1,2,3]` and emits trip `[1,2,3]` → `FP_{1,2,3}` ≠ `FP_{1,2}`, so it's **not suppressed** and gets persisted too.
3. DB now has two saved trips sharing drive 1 → identical `startDate` → LazyColumn key collision.

**Fix:** exclude drives & DC charges already claimed by any saved trip (via `SavedTripDao.getUsedLegIds`) before invoking `TripDetector`. With this guard, the detector can't emit an overlapping auto-detected trip, so two saved trips can never share a first drive.

### 2. Defensive UI key — composite key in the trips \`LazyColumn\`
\`TripsScreen\` used \`trip.startDate\` alone as the item key, which made the bug visible as a crash. Swapped for \`"startDate|endDate|firstDriveId"\`. \`driveId\` is a per-car unique int, so the composite is unique for any non-overlapping pair of trips — and even for pathological overlap cases the list now renders instead of crashing.

### Users already affected
Users whose DB already contains overlapping saved trips (created under pre-fix behavior) will now see both rows render correctly without a crash. They can manually delete the redundant one.

## Test plan
- [x] \`./gradlew :app:compileDebugKotlin :app:testDebugUnitTest\` — passes, no new failures
- [x] Existing \`TripDetectorTest\` untouched and still passing (detector itself unchanged)
- [ ] Install on device; confirm trips list opens without crash
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)