### PR TITLE
Editorial row layout for drives & charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Drives & charges list redesign**: Both lists swap their 4-stat-card rows for a magazine-style editorial layout — a 4 dp accent edge (gold for drives, green for AC, orange for DC), an ALL-CAPS dateline above the route or location, supporting numbers reduced to small pills (duration, max speed, battery delta, cost), and the headline metric (km / kWh) set as a display-weight hero on the right. Rows are noticeably shorter so more fits on screen, and the visual language now matches the trips list. Free charges show a green "FREE" pill; when TeslaMate cost-editing is available, the cost pill becomes tappable and gains a small ↗ glyph — replacing the old trailing open-in-new icon. Drive durations now use the cascading-unit format (`47m`, `2h 14m`) instead of `0:47` / `2:14`, matching the trips list.
+
 ## [1.6.0] - 2026-04-25
 
 This release is a top-to-bottom rebuild of the **Trips experience**, plus a handful of refinements elsewhere.

--- a/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
+++ b/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
@@ -1,0 +1,220 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.FlowRowScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+
+/**
+ * "Magazine editorial" list-item layout shared by the drives and charges screens.
+ *
+ * Layout: 4 dp accent strip on the leading edge, soft accent halo bleeding in from the
+ * top-right corner, left column with an ALL-CAPS dateline (and optional trailing badge)
+ * over the title and a FlowRow of supporting pills, right column with the headline
+ * metric in display weight and its unit beneath in the accent color.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun EditorialListItem(
+    accent: Color,
+    dateline: String,
+    title: String,
+    heroValue: String,
+    heroUnit: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    datelineTrailing: (@Composable RowScope.() -> Unit)? = null,
+    pills: @Composable FlowRowScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            // Soft accent halo, top-right corner. Card clips to its rounded shape so the
+            // negative-offset circle bleeds into the corner without escaping the card.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 40.dp, y = (-40).dp)
+                    .size(140.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.radialGradient(
+                            colors = listOf(accent.copy(alpha = 0.14f), Color.Transparent)
+                        )
+                    )
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min)
+            ) {
+                // Accent edge — fillMaxHeight inside an IntrinsicSize.Min row picks up the
+                // body's intrinsic height without circularity.
+                Box(
+                    modifier = Modifier
+                        .width(4.dp)
+                        .fillMaxHeight()
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(accent, accent.copy(alpha = 0.4f))
+                            )
+                        )
+                )
+
+                Row(
+                    modifier = Modifier
+                        .padding(start = 18.dp, end = 16.dp, top = 14.dp, bottom = 12.dp),
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 12.dp)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = dateline,
+                                color = accent,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 10.sp,
+                                letterSpacing = 1.2.sp,
+                                maxLines = 1
+                            )
+                            if (datelineTrailing != null) {
+                                Spacer(modifier = Modifier.width(8.dp))
+                                datelineTrailing()
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            letterSpacing = (-0.3).sp
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                            content = pills
+                        )
+                    }
+
+                    Column(horizontalAlignment = Alignment.End) {
+                        Text(
+                            text = heroValue,
+                            fontSize = 32.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            letterSpacing = (-1).sp,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1
+                        )
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = heroUnit.uppercase(Locale.getDefault()),
+                            color = accent,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 11.sp,
+                            letterSpacing = 1.2.sp,
+                            maxLines = 1
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Small rounded pill used in the FlowRow under an editorial item's title. Default
+ * styling is a faint white-tint background with onSurface text — pass `background` /
+ * `color` for category-tinted variants (e.g. accent-tinted battery delta, AC/DC cost).
+ */
+@Composable
+fun EditorialPill(
+    text: String,
+    modifier: Modifier = Modifier,
+    background: Color = Color.White.copy(alpha = 0.05f),
+    color: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.78f),
+    fontWeight: FontWeight = FontWeight.SemiBold,
+) {
+    Text(
+        text = text,
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(background)
+            .padding(horizontal = 7.dp, vertical = 3.dp),
+        color = color,
+        fontWeight = fontWeight,
+        fontSize = 11.sp,
+        maxLines = 1
+    )
+}
+
+/**
+ * Format an ISO-8601 datetime (with or without offset, as TeslaMate may emit either)
+ * as a locale-aware "MON · 14 APR · 09:42" dateline. Falls back to the raw input on
+ * parse failure rather than swallowing it — better to show a weird value than to hide
+ * it entirely while debugging.
+ */
+internal fun formatEditorialDate(dateStr: String?): String {
+    if (dateStr.isNullOrBlank()) return ""
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (_: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        }
+        // Middle dots are literal because they're outside the pattern alphabet.
+        dt.format(DateTimeFormatter.ofPattern("EEE · d MMM · HH:mm", Locale.getDefault()))
+            .uppercase(Locale.getDefault())
+    } catch (_: Exception) {
+        dateStr
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
+++ b/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
@@ -15,11 +15,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -29,10 +26,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.time.LocalDateTime
@@ -49,6 +52,34 @@ import java.util.Locale
  * over the title and a FlowRow of supporting pills, right column with the headline
  * metric in display weight and its unit beneath in the accent color.
  */
+
+/**
+ * Tight text style: disables Compose's default `includeFontPadding` (which adds ~10% of
+ * the font size as half-leading above/below every glyph) and trims line-height padding
+ * to both sides. Without this, a Text reads visually compact but still measures taller
+ * than its `lineHeight`, leaving phantom whitespace inside cards.
+ */
+private val tightLineHeightStyle = LineHeightStyle(
+    alignment = LineHeightStyle.Alignment.Center,
+    trim = LineHeightStyle.Trim.Both,
+)
+private val tightPlatformStyle = PlatformTextStyle(includeFontPadding = false)
+private fun tightStyle(
+    fontSize: TextUnit,
+    lineHeight: TextUnit = fontSize,
+    fontWeight: FontWeight? = null,
+    color: Color = Color.Unspecified,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+): TextStyle = TextStyle(
+    fontSize = fontSize,
+    lineHeight = lineHeight,
+    fontWeight = fontWeight,
+    color = color,
+    letterSpacing = letterSpacing,
+    platformStyle = tightPlatformStyle,
+    lineHeightStyle = tightLineHeightStyle,
+)
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EditorialListItem(
@@ -71,100 +102,136 @@ fun EditorialListItem(
         ),
         shape = RoundedCornerShape(12.dp)
     ) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            // Soft accent halo, top-right corner. Card clips to its rounded shape so the
-            // negative-offset circle bleeds into the corner without escaping the card.
+        // Halo is drawn as a paint effect via drawBehind, NOT as a child Box. A child
+        // Box with `size(140.dp)` would have contributed 140 dp to the parent's measured
+        // height (align/offset only affect positioning, not measurement) and forced
+        // every card to be ≥ 140 dp tall regardless of its content. drawBehind has no
+        // layout impact — the row sizes itself purely from its content.
+        //
+        // Halo position is anchored to the hero column on the right edge: a soft accent
+        // glow sits behind the headline km/kWh, visually linking the accent color to
+        // the most important number in the row.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+                .drawBehind {
+                    val r = 80.dp.toPx()
+                    val center = Offset(
+                        x = size.width - 28.dp.toPx(),
+                        y = size.height * 0.35f,
+                    )
+                    drawCircle(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                accent.copy(alpha = 0.38f),
+                                accent.copy(alpha = 0.12f),
+                                accent.copy(alpha = 0.02f),
+                                Color.Transparent,
+                            ),
+                            center = center,
+                            radius = r,
+                        ),
+                        radius = r,
+                        center = center,
+                    )
+                }
+        ) {
+            // Accent edge — fillMaxHeight inside an IntrinsicSize.Min row picks up the
+            // body's intrinsic height without circularity.
             Box(
                 modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .offset(x = 40.dp, y = (-40).dp)
-                    .size(140.dp)
-                    .clip(CircleShape)
+                    .width(4.dp)
+                    .fillMaxHeight()
                     .background(
-                        Brush.radialGradient(
-                            colors = listOf(accent.copy(alpha = 0.14f), Color.Transparent)
+                        Brush.verticalGradient(
+                            colors = listOf(accent, accent.copy(alpha = 0.4f))
                         )
                     )
             )
 
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(IntrinsicSize.Min)
+                    .padding(start = 14.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+                verticalAlignment = Alignment.Top
             ) {
-                // Accent edge — fillMaxHeight inside an IntrinsicSize.Min row picks up the
-                // body's intrinsic height without circularity.
-                Box(
+                Column(
                     modifier = Modifier
-                        .width(4.dp)
-                        .fillMaxHeight()
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(accent, accent.copy(alpha = 0.4f))
-                            )
-                        )
-                )
-
-                Row(
-                    modifier = Modifier
-                        .padding(start = 18.dp, end = 16.dp, top = 14.dp, bottom = 12.dp),
-                    verticalAlignment = Alignment.Bottom
+                        .weight(1f)
+                        .padding(end = 10.dp)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(end = 12.dp)
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = dateline,
-                                color = accent,
-                                fontWeight = FontWeight.ExtraBold,
+                    // Line 1 — ALL-CAPS dateline (with optional trailing badge).
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = dateline,
+                            style = tightStyle(
                                 fontSize = 10.sp,
+                                lineHeight = 12.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = accent,
                                 letterSpacing = 1.2.sp,
-                                maxLines = 1
-                            )
-                            if (datelineTrailing != null) {
-                                Spacer(modifier = Modifier.width(8.dp))
-                                datelineTrailing()
-                            }
+                            ),
+                            maxLines = 1
+                        )
+                        if (datelineTrailing != null) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            datelineTrailing()
                         }
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = title,
-                            style = MaterialTheme.typography.titleMedium,
+                    }
+                    Spacer(modifier = Modifier.height(3.dp))
+                    // Line 2 — title (bold), the row's primary identifier.
+                    Text(
+                        text = title,
+                        style = tightStyle(
+                            fontSize = 15.sp,
+                            lineHeight = 17.sp,
                             fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            letterSpacing = (-0.3).sp
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        FlowRow(
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                            content = pills
-                        )
-                    }
-
-                    Column(horizontalAlignment = Alignment.End) {
-                        Text(
-                            text = heroValue,
-                            fontSize = 32.sp,
-                            fontWeight = FontWeight.ExtraBold,
-                            letterSpacing = (-1).sp,
                             color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 1
-                        )
-                        Spacer(modifier = Modifier.height(2.dp))
-                        Text(
-                            text = heroUnit.uppercase(Locale.getDefault()),
-                            color = accent,
+                            letterSpacing = (-0.3).sp,
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(5.dp))
+                    // Line 3 — supporting pills.
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(3.dp),
+                        content = pills
+                    )
+                }
+
+                // Hero column fills the row height with SpaceBetween so the number sits
+                // at the top (next to the dateline) and the unit drops to the bottom
+                // (next to the pills). The halo glow drawn behind the right side of the
+                // row visually anchors both.
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    modifier = Modifier.fillMaxHeight(),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = heroValue,
+                        style = tightStyle(
+                            fontSize = 26.sp,
+                            lineHeight = 26.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            letterSpacing = (-0.8).sp,
+                        ),
+                        maxLines = 1
+                    )
+                    Text(
+                        text = heroUnit.uppercase(Locale.getDefault()),
+                        style = tightStyle(
+                            fontSize = 10.sp,
+                            lineHeight = 11.sp,
                             fontWeight = FontWeight.SemiBold,
-                            fontSize = 11.sp,
+                            color = accent,
                             letterSpacing = 1.2.sp,
-                            maxLines = 1
-                        )
-                    }
+                        ),
+                        maxLines = 1
+                    )
                 }
             }
         }
