### PR TITLE
fix(where-was-i): "Invalid date" for any non-UTC timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Draggable month scrollbar**: drives, charges and trips lists now show a small thumb on the right edge whenever the list is long enough to need it (≥20 items and actually scrollable). Drag the thumb vertically for fast scroll; while dragging, a floating label pill peeks out to the left of your finger showing the date of the row under the thumb. Format auto-adapts to the list's date range — `25 APR` for short ranges (≤2 months), `APR '26` once it spans more. Thumb fades after a moment of inactivity. Locale-aware month names in all 5 supported languages.
 - **Branded loading spinner**: the MD logotype, drawn dim with a brighter accent dot tracing its outline forward and back, replaces the generic spinner across long loads (initial loads on every screen, plus a dim-scrim overlay on the drives/charges lists when switching date filters). Debounced 200 ms so cached/snappy loads never flash a spinner.
 
-### Changed
-- Mileage screen perf improvements.
+### Fixed
+- **"Where was I?" returned "Invalid date"** for any date with a non-UTC timezone offset — the timestamp was URL-decoded twice on the way to the screen, mangling the `+02:00` (or similar) part of the offset into a literal space and breaking parsing. Single-decode now.
 
 ### Changed
+- Mileage screen perf improvements.
 - **Drives & charges list redesign**: Both lists swap their 4-stat-card rows for a magazine-style editorial layout — a 4 dp accent edge (gold for drives, green for AC, orange for DC), an ALL-CAPS dateline above the route or location, supporting numbers reduced to small pills (duration, max speed, battery delta, cost), and the headline metric (km / kWh) set as a display-weight hero on the right. Rows are noticeably shorter so more fits on screen, and the visual language now matches the trips list. Free charges show a green "FREE" pill; when TeslaMate cost-editing is available, the cost pill becomes tappable and gains a small ↗ glyph — replacing the old trailing open-in-new icon. Drive durations now use the cascading-unit format (`47m`, `2h 14m`) instead of `0:47` / `2:14`, matching the trips list.
 
 ## [1.6.0] - 2026-04-25

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -634,9 +634,16 @@ fun NavGraph(
             )
         ) { backStackEntry ->
             val carId = backStackEntry.arguments?.getInt("carId") ?: return@composable
-            val timestamp = backStackEntry.arguments?.getString("timestamp")?.let {
-                URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
-            } ?: return@composable
+            // Compose Navigation 2.7+ auto-decodes query-parameter values, so the
+            // timestamp is already URL-decoded by the time we read it. The
+            // previous manual URLDecoder.decode here was double-decoding — and
+            // since `URLDecoder.decode` treats `+` as a literal space (URL
+            // form-encoding rule), it mangled the `+` in the timezone offset
+            // (e.g. `+02:00` → ` 02:00`), making the resulting string
+            // unparseable as an OffsetDateTime and surfacing as the "Invalid
+            // date" error in WhereWasIViewModel for any non-UTC date.
+            val timestamp = backStackEntry.arguments?.getString("timestamp")
+                ?: return@composable
             val exteriorColor = backStackEntry.arguments?.getString("exteriorColor")
 
             WhereWasIScreen(


### PR DESCRIPTION
## Summary

The "Where was I that day?" entry point on the dashboard returned an "Invalid date" error for any picked date when the device's timezone was non-UTC (e.g. CET → `+01:00` or `+02:00`).

## Root cause

`NavGraph.kt` URL-decoded the timestamp query argument **twice** on the way to the screen:

1. Compose Navigation 2.9.7 auto-decodes query-parameter values when placing them into `backStackEntry.arguments`.
2. The composable handler then ran `URLDecoder.decode(it, …)` on top of that.

The first pass turns `%2B02%3A00` → `+02:00`. The second pass treats `+` as a literal space (the URL form-encoding rule), producing `2024-10-17T15:30 02:00`. `OffsetDateTime.parse` chokes on that and the VM falls into the "Invalid date" error branch. The bug fires for **any** date the user picks, not just dates in the far past — the user happened to test with Oct 17 2024.

The sibling `TripDetail` route already follows the right pattern (encode once on send, let the framework decode on receive). Bringing `WhereWasI` in line.

## Fix

Drop the manual `URLDecoder.decode` call in the `Screen.WhereWasI` composable handler.

## Test Plan

- [x] Verified on physical device: picking Oct 17 2024 (and other historical dates) now loads actual where-was-I data instead of "Invalid date."
- [x] `./gradlew compileDebugKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)