### PR TITLE
fix(lists): stop full-screen flash on date-filter change with secondary filter active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Charges / Drives list flashed on date-filter change when a secondary filter was active**: the 1.3.x spinner-flicker fix only suppressed the full-screen spinner when the currently-*displayed* list was non-empty, so toggling the date range (e.g. 30 days → 7 days) while AC/DC or distance filters had zeroed out the visible list made `isLoading` flip back to `true` for the duration of the refetch and swap the whole content for a `CircularProgressIndicator`. The guard now checks the raw unfiltered load instead, so the spinner only appears on the true initial load and filter transitions stay smooth.
+
 ## [1.6.0-beta4] - 2026-04-24
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -210,8 +210,12 @@ class ChargesViewModel @Inject constructor(
 
         viewModelScope.launch {
             val state = _uiState.value
-            // Only show loading spinner on initial load, not when changing filters
-            if (!state.isRefreshing && state.charges.isEmpty()) {
+            // Only show the full-screen spinner on the true initial load — i.e. when
+            // we've never successfully fetched any data yet. Using state.charges (the
+            // filtered view) would trip the spinner whenever the active AC/DC or
+            // location filter happened to zero out the list, flashing the whole
+            // screen on every date-range change.
+            if (!state.isRefreshing && allCharges.isEmpty()) {
                 _uiState.update { it.copy(isLoading = true) }
             }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -194,8 +194,12 @@ class DrivesViewModel @Inject constructor(
 
         viewModelScope.launch {
             val state = _uiState.value
-            // Only show loading spinner on initial load, not when changing filters
-            if (!state.isRefreshing && state.drives.isEmpty()) {
+            // Only show the full-screen spinner on the true initial load — i.e. when
+            // we've never successfully fetched any data yet. Using state.drives (the
+            // filtered view) would trip the spinner whenever the active distance
+            // filter happened to zero out the list, flashing the whole screen on
+            // every date-range change.
+            if (!state.isRefreshing && allDrives.isEmpty()) {
                 _uiState.update { it.copy(isLoading = true) }
             }
 


### PR DESCRIPTION
## Summary

- **Charges** and **Drives** screens flashed the full loading spinner on date-filter changes whenever a secondary filter (AC/DC on charges, distance on drives) happened to zero out the currently-displayed list.
- The 1.3.x flicker fix (commit 66d61a2) was checking the *filtered* list (`state.charges` / `state.drives`) to gate the spinner. That works when no secondary filter is active, but as soon as the visible list is empty for filter reasons — not for load reasons — the guard fires and `ChargesScreen.kt:139` / `DrivesScreen.kt:145` swap the whole content for `CircularProgressIndicator`.
- Switched the guard to the raw unfiltered load (`allCharges` / `allDrives`). Those are populated only by the API response, so they're empty only on the true initial load. Filter transitions no longer touch `isLoading`.

Trips screen doesn't need the same fix — no secondary client-side filter, `isLoading` cleared unconditionally after the first load.

## Test plan

- [x] \`./gradlew :app:assembleDebug\` — builds clean
- [x] Installed on physical device (192.168.1.62)
- [ ] Manual: charges screen, select AC filter, toggle date 30d ↔ 7d → no flash, data updates in place
- [ ] Manual: charges screen, select DC filter (even if no DC in range → empty state), toggle date → no flash
- [ ] Manual: drives screen, apply a distance filter that zeroes the list, toggle date → no flash
- [ ] Manual: first launch of each screen → spinner still appears as before on the initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)