### PR TITLE
Where Was I redesign: merged what+where card, interactive map, repositioned chevron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **"Where was I?" screen redesign**: the separate Location and State cards are merged into a single "what + where" card, with a state-aware sentence on top — "Heading to Home" / "Charging at Tesla SC" / "Parked at Home" — that makes the relationship between the activity and the named place unambiguous (no more bare "Home" appearing during a drive headed home). The map is now fully interactive — single-finger drag pans, pinch zooms — and a new "Open in Maps" button overlay on the map opens the location in your external maps app. The chevron that opens the related drive/charge moved to the top-right of the merged card, vertically aligned with the title.
+
 ## [1.7.0] - 2026-04-30
 
 Complete visual refresh of the **drives and charges lists**, plus a new fast-scroll bar and several smaller fixes.

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -300,7 +301,9 @@ fun WhereWasIScreen(
                                 val titleSentence = stateSentence(carState, placeName)
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    verticalAlignment = Alignment.CenterVertically
+                                    // Top-align so the state icon and chevron stay anchored to the
+                                    // first line when a long place name wraps to two lines.
+                                    verticalAlignment = Alignment.Top
                                 ) {
                                     Icon(
                                         imageVector = stateIcon(carState),
@@ -314,6 +317,8 @@ fun WhereWasIScreen(
                                         style = MaterialTheme.typography.titleLarge,
                                         fontWeight = FontWeight.Bold,
                                         color = palette.onSurface,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
                                         modifier = Modifier.weight(1f)
                                     )
                                     if (hasLinkedActivity) {
@@ -355,13 +360,17 @@ fun WhereWasIScreen(
                                                     style = MaterialTheme.typography.bodyMedium,
                                                     fontWeight = FontWeight.Bold,
                                                     color = palette.accent,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis,
                                                     modifier = Modifier.clickable { onNavigateToCountriesVisited() }
                                                 )
                                             } else {
                                                 Text(
                                                     text = part,
                                                     style = MaterialTheme.typography.bodyMedium,
-                                                    color = palette.onSurfaceVariant
+                                                    color = palette.onSurfaceVariant,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
                                                 )
                                             }
                                             if (index < breadcrumbParts.lastIndex) {

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.wherewasi
 
 import android.content.Intent
 import android.net.Uri
+import android.view.MotionEvent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -21,6 +22,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.LocalParking
@@ -28,9 +30,11 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -197,104 +201,75 @@ fun WhereWasIScreen(
                         val context = LocalContext.current
                         val accentArgb = palette.accent.toArgb()
                         val youWereHere = stringResource(R.string.you_were_here)
+                        val openInMapsLabel = stringResource(R.string.where_was_i_open_in_maps)
                         Card(
-                            colors = CardDefaults.cardColors(containerColor = palette.surface),
-                            modifier = Modifier.clickable {
-                                val geoUri = Uri.parse("geo:$lat,$lon?q=$lat,$lon")
-                                context.startActivity(Intent(Intent.ACTION_VIEW, geoUri))
-                            }
+                            colors = CardDefaults.cardColors(containerColor = palette.surface)
                         ) {
-                            AndroidView(
-                                factory = { ctx ->
-                                    MapView(ctx).apply {
-                                        setTileSource(TileSourceFactory.MAPNIK)
-                                        setMultiTouchControls(false)
-                                        controller.setZoom(15.0)
-                                        controller.setCenter(GeoPoint(lat, lon))
-                                        val marker = org.osmdroid.views.overlay.Marker(this)
-                                        marker.position = GeoPoint(lat, lon)
-                                        marker.setAnchor(org.osmdroid.views.overlay.Marker.ANCHOR_CENTER, org.osmdroid.views.overlay.Marker.ANCHOR_BOTTOM)
-                                        marker.icon = createPinMarkerDrawable(ctx.resources, accentArgb)
-                                        marker.title = youWereHere
-                                        overlays.add(marker)
-                                    }
-                                },
+                            Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(250.dp)
                                     .clip(RoundedCornerShape(12.dp))
-                            )
-                        }
-                    }
-
-                    // Location breadcrumb + address
-                    state.location?.let { loc ->
-                        Card(
-                            colors = CardDefaults.cardColors(containerColor = palette.surface)
-                        ) {
-                            Column(modifier = Modifier.padding(16.dp)) {
-                                // Breadcrumb line: flag Country > Region > City
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.fillMaxWidth()
+                            ) {
+                                AndroidView(
+                                    factory = { ctx ->
+                                        MapView(ctx).apply {
+                                            setTileSource(TileSourceFactory.MAPNIK)
+                                            setMultiTouchControls(true)
+                                            // Tell the parent vertical scroll to stop intercepting
+                                            // touches so single-finger drag pans the map instead
+                                            // of scrolling the page.
+                                            setOnTouchListener { v, event ->
+                                                when (event.actionMasked) {
+                                                    MotionEvent.ACTION_DOWN,
+                                                    MotionEvent.ACTION_MOVE,
+                                                    MotionEvent.ACTION_POINTER_DOWN ->
+                                                        v.parent?.requestDisallowInterceptTouchEvent(true)
+                                                    MotionEvent.ACTION_UP,
+                                                    MotionEvent.ACTION_CANCEL ->
+                                                        v.parent?.requestDisallowInterceptTouchEvent(false)
+                                                }
+                                                false
+                                            }
+                                            controller.setZoom(15.0)
+                                            controller.setCenter(GeoPoint(lat, lon))
+                                            val marker = org.osmdroid.views.overlay.Marker(this)
+                                            marker.position = GeoPoint(lat, lon)
+                                            marker.setAnchor(org.osmdroid.views.overlay.Marker.ANCHOR_CENTER, org.osmdroid.views.overlay.Marker.ANCHOR_BOTTOM)
+                                            marker.icon = createPinMarkerDrawable(ctx.resources, accentArgb)
+                                            marker.title = youWereHere
+                                            overlays.add(marker)
+                                        }
+                                    },
+                                    modifier = Modifier.fillMaxSize()
+                                )
+                                FilledIconButton(
+                                    onClick = {
+                                        val geoUri = Uri.parse("geo:$lat,$lon?q=$lat,$lon")
+                                        try {
+                                            context.startActivity(Intent(Intent.ACTION_VIEW, geoUri))
+                                        } catch (_: android.content.ActivityNotFoundException) {
+                                            // No maps app installed — silently ignore
+                                        }
+                                    },
+                                    colors = IconButtonDefaults.filledIconButtonColors(
+                                        containerColor = palette.surface,
+                                        contentColor = palette.accent
+                                    ),
+                                    modifier = Modifier
+                                        .align(Alignment.TopEnd)
+                                        .padding(8.dp)
                                 ) {
-                                    loc.countryCode?.let { code ->
-                                        val flag = countryCodeToFlag(code)
-                                        Text(text = flag, fontSize = 16.sp)
-                                        Spacer(modifier = Modifier.width(4.dp))
-                                    }
-                                    val localizedCountryName = loc.countryCode?.let { code ->
-                                        java.util.Locale.Builder().setRegion(code).build().getDisplayCountry(java.util.Locale.getDefault())
-                                            .takeIf { it.isNotBlank() && it != code }
-                                    } ?: loc.countryName ?: loc.countryCode
-                                    val breadcrumbParts = listOfNotNull(
-                                        localizedCountryName,
-                                        loc.regionName,
-                                        loc.city
-                                    )
-                                    breadcrumbParts.forEachIndexed { index, part ->
-                                        if (index == 0 && loc.countryCode != null) {
-                                            // Country is tappable
-                                            Text(
-                                                text = part,
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                fontWeight = FontWeight.Bold,
-                                                color = palette.accent,
-                                                modifier = Modifier.clickable { onNavigateToCountriesVisited() }
-                                            )
-                                        } else {
-                                            Text(
-                                                text = part,
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = palette.onSurfaceVariant
-                                            )
-                                        }
-                                        if (index < breadcrumbParts.lastIndex) {
-                                            Text(
-                                                text = " > ",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = palette.onSurfaceVariant.copy(alpha = 0.5f)
-                                            )
-                                        }
-                                    }
-                                }
-
-                                // Geofence name or full address (bigger)
-                                val displayAddress = state.geofenceName
-                                    ?: loc.address
-                                if (displayAddress != null) {
-                                    Spacer(modifier = Modifier.height(8.dp))
-                                    Text(
-                                        text = displayAddress,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        color = palette.onSurface
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.OpenInNew,
+                                        contentDescription = openInMapsLabel
                                     )
                                 }
                             }
                         }
                     }
 
-                    // State card
+                    // Combined "what + where" card: state-aware sentence + breadcrumb + stats
                     state.carState?.let { carState ->
                         val hasLinkedActivity = when (carState) {
                             CarActivityState.DRIVING -> state.driveId != null
@@ -319,10 +294,12 @@ fun WhereWasIScreen(
                             } else Modifier.fillMaxWidth()
                         ) {
                             Column(modifier = Modifier.padding(16.dp)) {
-                                // State icon + label (centered)
+                                // Top row: state icon + state-aware sentence + chevron
+                                val placeName = state.geofenceName
+                                    ?: state.location?.address
+                                val titleSentence = stateSentence(carState, placeName)
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.Center,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Icon(
@@ -333,11 +310,69 @@ fun WhereWasIScreen(
                                     )
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Text(
-                                        text = stateLabel(carState),
-                                        style = MaterialTheme.typography.headlineSmall,
+                                        text = titleSentence,
+                                        style = MaterialTheme.typography.titleLarge,
                                         fontWeight = FontWeight.Bold,
-                                        color = palette.onSurface
+                                        color = palette.onSurface,
+                                        modifier = Modifier.weight(1f)
                                     )
+                                    if (hasLinkedActivity) {
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Icon(
+                                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                            contentDescription = null,
+                                            tint = palette.onSurfaceVariant,
+                                            modifier = Modifier.size(32.dp)
+                                        )
+                                    }
+                                }
+
+                                // Breadcrumb: flag Country > Region > City
+                                state.location?.let { loc ->
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        loc.countryCode?.let { code ->
+                                            val flag = countryCodeToFlag(code)
+                                            Text(text = flag, fontSize = 16.sp)
+                                            Spacer(modifier = Modifier.width(4.dp))
+                                        }
+                                        val localizedCountryName = loc.countryCode?.let { code ->
+                                            java.util.Locale.Builder().setRegion(code).build().getDisplayCountry(java.util.Locale.getDefault())
+                                                .takeIf { it.isNotBlank() && it != code }
+                                        } ?: loc.countryName ?: loc.countryCode
+                                        val breadcrumbParts = listOfNotNull(
+                                            localizedCountryName,
+                                            loc.regionName,
+                                            loc.city
+                                        )
+                                        breadcrumbParts.forEachIndexed { index, part ->
+                                            if (index == 0 && loc.countryCode != null) {
+                                                Text(
+                                                    text = part,
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = palette.accent,
+                                                    modifier = Modifier.clickable { onNavigateToCountriesVisited() }
+                                                )
+                                            } else {
+                                                Text(
+                                                    text = part,
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = palette.onSurfaceVariant
+                                                )
+                                            }
+                                            if (index < breadcrumbParts.lastIndex) {
+                                                Text(
+                                                    text = " > ",
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = palette.onSurfaceVariant.copy(alpha = 0.5f)
+                                                )
+                                            }
+                                        }
+                                    }
                                 }
 
                                 HorizontalDivider(
@@ -345,7 +380,6 @@ fun WhereWasIScreen(
                                     color = palette.onSurfaceVariant.copy(alpha = 0.2f)
                                 )
 
-                                // Info rows — shared info first, then state-specific
                                 // Row 1: Odometer | Outside Temp
                                 Row(modifier = Modifier.fillMaxWidth()) {
                                     InfoItem(
@@ -368,7 +402,7 @@ fun WhereWasIScreen(
 
                                 Spacer(modifier = Modifier.height(8.dp))
 
-                                // Row 2-3: State-specific
+                                // Row 2: state-specific
                                 when (carState) {
                                     CarActivityState.DRIVING -> {
                                         Row(modifier = Modifier.fillMaxWidth()) {
@@ -418,58 +452,32 @@ fun WhereWasIScreen(
                                             val sinceStr = state.parkedSince
                                             val sincePrefix = sinceStr?.let { stringResource(R.string.parked_since, "").trimEnd() }
 
-                                            Row(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Column(modifier = Modifier.weight(1f)) {
+                                            Column {
+                                                Text(
+                                                    text = buildAnnotatedString {
+                                                        append("$parkedForPrefix ")
+                                                        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                            append(durationStr)
+                                                        }
+                                                    },
+                                                    style = MaterialTheme.typography.bodyLarge,
+                                                    color = palette.onSurface
+                                                )
+                                                if (sinceStr != null && sincePrefix != null) {
                                                     Text(
                                                         text = buildAnnotatedString {
-                                                            append("$parkedForPrefix ")
+                                                            append("$sincePrefix ")
                                                             withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                                                append(durationStr)
+                                                                append(sinceStr)
                                                             }
                                                         },
-                                                        style = MaterialTheme.typography.bodyLarge,
-                                                        color = palette.onSurface
-                                                    )
-                                                    if (sinceStr != null && sincePrefix != null) {
-                                                        Text(
-                                                            text = buildAnnotatedString {
-                                                                append("$sincePrefix ")
-                                                                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                                                    append(sinceStr)
-                                                                }
-                                                            },
-                                                            style = MaterialTheme.typography.bodyMedium,
-                                                            color = palette.onSurfaceVariant
-                                                        )
-                                                    }
-                                                }
-                                                if (hasLinkedActivity) {
-                                                    Icon(
-                                                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                                        contentDescription = null,
-                                                        tint = palette.onSurfaceVariant,
-                                                        modifier = Modifier.size(24.dp)
+                                                        style = MaterialTheme.typography.bodyMedium,
+                                                        color = palette.onSurfaceVariant
                                                     )
                                                 }
                                             }
                                         }
                                     }
-                                }
-
-                                // Chevron hint for tappable cards (driving/charging)
-                                if (hasLinkedActivity && carState != CarActivityState.PARKED) {
-                                    Spacer(modifier = Modifier.height(8.dp))
-                                    Icon(
-                                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                        contentDescription = null,
-                                        tint = palette.onSurfaceVariant,
-                                        modifier = Modifier
-                                            .size(24.dp)
-                                            .align(Alignment.End)
-                                    )
                                 }
                             }
                         }
@@ -541,6 +549,25 @@ private fun stateLabel(state: CarActivityState): String = when (state) {
     CarActivityState.DRIVING -> stringResource(R.string.where_was_i_driving)
     CarActivityState.CHARGING -> stringResource(R.string.where_was_i_charging)
     CarActivityState.PARKED -> stringResource(R.string.where_was_i_parked)
+}
+
+/**
+ * Builds the state-aware sentence for the merged "what + where" card.
+ *
+ * If the place name is known, returns "Heading to X" / "Charging at X" / "Parked at X" so the
+ * relationship between the activity and the named location is unambiguous (especially for
+ * driving, where the geofence is the destination, not the current position). Falls back to the
+ * bare state label when no place name is available.
+ */
+@Composable
+private fun stateSentence(state: CarActivityState, placeName: String?): String {
+    if (placeName.isNullOrBlank()) return stateLabel(state)
+    val resId = when (state) {
+        CarActivityState.DRIVING -> R.string.where_was_i_heading_to
+        CarActivityState.CHARGING -> R.string.where_was_i_charging_at
+        CarActivityState.PARKED -> R.string.where_was_i_parked_at
+    }
+    return stringResource(resId, placeName)
 }
 
 private fun stateIcon(state: CarActivityState): ImageVector = when (state) {

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
@@ -149,7 +149,9 @@ class WhereWasIViewModel @Inject constructor(
             driveDistance = drive.distance,
             units = units,
             targetDateTime = _uiState.value.targetDateTime,
-            geofenceName = drive.endAddress ?: drive.startAddress
+            // Destination only — falling back to startAddress would mislead, since the screen
+            // frames this as "Heading to X" and X must be where the car is going.
+            geofenceName = drive.endAddress
         )
 
         // Fetch geocoding and weather in background

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1176,4 +1176,8 @@
     <!-- Parked duration shown on the Where Was I screen -->
     <string name="parked_for">Aparcat durant %s</string>
     <string name="parked_since">des de %s</string>
+    <string name="where_was_i_heading_to">En camí a %s</string>
+    <string name="where_was_i_charging_at">Carregant a %s</string>
+    <string name="where_was_i_parked_at">Aparcat a %s</string>
+    <string name="where_was_i_open_in_maps">Obrir al mapa</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1176,4 +1176,8 @@
     <!-- Parked duration shown on the Where Was I screen -->
     <string name="parked_for">Aparcado durante %s</string>
     <string name="parked_since">desde %s</string>
+    <string name="where_was_i_heading_to">En camino a %s</string>
+    <string name="where_was_i_charging_at">Cargando en %s</string>
+    <string name="where_was_i_parked_at">Aparcado en %s</string>
+    <string name="where_was_i_open_in_maps">Abrir en Mapas</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1176,4 +1176,8 @@
     <!-- Parked duration shown on the Where Was I screen -->
     <string name="parked_for">Parcheggiato da %s</string>
     <string name="parked_since">dalle %s</string>
+    <string name="where_was_i_heading_to">Diretta a %s</string>
+    <string name="where_was_i_charging_at">In ricarica a %s</string>
+    <string name="where_was_i_parked_at">Parcheggiata a %s</string>
+    <string name="where_was_i_open_in_maps">Apri nelle mappe</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1201,4 +1201,8 @@
     <!-- Parked duration shown on the Where Was I screen -->
     <string name="parked_for">已停放 %s</string>
     <string name="parked_since">自 %s 起</string>
+    <string name="where_was_i_heading_to">前往 %s</string>
+    <string name="where_was_i_charging_at">在 %s 充电</string>
+    <string name="where_was_i_parked_at">停放在 %s</string>
+    <string name="where_was_i_open_in_maps">在地图中打开</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1287,4 +1287,12 @@
     <string name="parked_for">Parked for %s</string>
     <!-- "Since" date of last activity, e.g. "since 22 Mar 2026, 11:52" -->
     <string name="parked_since">since %s</string>
+    <!-- Sentence shown on the Where Was I card when the car was driving toward a destination, e.g. "Heading to Home" -->
+    <string name="where_was_i_heading_to">Heading to %s</string>
+    <!-- Sentence shown on the Where Was I card when the car was charging at a location, e.g. "Charging at Tesla Supercharger" -->
+    <string name="where_was_i_charging_at">Charging at %s</string>
+    <!-- Sentence shown on the Where Was I card when the car was parked at a location, e.g. "Parked at Home" -->
+    <string name="where_was_i_parked_at">Parked at %s</string>
+    <!-- Content description for the icon button that opens the location in the user's external maps app -->
+    <string name="where_was_i_open_in_maps">Open in Maps</string>
 </resources>


### PR DESCRIPTION
## Summary

Holistic redesign of the **Where Was I?** screen to address three concerns reported by the user:

1. **Map was hard to move** — required two-finger drag because `setMultiTouchControls(false)` was set and the parent `verticalScroll` ate single-finger gestures. The card-level `Modifier.clickable` (the only path to opening external maps) further intercepted touches.
2. **Place-name label was unclear** — when the car was driving, the geofence shown big (e.g. "Home") was actually the *destination*, not where the car was, but the label gave no hint of that. The breadcrumb above showed the *current* city. The two pieces never connected.
3. **Chevron was small and at the bottom** — for driving/charging the chevron sat below the stats; for parked it lived inline with the duration row. Inconsistent.

## What changed

- **Merged Location + State cards** into a single "what + where" card with a state-aware sentence on top. Identical layout in all three states:

  | State | Top line |
  |---|---|
  | Driving | 🚗 **Heading to Home** |
  | Charging | ⚡ **Charging at Tesla SC** |
  | Parked | 🅿 **Parked at Home** |

  Below the title, the same breadcrumb (flag + Country > Region > City) gives global context. For driving, the "Heading to" + breadcrumb pair makes destination vs current position explicit; for charging/parked, the title and breadcrumb reinforce each other.

- **Map gestures**: `setMultiTouchControls(true)` + `OnTouchListener` that calls `parent.requestDisallowInterceptTouchEvent(true)` on `ACTION_DOWN`/`MOVE`/`POINTER_DOWN`, releasing on `UP`/`CANCEL`. Single-finger drag pans, pinch zooms.

- **Open in Maps button**: explicit `FilledIconButton` overlaid at the top-right of the map (uses the car palette's accent + surface), wraps the existing `geo:` intent. The card-level `clickable` that previously fought gestures is removed.

- **Chevron**: moved to the top-right of the merged card, vertically centered with the title sentence, sized 32 dp. Same position for driving, charging and parked. The old bottom-of-card chevron and the inline parked chevron are gone.

- **ViewModel**: for driving, `geofenceName` now uses `drive.endAddress` only (dropped the `?: drive.startAddress` fallback), since the new sentence framing requires the value to be the destination.

- **Strings**: added `where_was_i_heading_to`, `where_was_i_charging_at`, `where_was_i_parked_at`, `where_was_i_open_in_maps` to all 5 locales (en, it, es, ca, zh).

## Test plan
- [ ] Open Where Was I for a moment during a drive — title reads "Heading to <destination>" + breadcrumb shows current city.
- [ ] Open for a charging session — title reads "Charging at <name>".
- [ ] Open for a parked moment — title reads "Parked at <name>", duration still appears in the stats grid.
- [ ] Map: single-finger drag pans, pinch zooms, no scrolling of the page until you lift your finger.
- [ ] Tap "Open in Maps" button → external maps app opens at the right coordinates.
- [ ] Chevron at top-right opens the related drive/charge for all three states.
- [ ] All 5 locales render the new strings correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)