@@ -189,10 +256,13 @@ fun EditorialPill(
         modifier = modifier
             .clip(RoundedCornerShape(4.dp))
             .background(background)
-            .padding(horizontal = 7.dp, vertical = 3.dp),
-        color = color,
-        fontWeight = fontWeight,
-        fontSize = 11.sp,
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        style = tightStyle(
+            fontSize = 11.sp,
+            lineHeight = 12.sp,
+            fontWeight = fontWeight,
+            color = color,
+        ),
         maxLines = 1
     )
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -217,7 +217,7 @@ private fun ChargesContent(
         state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         item {
             DateFilterChips(

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -31,9 +31,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Paid
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -77,13 +75,14 @@ import com.matedroid.data.api.models.ChargeData
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.BarSegment
 import com.matedroid.ui.components.DateRangePickerDialog
+import com.matedroid.ui.components.EditorialListItem
+import com.matedroid.ui.components.EditorialPill
 import com.matedroid.ui.components.InteractiveBarChart
+import com.matedroid.ui.components.formatEditorialDate
 import com.matedroid.ui.components.formatShortDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -630,187 +629,51 @@ private fun ChargeItem(
     onClick: () -> Unit
 ) {
     val unknownLocation = stringResource(R.string.unknown_location)
-    val energyAddedLabel = stringResource(R.string.energy_added)
-    val durationLabel = stringResource(R.string.duration)
-    val costLabel = stringResource(R.string.cost)
-    val batteryLabel = stringResource(R.string.battery)
-    val editLabel = stringResource(R.string.edit)
+    val freeLabel = stringResource(R.string.charge_free)
+    val accent = if (isDcCharge) palette.dcColor else palette.acColor
 
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Header card with location, date, and AC/DC badge
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.LocationOn,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = charge.address ?: unknownLocation,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1
-                        )
-                        charge.startDate?.let { dateStr ->
-                            Text(
-                                text = formatDate(dateStr),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    ChargeTypeBadge(isDcCharge = isDcCharge, palette = palette)
-                }
-            }
+    val cost = charge.cost ?: 0.0
+    // Existing behavior: a missing cost renders the same as an explicit zero. The user
+    // can tell the two apart only via the edit-cost trailing affordance, which still
+    // points at TeslaMate's cost editor.
+    val isFree = cost == 0.0
+    val costText = if (isFree) freeLabel else "$currencySymbol%.2f".format(cost)
+    val costPillText = if (onEditCost != null) "$costText ↗" else costText
 
-            // Stats row with individual cards
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Energy added
-                ChargeStatCard(
-                    icon = Icons.Default.BatteryChargingFull,
-                    value = "%.1f".format(charge.chargeEnergyAdded ?: 0.0),
-                    unit = "kWh",
-                    label = energyAddedLabel,
-                    modifier = Modifier.weight(1f)
-                )
-
-                // Duration
-                ChargeStatCard(
-                    icon = Icons.Default.Schedule,
-                    value = charge.durationStr ?: "${charge.durationMin ?: 0}m",
-                    unit = "",
-                    label = durationLabel,
-                    modifier = Modifier.weight(1f)
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Cost (tappable if editable)
-                ChargeStatCard(
-                    icon = Icons.Default.Paid,
-                    value = "$currencySymbol%.2f".format(charge.cost ?: 0.0),
-                    unit = "",
-                    label = costLabel,
-                    modifier = Modifier.weight(1f),
-                    trailingIcon = if (onEditCost != null) Icons.AutoMirrored.Filled.OpenInNew else null,
-                    trailingContentDescription = editLabel,
-                    onClick = onEditCost
-                )
-
-                // Battery levels
-                val startLevel = charge.startBatteryLevel
-                val endLevel = charge.endBatteryLevel
-                ChargeStatCard(
-                    icon = Icons.Default.ElectricBolt,
-                    value = if (startLevel != null && endLevel != null) "$startLevel% → $endLevel%" else "--",
-                    unit = "",
-                    label = batteryLabel,
-                    modifier = Modifier.weight(1f)
-                )
-            }
+    EditorialListItem(
+        accent = accent,
+        dateline = formatEditorialDate(charge.startDate),
+        title = charge.address ?: unknownLocation,
+        heroValue = "%.1f".format(charge.chargeEnergyAdded ?: 0.0),
+        heroUnit = "kWh",
+        onClick = onClick,
+        datelineTrailing = {
+            ChargeTypeBadge(isDcCharge = isDcCharge, palette = palette)
         }
-    }
-}
-
-@Composable
-private fun ChargeStatCard(
-    icon: ImageVector,
-    value: String,
-    unit: String,
-    label: String,
-    modifier: Modifier = Modifier,
-    trailingIcon: ImageVector? = null,
-    trailingContentDescription: String? = null,
-    onClick: (() -> Unit)? = null
-) {
-    Card(
-        modifier = modifier.then(
-            if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
-        ),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
     ) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    Text(
-                        text = value,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    if (unit.isNotEmpty()) {
-                        Spacer(modifier = Modifier.width(2.dp))
-                        Text(
-                            text = unit,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-                Text(
-                    text = label,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            // Trailing icon in top-right corner
-            if (trailingIcon != null) {
-                Icon(
-                    imageVector = trailingIcon,
-                    contentDescription = trailingContentDescription,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(6.dp)
-                        .size(14.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
+        EditorialPill(charge.durationStr ?: "${charge.durationMin ?: 0}m")
+
+        val costBg = if (isFree) palette.acColor.copy(alpha = 0.14f) else Color.White.copy(alpha = 0.05f)
+        val costColor = if (isFree) palette.acColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.78f)
+        val costFontWeight = if (isFree) FontWeight.Bold else FontWeight.SemiBold
+        val costModifier = if (onEditCost != null) Modifier.clickable(onClick = onEditCost) else Modifier
+        EditorialPill(
+            text = costPillText,
+            modifier = costModifier,
+            background = costBg,
+            color = costColor,
+            fontWeight = costFontWeight
+        )
+
+        val start = charge.startBatteryLevel
+        val end = charge.endBatteryLevel
+        if (start != null && end != null) {
+            EditorialPill(
+                text = "$start→$end%",
+                background = accent.copy(alpha = 0.12f),
+                color = accent,
+                fontWeight = FontWeight.Bold
+            )
         }
     }
 }
@@ -833,17 +696,6 @@ private fun ChargeTypeBadge(isDcCharge: Boolean, palette: CarColorPalette) {
             fontWeight = FontWeight.Bold,
             color = Color.White
         )
-    }
-}
-
-private fun formatDate(dateStr: String): String {
-    return try {
-        val inputFormatter = DateTimeFormatter.ISO_DATE_TIME
-        val outputFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy HH:mm")
-        val dateTime = LocalDateTime.parse(dateStr, inputFormatter)
-        dateTime.format(outputFormatter)
-    } catch (e: Exception) {
-        dateStr
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -1,7 +1,6 @@
 package com.matedroid.ui.screens.drives
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,11 +22,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DirectionsCar
-import androidx.compose.material.icons.filled.LocationOn
 import com.matedroid.ui.icons.CustomIcons
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Card
@@ -68,13 +64,14 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.DateRangePickerDialog
+import com.matedroid.ui.components.EditorialListItem
+import com.matedroid.ui.components.EditorialPill
 import com.matedroid.ui.components.InteractiveBarChart
+import com.matedroid.ui.components.formatEditorialDate
 import com.matedroid.ui.components.formatShortDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -269,6 +266,7 @@ private fun DrivesContent(
                 DriveItem(
                     drive = drive,
                     units = units,
+                    palette = palette,
                     onClick = { onDriveClick(drive.id) }
                 )
             }
@@ -471,196 +469,54 @@ private fun SummaryItem(
 private fun DriveItem(
     drive: DriveData,
     units: Units?,
+    palette: CarColorPalette,
     onClick: () -> Unit
 ) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        )
+    val unknown = stringResource(R.string.unknown)
+    val startCity = drive.startAddress ?: unknown
+    val endCity = drive.endAddress ?: unknown
+
+    EditorialListItem(
+        accent = palette.accent,
+        dateline = formatEditorialDate(drive.startDate),
+        title = "$startCity → $endCity",
+        heroValue = "%.0f".format(UnitFormatter.formatDistanceValue(drive.distance ?: 0.0, units)),
+        heroUnit = UnitFormatter.getDistanceUnit(units),
+        onClick = onClick,
     ) {
-        Column(
-            modifier = Modifier.padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Header card with route
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                )
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.LocationOn,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = drive.startAddress ?: stringResource(R.string.unknown),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    Row(
-                        modifier = Modifier.padding(start = 28.dp, top = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "→",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = drive.endAddress ?: stringResource(R.string.unknown),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    drive.startDate?.let { dateStr ->
-                        Text(
-                            text = formatDate(dateStr),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(start = 28.dp, top = 4.dp)
-                        )
-                    }
-                }
-            }
-
-            // Stats row with individual cards
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Distance
-                DriveStatCard(
-                    icon = CustomIcons.SteeringWheel,
-                    value = "%.1f".format(UnitFormatter.formatDistanceValue(drive.distance ?: 0.0, units)),
-                    unit = UnitFormatter.getDistanceUnit(units),
-                    label = stringResource(R.string.distance),
-                    modifier = Modifier.weight(1f)
-                )
-
-                // Duration
-                DriveStatCard(
-                    icon = Icons.Default.Schedule,
-                    value = formatDuration(drive.durationMin ?: 0),
-                    unit = "",
-                    label = stringResource(R.string.duration),
-                    modifier = Modifier.weight(1f)
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Max Speed
-                DriveStatCard(
-                    icon = Icons.Default.Speed,
-                    value = "${drive.speedMax ?: 0}",
-                    unit = UnitFormatter.getSpeedUnit(units),
-                    label = stringResource(R.string.max_speed),
-                    modifier = Modifier.weight(1f)
-                )
-
-                // Battery used
-                val startLevel = drive.startBatteryLevel
-                val endLevel = drive.endBatteryLevel
-                DriveStatCard(
-                    icon = Icons.Default.BatteryChargingFull,
-                    value = if (startLevel != null && endLevel != null) "$startLevel% → $endLevel%" else "--",
-                    unit = "",
-                    label = stringResource(R.string.battery),
-                    modifier = Modifier.weight(1f)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun DriveStatCard(
-    icon: ImageVector,
-    value: String,
-    unit: String,
-    label: String,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Row(
-                verticalAlignment = Alignment.Bottom
-            ) {
-                Text(
-                    text = value,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                if (unit.isNotEmpty()) {
-                    Spacer(modifier = Modifier.width(2.dp))
-                    Text(
-                        text = unit,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+        EditorialPill(formatDuration(drive.durationMin ?: 0))
+        EditorialPill("${drive.speedMax ?: 0} ${UnitFormatter.getSpeedUnit(units)}")
+        val start = drive.startBatteryLevel
+        val end = drive.endBatteryLevel
+        if (start != null && end != null) {
+            EditorialPill(
+                text = "$start→$end%",
+                background = palette.accent.copy(alpha = 0.12f),
+                color = palette.accent,
+                fontWeight = FontWeight.Bold
             )
         }
     }
 }
 
-private fun formatDate(dateStr: String): String {
-    return try {
-        val inputFormatter = DateTimeFormatter.ISO_DATE_TIME
-        val outputFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy HH:mm")
-        val dateTime = LocalDateTime.parse(dateStr, inputFormatter)
-        dateTime.format(outputFormatter)
-    } catch (e: Exception) {
-        dateStr
-    }
-}
-
+/**
+ * Cascading-unit duration: <1h shows minutes, ≥1h shows "Xh Ym" (or just "Xh" if no
+ * remaining minutes), ≥1d shows "Xd Yh". Mirrors the trips list so durations across the
+ * three lists are formatted consistently.
+ */
 private fun formatDuration(minutes: Int): String {
-    val hours = minutes / 60
-    val mins = minutes % 60
-    return "%d:%02d".format(hours, mins)
+    val total = minutes.coerceAtLeast(0)
+    val hours = total / 60
+    val mins = total % 60
+    return when {
+        hours >= 24 -> {
+            val days = hours / 24
+            val remH = hours - days * 24
+            if (remH > 0) "${days}d ${remH}h" else "${days}d"
+        }
+        hours >= 1 -> if (mins > 0) "${hours}h ${mins}m" else "${hours}h"
+        else -> "${total}m"
+    }
 }
 
 /**

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -192,7 +192,7 @@ private fun DrivesContent(
         state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         item {
             DateFilterChips(

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -284,6 +284,8 @@
     <string name="cost_filter_no_cost">Sense cost</string>
     <!-- Pista mostrada sobre la llista quan el cotxe té Supercàrrega gratis i el filtre "Sense cost" està actiu -->
     <string name="charges_free_supercharging_hint">Aquest cotxe té Supercàrrega gratis — les sessions als Superchargers normalment no tenen cost. Als altres punts DC potser caldrà assignar-ne un.</string>
+    <!-- Pill mostrat en lloc del cost quan una sessió és gratuïta -->
+    <string name="charge_free">GRATIS</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Tots</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,6 +284,8 @@
     <string name="cost_filter_no_cost">Sin coste</string>
     <!-- Pista mostrada encima de la lista cuando el coche tiene Supercarga gratis y el filtro "Sin coste" está activo -->
     <string name="charges_free_supercharging_hint">Este coche tiene Supercarga gratis — las sesiones en Supercargadores normalmente no tienen coste. En otros puntos DC quizá haya que asignarlo.</string>
+    <!-- Pill mostrado en lugar del coste cuando una sesión es gratuita -->
+    <string name="charge_free">GRATIS</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Todos</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -284,6 +284,8 @@
     <string name="cost_filter_no_cost">Senza costo</string>
     <!-- Hint mostrato sopra la lista quando l'auto ha Supercharge gratuito e il filtro "Senza costo" è attivo -->
     <string name="charges_free_supercharging_hint">Su questa auto il Supercharge è gratuito — le ricariche ai Supercharger normalmente non hanno costo. Per le altre colonnine DC potrebbe servire impostarne uno.</string>
+    <!-- Pill mostrato al posto del costo quando una ricarica è gratuita -->
+    <string name="charge_free">GRATIS</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Tutti</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -284,6 +284,8 @@
     <string name="cost_filter_no_cost">无费用</string>
     <!-- 当车辆享有免费超充且已选择"无费用"时在列表上方显示的提示 -->
     <string name="charges_free_supercharging_hint">此车享有免费超充 —— 超级充电站的充电通常不产生费用。非超充的直流站点可能仍需手动填写费用。</string>
+    <!-- 充电会话免费时在费用位置显示的标签 -->
+    <string name="charge_free">免费</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">全部</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,8 @@
     <string name="cost_filter_no_cost">No cost</string>
     <!-- Hint shown above the charges list when the car has free Supercharging and "No cost" is selected, to clarify that Supercharger sessions are legitimately free -->
     <string name="charges_free_supercharging_hint">Free Supercharging is on for this car — Supercharger sessions are normally free. Non-Supercharger DC stops may still need a cost set.</string>
+    <!-- Cost pill on a charge row, shown in place of the cost when cost is zero. Short / capitalized; appears on the editorial-style charges list. -->
+    <string name="charge_free">FREE</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">All</string>


### PR DESCRIPTION
## Summary
- Drive and charge rows swap their 4-stat-card layout for a magazine-style editorial row: 4 dp accent edge (gold for drives, green for AC, orange for DC), ALL-CAPS dateline above the route or location, headline metric (km / kWh) as a display-weight hero on the right with a soft accent halo behind it, supporting numbers reduced to small pills underneath. Visual language now matches the trips list.
- Cost pill on the charges list becomes tappable when TeslaMate cost-editing is wired up (gets a small ↗ glyph) — replaces the old trailing open-in-new icon. Free charges show a green "FREE" pill (new `R.string.charge_free` in en/it/es/ca/zh).
- Drive durations switch to the trips-style cascading format (`47m`, `2h 14m`) instead of `0:47` / `2:14`.

The follow-up commit (`fix(lists): tighten editorial rows + halo behind hero`) fixes the layout-height bug where the halo was a 140 dp `Box` child of the wrapping Box — `align()` / `offset()` don't change measurement, so the parent floor was 140 dp regardless of content. Halo is now drawn via `Modifier.drawBehind` (paint effect, not layout child) so the row sizes itself purely from content. Same commit also adds a `tightStyle` helper that disables `includeFontPadding` and trims line-height padding to both sides, since otherwise every Text measures ~10 % taller than its lineHeight.

## Test plan
- [x] `./gradlew compileDebugKotlin` clean
- [x] `./gradlew lintDebug` clean (no new warnings on touched files)
- [x] Verified on physical device: drives and charges lists render the new layout, halo glow visible behind hero on each row, ~8 rows fit per screen, free / DC / AC tints applied correctly.
- [ ] Verify `onEditCost` cost pill still navigates to TeslaMate web editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)