### PR TITLE
fix(charges): render hero unit as kWh, not KWH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **"Where was I?" returned "Invalid date"** for any date with a non-UTC timezone offset — the timestamp was URL-decoded twice on the way to the screen, mangling the `+02:00` (or similar) part of the offset into a literal space and breaking parsing. Single-decode now.
+- **Charges list hero unit was rendered as `KWH`** — SI symbols are case-sensitive, so the unit now correctly reads `kWh`. Distance units on the drives list still render uppercase to keep the editorial all-caps look.
 
 ### Changed
 - Mileage screen perf improvements.

--- a/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
+++ b/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
@@ -222,7 +222,7 @@ fun EditorialListItem(
                         maxLines = 1
                     )
                     Text(
-                        text = heroUnit.uppercase(Locale.getDefault()),
+                        text = heroUnit,
                         style = tightStyle(
                             fontSize = 10.sp,
                             lineHeight = 11.sp,

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -519,7 +519,7 @@ private fun DriveItem(
         dateline = formatEditorialDate(drive.startDate),
         title = "$startCity → $endCity",
         heroValue = "%.0f".format(UnitFormatter.formatDistanceValue(drive.distance ?: 0.0, units)),
-        heroUnit = UnitFormatter.getDistanceUnit(units),
+        heroUnit = UnitFormatter.getDistanceUnit(units).uppercase(java.util.Locale.getDefault()),
         onClick = onClick,
     ) {
         EditorialPill(formatDuration(drive.durationMin ?: 0))


### PR DESCRIPTION
## Summary
The new editorial-style charges list was rendering the hero unit label as `KWH` because `EditorialListItem` force-uppercased every `heroUnit`. SI symbols are case-sensitive — `kWh` is the only correct form, `KWH` doesn't exist as a unit.

## Root Cause
`EditorialListItem.kt` ran `heroUnit.uppercase(Locale.getDefault())` before drawing it. That was OK for distance abbreviations on the drives list (`km` → `KM`, `mi` → `MI`) where the all-caps look is part of the editorial typography, but it mangled `kWh` on the charges list.

## Solution
- Drop the auto-uppercase from `EditorialListItem`.
- Have the drives caller pre-uppercase its distance unit so the editorial all-caps look is preserved where it makes sense.
- Charges caller already passes `"kWh"` and now renders it as-is.

## Test Plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [ ] Manual: charges list shows `kWh` next to the hero number
- [ ] Manual: drives list still shows `KM` / `MI` next to the hero number

🤖 Generated with [Claude Code](https://claude.com/claude-code)