### PR TITLE
Draggable month scrollbar for drives, charges, trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Draggable month scrollbar**: drives, charges and trips lists now show a small thumb on the right edge whenever the list is long enough to need it (≥20 items and actually scrollable). Drag the thumb vertically for fast scroll; while dragging, a floating label pill peeks out to the left of your finger showing the date of the row under the thumb. Format auto-adapts to the list's date range — `25 APR` for short ranges (≤2 months), `APR '26` once it spans more. Thumb fades after a moment of inactivity. Locale-aware month names in all 5 supported languages.
+
 ### Changed
 - **Drives & charges list redesign**: Both lists swap their 4-stat-card rows for a magazine-style editorial layout — a 4 dp accent edge (gold for drives, green for AC, orange for DC), an ALL-CAPS dateline above the route or location, supporting numbers reduced to small pills (duration, max speed, battery delta, cost), and the headline metric (km / kWh) set as a display-weight hero on the right. Rows are noticeably shorter so more fits on screen, and the visual language now matches the trips list. Free charges show a green "FREE" pill; when TeslaMate cost-editing is available, the cost pill becomes tappable and gains a small ↗ glyph — replacing the old trailing open-in-new icon. Drive durations now use the cascading-unit format (`47m`, `2h 14m`) instead of `0:47` / `2:14`, matching the trips list.
 

--- a/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
+++ b/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
@@ -1,0 +1,435 @@
+package com.matedroid.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+private val ThumbWidth = 26.dp
+private val ThumbHeight = 48.dp
+private val ThumbRightInset = 4.dp
+// Distance from the right edge of the overlay to the right edge of the label —
+// just past the typical fingertip width so the label peeks out from behind a
+// dragging thumb without being obscured by it.
+private val LabelLeftOffset = 56.dp
+// Width of the indicator's Box overlay. Sized to comfortably fit the label pill
+// extending to the left of the thumb. Touches outside the thumb pass through to
+// the underlying LazyColumn since neither the Box nor the label intercept them.
+private val OverlayWidth = 220.dp
+
+private const val IDLE_FADE_DELAY_MS = 1100L
+private const val FADE_DURATION_MS = 220
+private const val LABEL_FADE_MS = 140
+
+// When the list spans <= this many distinct months, the label shows day-of-month
+// ("25 APR"). Above this, it shows month + 2-digit year ("APR '26") because year
+// becomes the disambiguating axis once the list crosses many months.
+private const val DAY_FORMAT_MONTH_THRESHOLD = 2
+
+private const val DAY_PATTERN = "d MMM"
+private const val YEAR_PATTERN = "MMM ''yy"
+
+/**
+ * Vertical scroll indicator overlaying the right edge of a [LazyListState]-backed
+ * list. Idle: a small accent-colored pill thumb that fades after inactivity. While
+ * the user is dragging the thumb, a separate floating label pill appears to the
+ * left of the thumb (clear of the dragging finger) showing the date of the row
+ * currently under the thumb. Format auto-adapts to the list's date range —
+ * day-of-month for short ranges, month + year for long ones.
+ *
+ * **Perf shape.** Frequently-changing state (the scroll fraction, the drag
+ * fraction, the fade alphas) is intentionally read inside deferred-lambda
+ * modifiers (`Modifier.offset { ... }`, `Modifier.graphicsLayer { ... }`) rather
+ * than in the composable body. Compose's snapshot system tracks those reads but
+ * only re-runs the layout / draw pass when they change — the composable itself
+ * doesn't recompose on every scroll frame, which is what made earlier versions
+ * sluggish on long lists.
+ *
+ * Stack on top of the LazyColumn it controls — e.g.
+ * `Modifier.align(Alignment.CenterEnd)` inside a parent `Box.fillMaxSize()`.
+ *
+ * @param state the LazyListState driving the list this indicator scrolls.
+ * @param dateAt resolves a list-item index to its [LocalDate], or null for header
+ *        items (filter chips, summary card, etc.) that don't carry a date.
+ * @param accent the car palette accent color used for the thumb fill and label.
+ * @param minItemsToShow the indicator stays hidden when the list has fewer items
+ *        than this — short lists don't need fast-scroll affordance.
+ */
+@Composable
+fun MonthScrollIndicator(
+    state: LazyListState,
+    dateAt: (itemIndex: Int) -> LocalDate?,
+    accent: Color,
+    modifier: Modifier = Modifier,
+    minItemsToShow: Int = 20,
+) {
+    val totalItems by remember {
+        derivedStateOf { state.layoutInfo.totalItemsCount }
+    }
+    val isScrollable by remember {
+        derivedStateOf { state.canScrollForward || state.canScrollBackward }
+    }
+    if (totalItems < minItemsToShow || !isScrollable) return
+
+    val handleDescription = stringResource(
+        com.matedroid.R.string.scrollbar_drag_handle_description
+    )
+
+    val coroutineScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+
+    val configuration = LocalConfiguration.current
+    val locale = remember(configuration) {
+        configuration.locales[0] ?: Locale.getDefault()
+    }
+    val dayFormatter = remember(locale) {
+        DateTimeFormatter.ofPattern(DAY_PATTERN, locale)
+    }
+    val yearFormatter = remember(locale) {
+        DateTimeFormatter.ofPattern(YEAR_PATTERN, locale)
+    }
+
+    // The lambda passed in is recreated on every recomposition of the caller, so
+    // it can never be stable as a `remember` key. Hold the latest one in a
+    // delegated state and read it from inside the derivedStateOf below.
+    val currentDateAt by rememberUpdatedState(dateAt)
+
+    // Distinct month count drives the label format. Computing this only when
+    // `totalItems` changes (data loaded / filter changed) keeps it off the hot
+    // scroll path — `derivedStateOf` would otherwise re-iterate every time the
+    // captured dateAt lambda changes identity, which is every recomposition.
+    val monthCount by remember {
+        derivedStateOf {
+            val total = state.layoutInfo.totalItemsCount
+            if (total == 0) return@derivedStateOf 0
+            var count = 0
+            var prev: YearMonth? = null
+            for (i in 0 until total) {
+                val date = currentDateAt(i) ?: continue
+                val ym = YearMonth.from(date)
+                if (ym != prev) {
+                    count++
+                    prev = ym
+                }
+            }
+            count
+        }
+    }
+
+    var trackHeightPx by remember { mutableIntStateOf(0) }
+    var dragFraction by remember { mutableStateOf<Float?>(null) }
+    val isDragging by remember { derivedStateOf { dragFraction != null } }
+
+    val thumbVisibility = remember { Animatable(1f) }
+    val labelVisibility = remember { Animatable(0f) }
+    val thumbHeightPx = with(density) { ThumbHeight.toPx() }
+
+    // Initial idle fade — show the thumb on first paint so the user knows the
+    // affordance exists, then fade it out after a beat. Subsequent scroll events
+    // re-show via the snapshotFlow below.
+    LaunchedEffect(Unit) {
+        delay(IDLE_FADE_DELAY_MS)
+        if (dragFraction == null) {
+            thumbVisibility.animateTo(0f, animationSpec = tween(FADE_DURATION_MS))
+        }
+    }
+
+    val scrollFraction by remember {
+        derivedStateOf {
+            // Index-based fraction with explicit end cases. The end cases are
+            // critical: in the middle of a long list `firstVisibleItemIndex /
+            // (total - 1)` only ever reaches `(total - visibleCount) / (total - 1)`
+            // — never 1.0. The `canScrollForward = false` override snaps the
+            // thumb to the bottom when the list is genuinely at the end, and the
+            // equivalent override pins it to the top at the start.
+            val total = state.layoutInfo.totalItemsCount
+            if (total <= 1) return@derivedStateOf 0f
+            if (!state.canScrollBackward) return@derivedStateOf 0f
+            if (!state.canScrollForward) return@derivedStateOf 1f
+            val firstItemHeight = state.layoutInfo.visibleItemsInfo
+                .firstOrNull()?.size?.toFloat() ?: 1f
+            val offsetFraction = state.firstVisibleItemScrollOffset.toFloat() /
+                firstItemHeight.coerceAtLeast(1f)
+            val numerator = state.firstVisibleItemIndex + offsetFraction
+            val denominator = (total - 1).coerceAtLeast(1).toFloat()
+            (numerator / denominator).coerceIn(0f, 1f)
+        }
+    }
+
+    // Fade the THUMB on scroll: snapshotFlow emits whenever scroll state or drag
+    // state changes, collectLatest cancels the previous fade-out timer on each
+    // emission, and fade-out only fires when the user isn't dragging.
+    LaunchedEffect(state) {
+        snapshotFlow {
+            // Pack drag-state + scroll position into a single Long key so we
+            // avoid allocating a wrapper class per emission. Bit 63 = isDragging,
+            // bits 32..62 = firstVisibleItemIndex, bits 0..31 = scrollOffset.
+            val isDragNow = if (dragFraction != null) 1L shl 63 else 0L
+            val idx = (state.firstVisibleItemIndex.toLong() and 0x7FFF_FFFFL) shl 32
+            val off = state.firstVisibleItemScrollOffset.toLong() and 0xFFFF_FFFFL
+            isDragNow or idx or off
+        }.drop(1).collectLatest { packed ->
+            thumbVisibility.snapTo(1f)
+            val isDragNow = (packed ushr 63) == 1L
+            if (!isDragNow) {
+                delay(IDLE_FADE_DELAY_MS)
+                thumbVisibility.animateTo(0f, animationSpec = tween(FADE_DURATION_MS))
+            }
+        }
+    }
+
+    // The LABEL is bound strictly to drag. Fade in on drag-start, fade out on
+    // drag-end / cancel. No idle fade timer of its own. Note: `isDragging` is a
+    // derivedStateOf that only invalidates on null↔Float transitions — drag
+    // updates that just change the Float don't re-trigger this effect.
+    LaunchedEffect(isDragging) {
+        labelVisibility.animateTo(
+            if (isDragging) 1f else 0f,
+            animationSpec = tween(LABEL_FADE_MS),
+        )
+    }
+
+    // Label text is a derivedStateOf so it only invalidates when the rendered
+    // string actually changes — many drag-fraction updates within the same row
+    // produce the same date and don't recompose Text.
+    val labelText by remember {
+        derivedStateOf {
+            val frac = dragFraction ?: return@derivedStateOf null
+            val info = state.layoutInfo
+            if (info.visibleItemsInfo.isEmpty()) return@derivedStateOf null
+            val thumbCenterY =
+                ((trackHeightPx - thumbHeightPx) * frac + thumbHeightPx / 2f)
+                    .coerceAtLeast(0f)
+            val nearest = info.visibleItemsInfo.minByOrNull { item ->
+                abs((item.offset + item.size / 2f) - thumbCenterY)
+            } ?: return@derivedStateOf null
+            val total = info.totalItemsCount
+            var probe = nearest.index
+            while (probe < total) {
+                val date = currentDateAt(probe)
+                if (date != null) {
+                    val formatter =
+                        if (monthCount in 1..DAY_FORMAT_MONTH_THRESHOLD) dayFormatter
+                        else yearFormatter
+                    return@derivedStateOf formatter.format(date).uppercase(locale)
+                }
+                probe++
+            }
+            null
+        }
+    }
+
+    // Cached "should the thumb absorb touches?" boolean — only flips when the
+    // fade animation crosses the threshold. Avoids re-attaching pointerInput
+    // every frame as the alpha animates.
+    val isThumbInteractive by remember {
+        derivedStateOf { thumbVisibility.value > 0.1f }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .width(OverlayWidth)
+            .onSizeChanged { trackHeightPx = it.height },
+    ) {
+        // Floating label, pinned to the thumb's vertical position but offset
+        // far enough left to peek past a dragging finger. Position is a
+        // deferred-lambda offset (re-evaluated at layout, not composition); alpha
+        // is a graphicsLayer property (re-evaluated at draw, not composition).
+        // Both readers stay off the recomposition path.
+        if (isDragging) {
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = accent,
+                shadowElevation = 4.dp,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset {
+                        val frac = dragFraction ?: scrollFraction
+                        val y = ((trackHeightPx - thumbHeightPx) * frac).coerceAtLeast(0f)
+                        IntOffset(0, y.toInt())
+                    }
+                    .padding(end = LabelLeftOffset)
+                    .height(ThumbHeight)
+                    .graphicsLayer { alpha = labelVisibility.value },
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(horizontal = 14.dp),
+                ) {
+                    Text(
+                        text = labelText.orEmpty(),
+                        color = Color.White,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.6.sp,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+
+        // Thumb itself: small icon-only pill against the right edge. Only attaches
+        // its pointerInput when visible enough to be a sensible touch target —
+        // otherwise touches in the thumb's area pass through to the LazyColumn
+        // underneath, so swiping the right edge of a list with a faded-out thumb
+        // doesn't accidentally trigger a thumb drag.
+        val pointerMod = if (isThumbInteractive) {
+            Modifier.pointerInput(state) {
+                detectVerticalDragGestures(
+                    onDragStart = {
+                        // Read scroll state freshly. Closing over the local
+                        // `effectiveFraction` instead would freeze its first-
+                        // composition value (0f) and snap the thumb back to the
+                        // top every time the user grabs it.
+                        dragFraction = dragFraction ?: scrollFraction
+                    },
+                    onDragEnd = { dragFraction = null },
+                    onDragCancel = { dragFraction = null },
+                    onVerticalDrag = { change, deltaY ->
+                        change.consume()
+                        val track = trackHeightPx.toFloat() - thumbHeightPx
+                        if (track <= 0f) return@detectVerticalDragGestures
+                        val current = dragFraction ?: scrollFraction
+                        val newFrac = (current + deltaY / track).coerceIn(0f, 1f)
+                        handleDrag(
+                            newFrac = newFrac,
+                            state = state,
+                            onUpdate = { dragFraction = it },
+                            coroutineScope = coroutineScope,
+                        )
+                    },
+                )
+            }
+        } else Modifier
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .offset {
+                    val frac = dragFraction ?: scrollFraction
+                    val y = ((trackHeightPx - thumbHeightPx) * frac).coerceAtLeast(0f)
+                    IntOffset(0, y.toInt())
+                }
+                .graphicsLayer { alpha = thumbVisibility.value }
+                .padding(end = ThumbRightInset)
+                .size(width = ThumbWidth, height = ThumbHeight)
+                .clip(RoundedCornerShape(13.dp))
+                .background(accent)
+                .semantics {
+                    contentDescription = handleDescription
+                    role = Role.Button
+                }
+                .then(pointerMod),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.UnfoldMore,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+private fun handleDrag(
+    newFrac: Float,
+    state: LazyListState,
+    onUpdate: (Float) -> Unit,
+    coroutineScope: kotlinx.coroutines.CoroutineScope,
+) {
+    val info = state.layoutInfo
+    val total = info.totalItemsCount
+    if (total <= 0) return
+
+    val maxIndex = (total - 1).coerceAtLeast(1)
+    val rawIdxFloat = newFrac * maxIndex
+    val idx = rawIdxFloat.toInt().coerceIn(0, total - 1)
+
+    // Sub-item resolution: integer index + pixel offset within the item, so a
+    // short list with only a handful of distinct integer index stops still
+    // scrolls smoothly under the drag rather than stair-stepping.
+    val itemPx = info.visibleItemsInfo.firstOrNull()?.size?.toFloat() ?: 0f
+    val offsetPx = ((rawIdxFloat - idx) * itemPx).roundToInt().coerceAtLeast(0)
+    onUpdate(newFrac)
+    coroutineScope.launch { state.scrollToItem(idx, offsetPx) }
+}
+
+/**
+ * Parse the ISO-8601 datetime that TeslaMate emits (with or without offset) into a
+ * [LocalDate]. Returns null on parse failure rather than throwing — the scroll
+ * indicator simply treats unparseable rows as undated.
+ */
+internal fun String?.parseListItemDate(): LocalDate? {
+    if (this.isNullOrBlank()) return null
+    return try {
+        val dt = try {
+            OffsetDateTime.parse(this).toLocalDateTime()
+        } catch (_: DateTimeParseException) {
+            LocalDateTime.parse(this.replace("Z", ""))
+        }
+        dt.toLocalDate()
+    } catch (_: Exception) {
+        null
+    }
+}
+
+internal fun String?.parseListItemYearMonth(): YearMonth? =
+    parseListItemDate()?.let(YearMonth::from)

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -78,8 +78,10 @@ import com.matedroid.ui.components.DateRangePickerDialog
 import com.matedroid.ui.components.EditorialListItem
 import com.matedroid.ui.components.EditorialPill
 import com.matedroid.ui.components.InteractiveBarChart
+import com.matedroid.ui.components.MonthScrollIndicator
 import com.matedroid.ui.components.formatEditorialDate
 import com.matedroid.ui.components.formatShortDate
+import com.matedroid.ui.components.parseListItemDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
@@ -213,6 +215,14 @@ private fun ChargesContent(
         initialFirstVisibleItemScrollOffset = initialScrollOffset
     )
 
+    // Header items in render order: date chips, dropdowns, free hint (conditional),
+    // summary, charts (conditional), history header. Adjust if items are added.
+    val showFreeHint = freeSupercharging && selectedCostFilter == CostFilter.NO_COST
+    val headerCount = 4 +
+        (if (showFreeHint) 1 else 0) +
+        (if (chartData.isNotEmpty()) 1 else 0)
+
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
         state = listState,
         modifier = Modifier.fillMaxSize(),
@@ -340,6 +350,17 @@ private fun ChargesContent(
                 )
             }
         }
+    }
+
+    MonthScrollIndicator(
+        state = listState,
+        dateAt = { index ->
+            if (index < headerCount) null
+            else charges.getOrNull(index - headerCount)?.startDate.parseListItemDate()
+        },
+        accent = palette.accent,
+        modifier = Modifier.align(Alignment.CenterEnd),
+    )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -67,8 +67,10 @@ import com.matedroid.ui.components.DateRangePickerDialog
 import com.matedroid.ui.components.EditorialListItem
 import com.matedroid.ui.components.EditorialPill
 import com.matedroid.ui.components.InteractiveBarChart
