### PR TITLE
fix(trips): heal DBs from beta1 overlap bug + bulletproof list key

### DIFF
--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -49,10 +49,42 @@ class TripRepository @Inject constructor(
         val allCharges = chargeSummaryDao.getAllForCar(carId)
 
         autoPersistNewTrips(carId, drives, dcCharges)
+        cleanupDuplicateSavedTrips(carId)
 
         val saved = savedTripDao.getAllWithLegs(carId)
         return buildTripsFromSaved(saved, drives, allCharges)
             .sortedByDescending { it.startDate }
+    }
+
+    /**
+     * Heal DBs polluted by beta1's detection bug, which could persist several saved trips
+     * with the same drive set. When duplicates exist, keep the one most worth preserving
+     * (user-merged > user-edited > auto-detected, tiebreak: named over unnamed, then lowest id)
+     * and delete the rest.
+     */
+    private suspend fun cleanupDuplicateSavedTrips(carId: Int) {
+        val saved = savedTripDao.getAllWithLegs(carId)
+        if (saved.size < 2) return
+        val byFingerprint = saved.groupBy { computeFingerprint(it.driveIds()) }
+        for ((_, group) in byFingerprint) {
+            if (group.size <= 1) continue
+            val ranked = group.sortedWith(
+                compareBy(
+                    { sourcePriority(it.trip.source) },
+                    { if (it.trip.name.isNullOrBlank()) 1 else 0 },
+                    { it.trip.id }
+                )
+            )
+            for (duplicate in ranked.drop(1)) {
+                savedTripDao.deleteTrip(duplicate.trip.id)
+            }
+        }
+    }
+
+    private fun sourcePriority(source: String): Int = when (source) {
+        SavedTrip.SOURCE_USER_MERGED -> 0
+        SavedTrip.SOURCE_USER_EDITED -> 1
+        else -> 2  // AUTO_DETECTED (and any future sources)
     }
 
     /** Fingerprint for a list of drive IDs. Stable regardless of order. */

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -244,13 +244,15 @@ private fun TripsContent(
         }
 
         // Trip cards
-        // Composite key: startDate alone can collide when a saved trip and an auto-detected
-        // trip begin at the same drive timestamp. driveId is a stable per-car unique int, so
-        // combining it with startDate/endDate guarantees uniqueness for the LazyColumn.
+        // Bulletproof key: base is the composite of startDate/endDate/firstDriveId, which is
+        // unique across any non-overlapping pair of trips. The list index is appended as a
+        // final tiebreaker so that even a pre-fix DB still carrying literal duplicate saved
+        // trips renders instead of crashing — the repository's cleanup-on-load will have
+        // deleted them by the next launch anyway.
         itemsIndexed(
             trips,
-            key = { _, trip ->
-                "${trip.startDate}|${trip.endDate}|${trip.drives.firstOrNull()?.driveId ?: 0}"
+            key = { index, trip ->
+                "${trip.startDate}|${trip.endDate}|${trip.drives.firstOrNull()?.driveId ?: 0}|$index"
             }
         ) { index, trip ->
             TripItem(


### PR DESCRIPTION
## Summary
Beta2's repo-level guard prevents **new** overlapping auto-detected trips, but users upgrading from beta1 still carry literal duplicate saved trips (same drive set, same fingerprint) in their DB. That causes even the beta2 composite LazyColumn key (`startDate|endDate|firstDriveId`) to collide and crash. Reported by a user after upgrading.

### 1. `cleanupDuplicateSavedTrips()` — heal on every load
Groups saved trips by SHA fingerprint of sorted drive IDs. Any group larger than 1 is a literal duplicate (same drive set ⇒ same trip content). Keep the most-valuable one and delete the rest:
- user-merged > user-edited > auto-detected
- within same source: named over unnamed
- final tiebreak: lowest id (oldest)

Runs before `buildTripsFromSaved` in `TripRepository.getTrips`, so the returned list never contains duplicates. Users' DBs heal on first post-upgrade trips-list open.

### 2. LazyColumn key: append index as last-resort tiebreaker
`"startDate|endDate|firstDriveId|$index"`. With cleanup in place the index is redundant, but it makes the key bulletproof against any future data pathology we haven't imagined yet. The cost (Compose treats all rows as new on a reorder) is negligible on a sorted trips list that doesn't reorder.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest` — clean
- [x] Installed release build on Pixel 6a via `installRelease`
- [ ] User upgrade path (from beta2 install with polluted DB) renders trips list without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)