### PR TITLE
fix(trips): cosmetic polish on list + detail

### DIFF
--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -464,18 +464,18 @@ private fun TripDetailContent(
             }
         }
 
-        TripWeatherSparklineCard(
-            samples = weatherPoints,
-            palette = palette,
-            units = units
-        )
-
         if (canEdit) {
             TripEditActions(
                 onAddLeg = onAddLeg,
                 onMergeTrip = onMergeTrip
             )
         }
+
+        TripWeatherSparklineCard(
+            samples = weatherPoints,
+            palette = palette,
+            units = units
+        )
 
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -288,7 +288,7 @@ private fun SummaryCard(
                 SummaryItem(
                     icon = Icons.Filled.Speed,
                     label = stringResource(R.string.total_distance),
-                    value = UnitFormatter.formatDistance(totalDistance, units),
+                    value = UnitFormatter.formatDistance(totalDistance, units, decimals = 0),
                     palette = palette,
                     modifier = Modifier.weight(0.8f)
                 )
@@ -305,7 +305,7 @@ private fun SummaryCard(
                 SummaryItem(
                     icon = Icons.Filled.ElectricBolt,
                     label = stringResource(R.string.trip_energy_charged),
-                    value = "%.1f kWh".format(totalEnergyCharged),
+                    value = "%,.0f kWh".format(totalEnergyCharged),
                     palette = palette,
                     modifier = Modifier.weight(0.8f)
                 )
@@ -458,7 +458,7 @@ private fun formatDateChip(dateStr: String): String {
         } catch (_: DateTimeParseException) {
             LocalDateTime.parse(dateStr.replace("Z", ""))
         }
-        dt.format(DateTimeFormatter.ofPattern("d MMM")).uppercase()
+        dt.format(DateTimeFormatter.ofPattern("d MMM yy")).uppercase()
     } catch (_: Exception) {
         dateStr
     }
@@ -550,9 +550,46 @@ internal fun Trip.displayName(): String {
     return custom ?: "${extractCity(startAddress)} → ${extractCity(endAddress)}"
 }
 
+/**
+ * Format a minutes-granularity duration with unit cascading: as the duration grows into
+ * a larger magnitude the smaller unit is dropped (rounded into the next-larger one),
+ * so readers aren't distracted by precision that no longer matters.
+ *  <1h → "Xm"
+ *  1–24h → "Xh Ym" (minute precision)
+ *  1–7d → "Xd Yh" (hour precision, minutes rolled into hours)
+ *  1w–~1mo → "Xw Yd"
+ *  ≥30d → "Xmo Yw"
+ */
 private fun formatDuration(minutes: Int): String {
-    val h = minutes / 60
-    val m = minutes % 60
-    return if (h > 0) "${h}h ${m}m" else "${m}m"
+    val totalMinutes = minutes.coerceAtLeast(0)
+    val totalHours = totalMinutes / 60.0
+    val totalDays = totalHours / 24.0
+
+    return when {
+        totalDays >= 30 -> {
+            val weeks = (totalDays / 7.0).toInt().coerceAtLeast(1)
+            val months = weeks / 4
+            val remWeeks = weeks - months * 4
+            if (remWeeks > 0) "${months}mo ${remWeeks}w" else "${months}mo"
+        }
+        totalDays >= 7 -> {
+            val days = Math.round(totalDays).toInt()
+            val weeks = days / 7
+            val remDays = days - weeks * 7
+            if (remDays > 0) "${weeks}w ${remDays}d" else "${weeks}w"
+        }
+        totalHours >= 24 -> {
+            val hours = Math.round(totalHours).toInt()
+            val days = hours / 24
+            val remHours = hours - days * 24
+            if (remHours > 0) "${days}d ${remHours}h" else "${days}d"
+        }
+        totalHours >= 1 -> {
+            val h = totalMinutes / 60
+            val m = totalMinutes % 60
+            if (m > 0) "${h}h ${m}m" else "${h}h"
+        }
+        else -> "${totalMinutes}m"
+    }
 }
 


### PR DESCRIPTION
## Summary

### Trips list
- **Date chip** on each row now includes a 2-digit year: `21 APR 26` instead of `21 APR`.
- **Duration formatting** cascades magnitudes — drops minutes once days appear, hours once weeks appear, days once months. Examples: `2d 3h`, `1w 2d`, `1mo 2w`. Applied to per-trip duration in each row AND to the total driving time in the summary card at the top (same helper).
- **Summary card** now shows total distance and total energy charged without decimals (`decimals = 0` to `UnitFormatter.formatDistance`, `%,.0f` for kWh).

### Trip detail
- Moved the **Add leg / Merge trip** actions to sit directly under the trip legs card and before the weather sparkline card — closer to the content they act on.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — clean
- [x] Installed release build on Pixel 6a via `installRelease`
- [ ] Eyeball trips list + detail on device before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)