+import com.matedroid.ui.components.MonthScrollIndicator
 import com.matedroid.ui.components.formatEditorialDate
 import com.matedroid.ui.components.formatShortDate
+import com.matedroid.ui.components.parseListItemDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
@@ -188,6 +190,11 @@ private fun DrivesContent(
     onDistanceFilterSelected: (DriveDistanceFilter) -> Unit,
     onDriveClick: (driveId: Int) -> Unit
 ) {
+    // Header items in this LazyColumn, in render order: date chips, distance chips,
+    // summary, charts (conditional), history header. Adjust if items are added.
+    val headerCount = 4 + (if (chartData.isNotEmpty()) 1 else 0)
+
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
         state = listState,
         modifier = Modifier.fillMaxSize(),
@@ -271,6 +278,17 @@ private fun DrivesContent(
                 )
             }
         }
+    }
+
+    MonthScrollIndicator(
+        state = listState,
+        dateAt = { index ->
+            if (index < headerCount) null
+            else drives.getOrNull(index - headerCount)?.startDate.parseListItemDate()
+        },
+        accent = palette.accent,
+        modifier = Modifier.align(Alignment.CenterEnd),
+    )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ElectricBolt
@@ -61,8 +62,10 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.DateRangePickerDialog
+import com.matedroid.ui.components.MonthScrollIndicator
 import com.matedroid.ui.components.TripFingerprintStrip
 import com.matedroid.ui.components.formatShortDate
+import com.matedroid.ui.components.parseListItemDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
@@ -200,7 +203,13 @@ private fun TripsContent(
     dcChargeIds: Set<Int>,
     onTripClick: (Trip) -> Unit
 ) {
+    val listState = rememberLazyListState()
+    // Header items in render order: year chips (conditional), summary, section header.
+    val headerCount = 2 + (if (availableYears.size > 1) 1 else 0)
+
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
+        state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -263,6 +272,17 @@ private fun TripsContent(
                 onClick = { onTripClick(trip) }
             )
         }
+    }
+
+    MonthScrollIndicator(
+        state = listState,
+        dateAt = { index ->
+            if (index < headerCount) null
+            else trips.getOrNull(index - headerCount)?.startDate.parseListItemDate()
+        },
+        accent = palette.accent,
+        modifier = Modifier.align(Alignment.CenterEnd),
+    )
     }
 }
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -286,6 +286,8 @@
     <string name="charges_free_supercharging_hint">Aquest cotxe té Supercàrrega gratis — les sessions als Superchargers normalment no tenen cost. Als altres punts DC potser caldrà assignar-ne un.</string>
     <!-- Pill mostrat en lloc del cost quan una sessió és gratuïta -->
     <string name="charge_free">GRATIS</string>
+    <!-- Etiqueta d'accessibilitat per a la nansa arrossegable de la barra de desplaçament -->
+    <string name="scrollbar_drag_handle_description">Arrossega per desplaçar-te ràpid per la llista</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Tots</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -286,6 +286,8 @@
     <string name="charges_free_supercharging_hint">Este coche tiene Supercarga gratis — las sesiones en Supercargadores normalmente no tienen coste. En otros puntos DC quizá haya que asignarlo.</string>
     <!-- Pill mostrado en lugar del coste cuando una sesión es gratuita -->
     <string name="charge_free">GRATIS</string>
+    <!-- Etiqueta de accesibilidad para el tirador arrastrable de la barra de desplazamiento -->
+    <string name="scrollbar_drag_handle_description">Arrastra para desplazarte rápido por la lista</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Todos</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -286,6 +286,8 @@
     <string name="charges_free_supercharging_hint">Su questa auto il Supercharge è gratuito — le ricariche ai Supercharger normalmente non hanno costo. Per le altre colonnine DC potrebbe servire impostarne uno.</string>
     <!-- Pill mostrato al posto del costo quando una ricarica è gratuita -->
     <string name="charge_free">GRATIS</string>
+    <!-- Etichetta di accessibilità per la maniglia trascinabile della scrollbar -->
+    <string name="scrollbar_drag_handle_description">Trascina per scorrere rapidamente la lista</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">Tutti</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -286,6 +286,8 @@
     <string name="charges_free_supercharging_hint">此车享有免费超充 —— 超级充电站的充电通常不产生费用。非超充的直流站点可能仍需手动填写费用。</string>
     <!-- 充电会话免费时在费用位置显示的标签 -->
     <string name="charge_free">免费</string>
+    <!-- 列表右侧可拖动滚动手柄的无障碍标签 -->
+    <string name="scrollbar_drag_handle_description">拖动以快速滚动列表</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">全部</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,8 @@
     <string name="charges_free_supercharging_hint">Free Supercharging is on for this car — Supercharger sessions are normally free. Non-Supercharger DC stops may still need a cost set.</string>
     <!-- Cost pill on a charge row, shown in place of the cost when cost is zero. Short / capitalized; appears on the editorial-style charges list. -->
     <string name="charge_free">FREE</string>
+    <!-- Accessibility label for the draggable thumb on the right edge of the drives, charges and trips lists. Announced by screen readers; read out as the user focuses the handle. -->
+    <string name="scrollbar_drag_handle_description">Drag to scroll quickly through the list</string>
 
     <!-- Distance filter chips (metric) -->
     <string name="filter_all">All</string>


### PR DESCRIPTION
## Summary

Adds a small accent-tinted thumb on the right edge of the **drives**, **charges** and **trips** `LazyColumn`s. Visible only when the list overflows and has ≥ 20 items. Drag the thumb vertically for fast scroll; while dragging, a floating label pill peeks out 56 dp to the left of the thumb (clear of the dragging finger) showing the date of the row currently under the thumb. Format auto-adapts to the list's date span:

- `25 APR` for ≤ 2 distinct months
- `APR '26` for more

`DateTimeFormatter` with the device locale, so it renders correctly in all five supported languages (en/it/es/ca/zh). Thumb fades after a moment of inactivity; touches in the thumb's area pass through to the LazyColumn while it's faded.

## Implementation

New shared composable `MonthScrollIndicator` in `app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt`. Each screen wraps its `LazyColumn` in a `Box.fillMaxSize()` and overlays the indicator at `Alignment.CenterEnd`, passing a `dateAt: (Int) -> LocalDate?` callback that maps list-item index to the corresponding row's date (returning `null` for header items like filter chips, summary card, chart pager, and section headers).

Snap-to-month was implemented and tried during iteration but felt poor on real data — it's been removed from this PR; the scrubber is smooth-only.

Two non-obvious things that took some doing:

- **The accent halo behind hero metrics** in `EditorialListItem` was originally a 140 dp child `Box`. `Modifier.align()` and `Modifier.offset()` only affect positioning, not measurement, so the parent `Box` measured itself as `max(140 dp halo, ~50 dp content) = 140 dp` — every editorial row was forced to ≥ 140 dp regardless of content. Drawing the halo via `Modifier.drawBehind` (a paint effect, not a layout child) drops that floor entirely.
- **Scroll-frame perf**: every frequently-changing state read (scroll fraction, drag fraction, fade alphas) lives inside deferred-lambda modifiers (`Modifier.offset { ... }`, `Modifier.graphicsLayer { ... }`) rather than the composable body. Compose's snapshot system tracks reads inside those lambdas but only re-runs the layout / draw pass when they change — the composable itself doesn't recompose on a scroll frame. `labelText` is a `derivedStateOf<String?>` so `Text` recomposes only when the displayed string actually changes, not on every drag-fraction tick. `snapshotFlow` packs its key into a single `Long` instead of a `Triple` to drop one allocation per scroll frame.

## Test plan

- [x] `./gradlew compileDebugKotlin` clean
- [x] `./gradlew lintDebug` clean (no new warnings on touched files)
- [x] Verified on physical device (drives, charges, trips):
  - Short lists: indicator hidden.
  - Long lists: thumb appears, fades after idle, drag scrolls smoothly to target.
  - Drag label tracks the row at the thumb's vertical position.
  - Format flips correctly between `d MMM` and `MMM 'yy` at the 2-distinct-months threshold.
  - Italian / Spanish / Catalan / Chinese render localized month names.
  - Year-long lists scroll smoothly without thumb-position skidding.
- [ ] Smoke-test on a fresh F-Droid release build before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)