### PR TITLE
  fix: unify locale-aware date, time, and duration formatting

### DIFF
--- a/app/src/main/java/com/matedroid/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/WeatherRepository.kt
@@ -3,10 +3,11 @@ package com.matedroid.data.repository
 import android.util.Log
 import com.matedroid.data.api.OpenMeteoApi
 import com.matedroid.data.api.models.DrivePosition
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.async
@@ -288,7 +289,7 @@ class WeatherRepository @Inject constructor(
             val temperature = hourly.temperature2m?.getOrNull(timeIndex) ?: return null
             val weatherCode = hourly.weatherCode?.getOrNull(timeIndex) ?: 0
 
-            val timeStr = dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
+            val timeStr = dateTime.formatTime(Locale.getDefault())
 
             return WeatherPoint(
                 time = timeStr,
@@ -307,18 +308,8 @@ class WeatherRepository @Inject constructor(
      * Parses a date string into LocalDateTime.
      * Supports both ISO 8601 with offset and without.
      */
-    private fun parseDateTime(dateStr: String): LocalDateTime? {
-        return try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            try {
-                LocalDateTime.parse(dateStr.replace("Z", ""))
-            } catch (e2: Exception) {
-                Log.e(TAG, "Failed to parse date: $dateStr", e2)
-                null
-            }
-        }
-    }
+    private fun parseDateTime(dateStr: String): LocalDateTime? =
+        parseIsoDateTime(dateStr)
 
     /**
      * Calculates the distance between two points using the Haversine formula.

--- a/app/src/main/java/com/matedroid/data/sync/SyncLogCollector.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncLogCollector.kt
@@ -4,8 +4,7 @@ import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,7 +18,7 @@ class SyncLogCollector @Inject constructor() {
 
     companion object {
         private const val MAX_LOG_ENTRIES = 500
-        private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+        private val dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS", Locale.getDefault())
     }
 
     private val _logs = MutableStateFlow<List<String>>(emptyList())
@@ -29,7 +28,7 @@ class SyncLogCollector @Inject constructor() {
 
     @Synchronized
     fun log(tag: String, message: String) {
-        val timestamp = dateFormat.format(Date())
+        val timestamp = java.time.LocalTime.now().format(dateFormat)
         val entry = "$timestamp [$tag] $message"
 
         // Also log to Android logcat
@@ -47,7 +46,7 @@ class SyncLogCollector @Inject constructor() {
 
     @Synchronized
     fun logError(tag: String, message: String, error: Throwable? = null) {
-        val timestamp = dateFormat.format(Date())
+        val timestamp = java.time.LocalTime.now().format(dateFormat)
         val errorMsg = error?.message?.let { " - $it" } ?: ""
         val entry = "$timestamp [$tag] ERROR: $message$errorMsg"
 

--- a/app/src/main/java/com/matedroid/domain/TripAggregator.kt
+++ b/app/src/main/java/com/matedroid/domain/TripAggregator.kt
@@ -3,9 +3,8 @@ package com.matedroid.domain
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.domain.model.Trip
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 
 /**
@@ -67,15 +66,6 @@ object TripAggregator {
         )
     }
 
-    private fun parseDateTime(dateStr: String): LocalDateTime? {
-        return try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            try {
-                LocalDateTime.parse(dateStr.replace("Z", ""))
-            } catch (e2: Exception) {
-                null
-            }
-        }
-    }
+    private fun parseDateTime(dateStr: String): LocalDateTime? =
+        parseIsoDateTime(dateStr)
 }

--- a/app/src/main/java/com/matedroid/domain/TripDetector.kt
+++ b/app/src/main/java/com/matedroid/domain/TripDetector.kt
@@ -3,9 +3,8 @@ package com.matedroid.domain
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.domain.model.Trip
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -127,15 +126,6 @@ class TripDetector @Inject constructor() {
         TripAggregator.buildTrip(drives, charges)?.let { trips.add(it) }
     }
 
-    private fun parseDateTime(dateStr: String): LocalDateTime? {
-        return try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            try {
-                LocalDateTime.parse(dateStr.replace("Z", ""))
-            } catch (e2: Exception) {
-                null
-            }
-        }
-    }
+    private fun parseDateTime(dateStr: String): LocalDateTime? =
+        parseIsoDateTime(dateStr)
 }

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -11,10 +11,9 @@ import com.matedroid.data.local.entity.SavedTripConsumedFingerprint
 import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.local.entity.SavedTripWithLegs
 import com.matedroid.domain.model.Trip
+import com.matedroid.util.parseIsoDateTime
 import java.security.MessageDigest
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -315,11 +314,8 @@ class TripRepository @Inject constructor(
 
     private fun compareDates(a: String, b: String): Int = a.compareTo(b)
 
-    private fun parseDate(s: String): LocalDateTime? = try {
-        OffsetDateTime.parse(s).toLocalDateTime()
-    } catch (e: DateTimeParseException) {
-        try { LocalDateTime.parse(s.replace("Z", "")) } catch (e2: Exception) { null }
-    }
+    private fun parseDate(s: String): LocalDateTime? =
+        parseIsoDateTime(s)
 
     private fun daysBetween(a: String, b: String): Long? {
         val pa = parseDate(a) ?: return null

--- a/app/src/main/java/com/matedroid/ui/components/DateRangePickerDialog.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DateRangePickerDialog.kt
@@ -17,27 +17,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.matedroid.util.formatShortNoYear
 import com.matedroid.R
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
 import java.util.Locale
 
 /**
- * Format a [LocalDate] as day/month or month/day depending on locale.
- * EU locales: "7/4", US locale: "4/7".
+ * Format a [LocalDate] as a locale-aware short date without year.
+ * en-US: "5/10", zh-CN: "5/10", it-IT: "10/05".
  */
-fun formatShortDate(date: LocalDate): String {
-    val pattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-        FormatStyle.SHORT, null, IsoChronology.INSTANCE, Locale.getDefault()
-    )
-    val monthFirst = pattern.indexOf('M') < pattern.indexOf('d')
-    return if (monthFirst) "${date.monthValue}/${date.dayOfMonth}"
-    else "${date.dayOfMonth}/${date.monthValue}"
-}
+fun formatShortDate(date: LocalDate): String = date.formatShortNoYear(Locale.getDefault())
 
 /**
  * Two-step date picker dialog: first picks the "from" date, then the "to" date.

--- a/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
+++ b/app/src/main/java/com/matedroid/ui/components/EditorialListItem.kt
@@ -38,10 +38,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.matedroid.util.formatEditorial
+import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
+import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
 import java.util.Locale
 
 /**
@@ -268,23 +270,17 @@ fun EditorialPill(
 }
 
 /**
- * Format an ISO-8601 datetime (with or without offset, as TeslaMate may emit either)
- * as a locale-aware "MON · 14 APR · 09:42" dateline. Falls back to the raw input on
- * parse failure rather than swallowing it — better to show a weird value than to hide
- * it entirely while debugging.
+ * Format an ISO-8601 datetime as a locale-aware editorial dateline.
+ *
+ * Locale-aware examples:
+ *   en-US: "SUN · MAY 10 · 3:39 PM"
+ *   zh-CN: "周日 · 5月10日 · 15:39"
+ *   it-IT: "DOM · 10 MAG · 15:39"
+ *
+ * Falls back to the raw input on parse failure.
  */
-internal fun formatEditorialDate(dateStr: String?): String {
+internal fun formatEditorialDate(dateStr: String?, is24Hour: Boolean? = null): String {
     if (dateStr.isNullOrBlank()) return ""
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (_: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        // Middle dots are literal because they're outside the pattern alphabet.
-        dt.format(DateTimeFormatter.ofPattern("EEE · d MMM · HH:mm", Locale.getDefault()))
-            .uppercase(Locale.getDefault())
-    } catch (_: Exception) {
-        dateStr
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    return dt.formatEditorial(Locale.getDefault(), is24Hour)
 }

--- a/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
+++ b/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
@@ -51,12 +51,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import com.matedroid.util.parseIsoDate
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -417,19 +415,8 @@ private fun handleDrag(
  * [LocalDate]. Returns null on parse failure rather than throwing — the scroll
  * indicator simply treats unparseable rows as undated.
  */
-internal fun String?.parseListItemDate(): LocalDate? {
-    if (this.isNullOrBlank()) return null
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(this).toLocalDateTime()
-        } catch (_: DateTimeParseException) {
-            LocalDateTime.parse(this.replace("Z", ""))
-        }
-        dt.toLocalDate()
-    } catch (_: Exception) {
-        null
-    }
-}
+internal fun String?.parseListItemDate(): LocalDate? =
+    parseIsoDate(this)
 
 internal fun String?.parseListItemYearMonth(): YearMonth? =
     parseListItemDate()?.let(YearMonth::from)

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -63,10 +63,10 @@ import kotlinx.coroutines.launch
 import com.matedroid.R
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.sqrt
 
@@ -911,15 +911,7 @@ private fun formatTimelineDuration(minutes: Int): String {
 }
 
 private fun formatClockTime(dateStr: String): String {
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        dt.format(DateTimeFormatter.ofPattern("HH:mm"))
-    } catch (e: Exception) {
-        dateStr
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    return dt.formatTime(Locale.getDefault())
 }
 

--- a/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripWeatherSparklineCard.kt
@@ -45,8 +45,9 @@ import com.matedroid.data.repository.TripWeatherPoint
 import com.matedroid.data.repository.WeatherCondition
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.util.formatTime
 import androidx.compose.ui.res.stringResource
-import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -117,19 +118,19 @@ fun TripWeatherSparklineCard(
             // Endpoints row — first and last sample times for context
             val first = samples.first()
             val last = samples.last()
-            val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+            val locale = Locale.getDefault()
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = first.timestamp.format(timeFmt),
+                    text = first.timestamp.formatTime(locale),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
-                    text = last.timestamp.format(timeFmt),
+                    text = last.timestamp.formatTime(locale),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -79,11 +79,10 @@ import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.format.FormatStyle
+import com.matedroid.util.formatDurationCompact
+import com.matedroid.util.formatMedium
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -160,6 +159,7 @@ private fun ChargeDetailContent(
     onRemoveFromTrip: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
 
@@ -240,7 +240,7 @@ private fun ChargeDetailContent(
                     StatItem(startLabel, "${s.batteryStart}%"),
                     StatItem(endLabel, "${s.batteryEnd}%"),
                     StatItem(addedLabel, "+${s.batteryAdded}%"),
-                    StatItem(durationLabel, formatDuration(s.durationMin))
+                    StatItem(durationLabel, formatDurationCompact(s.durationMin))
                 )
             )
 
@@ -305,19 +305,11 @@ private fun ChargeDetailContent(
             val chargePoints = detail.chargePoints
             if (!chargePoints.isNullOrEmpty() && chargePoints.size > 2) {
                 // Extract time range for labels
-                val timeLabels = extractTimeLabels(chargePoints)
-                val timeFormatter = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+                val timeLabels = extractTimeLabels(chargePoints, is24Hour)
                 val fractionToTimeLabel: (Float) -> String = { fraction ->
                     val index = (fraction * chargePoints.lastIndex).roundToInt().coerceIn(0, chargePoints.lastIndex)
                     chargePoints[index].date?.let { dateStr ->
-                        try {
-                            val dt = try {
-                                java.time.OffsetDateTime.parse(dateStr).toLocalDateTime()
-                            } catch (e: java.time.format.DateTimeParseException) {
-                                java.time.LocalDateTime.parse(dateStr.replace("Z", ""))
-                            }
-                            dt.format(timeFormatter)
-                        } catch (e: Exception) { "" }
+                        parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
                     } ?: ""
                 }
 
@@ -390,6 +382,7 @@ private fun ChargeDetailContent(
 
 @Composable
 private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isDcCharge: Boolean) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val locationLabel = stringResource(R.string.location)
     val unknownLocationLabel = stringResource(R.string.unknown_location)
     val startedLabel = stringResource(R.string.started)
@@ -453,7 +446,7 @@ private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isD
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                     )
                     Text(
-                        text = formatDateTime(detail.startDate, unknownLabel),
+                        text = formatDateTime(detail.startDate, unknownLabel, is24Hour),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
@@ -476,7 +469,7 @@ private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isD
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                     )
                     Text(
-                        text = formatDateTime(detail.endDate, unknownLabel),
+                        text = formatDateTime(detail.endDate, unknownLabel, is24Hour),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
@@ -953,23 +946,12 @@ private fun ChargeTypeBadge(isDcCharge: Boolean) {
  * Returns list of 5 time strings at 0%, 25%, 50%, 75%, and 100% positions.
  * Following the chart guidelines: start, 1st quarter, half, 3rd quarter, end.
  */
-private fun extractTimeLabels(chargePoints: List<ChargePoint>): List<String> {
+private fun extractTimeLabels(chargePoints: List<ChargePoint>, is24Hour: Boolean? = null): List<String> {
     if (chargePoints.isEmpty()) return listOf("", "", "", "", "")
 
-    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    val locale = java.util.Locale.getDefault()
     val times = chargePoints.mapNotNull { point ->
-        point.date?.let { dateStr ->
-            try {
-                val dateTime = try {
-                    OffsetDateTime.parse(dateStr).toLocalDateTime()
-                } catch (e: DateTimeParseException) {
-                    LocalDateTime.parse(dateStr.replace("Z", ""))
-                }
-                dateTime
-            } catch (e: Exception) {
-                null
-            }
-        }
+        point.date?.let { parseIsoDateTime(it) }
     }
 
     if (times.isEmpty()) return listOf("", "", "", "", "")
@@ -977,28 +959,13 @@ private fun extractTimeLabels(chargePoints: List<ChargePoint>): List<String> {
     // 5 positions: start (0%), 1st quarter (25%), half (50%), 3rd quarter (75%), end (100%)
     val indices = listOf(0, times.size / 4, times.size / 2, times.size * 3 / 4, times.size - 1)
     return indices.map { idx ->
-        times.getOrNull(idx.coerceIn(0, times.size - 1))?.format(timeFormatter) ?: ""
+        times.getOrNull(idx.coerceIn(0, times.size - 1))?.formatTime(locale, is24Hour) ?: ""
     }
 }
 
-private fun formatDateTime(dateStr: String?, unknownLabel: String = "Unknown"): String {
-    if (dateStr == null) return unknownLabel
-    return try {
-        val dateTime = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        // Use locale-aware formatter for proper date/time localization
-        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
-        dateTime.format(formatter)
-    } catch (e: Exception) {
-        dateStr
-    }
-}
-
-private fun formatDuration(minutes: Int): String {
-    val hours = minutes / 60
-    val mins = minutes % 60
-    return "%d:%02d".format(hours, mins)
+private fun formatDateTime(dateStr: String?, unknownLabel: String = "Unknown", is24Hour: Boolean? = null): String {
+    if (dateStr.isNullOrBlank()) return unknownLabel
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    val locale = java.util.Locale.getDefault()
+    return "${dt.toLocalDate().formatMedium(locale)} ${dt.formatTime(locale, is24Hour)}"
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -668,6 +668,7 @@ private fun ChargeItem(
     onEditCost: (() -> Unit)? = null,
     onClick: () -> Unit
 ) {
+    val context = LocalContext.current
     val unknownLocation = stringResource(R.string.unknown_location)
     val freeLabel = stringResource(R.string.charge_free)
     val accent = if (isDcCharge) palette.dcColor else palette.acColor
@@ -680,9 +681,10 @@ private fun ChargeItem(
     val costText = if (isFree) freeLabel else "$currencySymbol%.2f".format(cost)
     val costPillText = if (onEditCost != null) "$costText ↗" else costText
 
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(context)
     EditorialListItem(
         accent = accent,
-        dateline = formatEditorialDate(charge.startDate),
+        dateline = formatEditorialDate(charge.startDate, is24Hour),
         title = charge.address ?: unknownLocation,
         heroValue = "%.1f".format(charge.chargeEnergyAdded ?: 0.0),
         heroUnit = "kWh",

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -21,10 +21,13 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
+import com.matedroid.util.formatMonthYear
+import com.matedroid.util.formatShortNoYear
+import com.matedroid.util.formatWeekLabel
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
-import java.util.Locale
 import javax.inject.Inject
 
 enum class ChartGranularity {
@@ -476,7 +479,7 @@ class ChargesViewModel @Inject constructor(
                     val itemsInDay = chargesByDay[key] ?: emptyList()
                     result.add(
                         createChargeChartPoint(
-                            label = current.format(DateTimeFormatter.ofPattern("d/M")),
+                            label = current.formatShortNoYear(Locale.getDefault()),
                             sortKey = key,
                             charges = itemsInDay,
                             dcChargeIds = _uiState.value.dcChargeIds
@@ -518,7 +521,7 @@ class ChargesViewModel @Inject constructor(
                     val weekOfYear = currentWeek.get(weekFields.weekOfYear())
                     result.add(
                         createChargeChartPoint(
-                            label = "W$weekOfYear",
+                            label = formatWeekLabel(weekOfYear, Locale.getDefault()),
                             sortKey = key,
                             charges = chargesInWeek,
                             dcChargeIds = _uiState.value.dcChargeIds
@@ -558,7 +561,7 @@ class ChargesViewModel @Inject constructor(
                     val chargesInMonth = chargesByMonth[key] ?: emptyList()
                     result.add(
                         createChargeChartPoint(
-                            label = firstDay.format(DateTimeFormatter.ofPattern("MMM yy")),
+                            label = firstDay.formatMonthYear(Locale.getDefault()),
                             sortKey = key,
                             charges = chargesInMonth,
                             dcChargeIds = _uiState.value.dcChargeIds

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -66,14 +66,16 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.ChargePoint
+import androidx.compose.ui.platform.LocalContext
 import com.matedroid.ui.components.FullscreenDualAxisLineChart
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 import kotlin.math.roundToInt
+import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
+import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -236,6 +238,7 @@ private fun CurrentChargeContent(
     chronologicalPoints: List<ChargePoint>,
     modifier: Modifier = Modifier
 ) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
 
@@ -270,22 +273,14 @@ private fun CurrentChargeContent(
         }
 
         // Charts - always show cards, even with few data points
-        val timeLabels = extractChronoTimeLabels(chronologicalPoints)
+        val timeLabels = extractChronoTimeLabels(chronologicalPoints, is24Hour)
         val powers = chronologicalPoints.mapNotNull { it.chargerPower?.toFloat() }
         val batteryLevels = chronologicalPoints.mapNotNull { it.batteryLevel?.toFloat() }
-        val timeFormatter = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
         val fractionToTimeLabel: (Float) -> String = { fraction ->
             val pts = chronologicalPoints
             val index = (fraction * pts.lastIndex).roundToInt().coerceIn(0, pts.lastIndex)
             pts[index].date?.let { dateStr ->
-                try {
-                    val dt = try {
-                        OffsetDateTime.parse(dateStr).toLocalDateTime()
-                    } catch (e: java.time.format.DateTimeParseException) {
-                        java.time.LocalDateTime.parse(dateStr.replace("Z", ""))
-                    }
-                    dt.format(timeFormatter)
-                } catch (e: Exception) { "" }
+                parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
             } ?: ""
         }
 
@@ -385,6 +380,7 @@ private fun CurrentChargeHeaderCard(
     chargeLimitSoc: Int?,
     chronologicalPoints: List<ChargePoint>
 ) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val unknownLabel = stringResource(R.string.unknown)
     val estimatedEndLabel = stringResource(R.string.current_charge_estimated_end)
     val elapsedLabel = stringResource(R.string.current_charge_elapsed)
@@ -529,7 +525,7 @@ private fun CurrentChargeHeaderCard(
                                 color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                             )
                             Text(
-                                text = formatEstimatedEnd(hours),
+                                text = formatEstimatedEnd(hours, is24Hour),
                                 style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Medium,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer
@@ -816,40 +812,28 @@ private fun LiveChartCard(
     }
 }
 
-private fun extractChronoTimeLabels(chargePoints: List<ChargePoint>): List<String> {
+private fun extractChronoTimeLabels(chargePoints: List<ChargePoint>, is24Hour: Boolean? = null): List<String> {
     if (chargePoints.isEmpty()) return listOf("", "", "", "", "")
 
-    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     val times = chargePoints.mapNotNull { point ->
-        point.date?.let { dateStr ->
-            try {
-                val dateTime = try {
-                    OffsetDateTime.parse(dateStr).toLocalDateTime()
-                } catch (e: DateTimeParseException) {
-                    LocalDateTime.parse(dateStr.replace("Z", ""))
-                }
-                dateTime
-            } catch (e: Exception) {
-                null
-            }
-        }
+        point.date?.let { parseIsoDateTime(it) }
     }
 
     if (times.isEmpty()) return listOf("", "", "", "", "")
 
     val indices = listOf(0, times.size / 4, times.size / 2, times.size * 3 / 4, times.size - 1)
+    val locale = java.util.Locale.getDefault()
     return indices.map { idx ->
-        times.getOrNull(idx.coerceIn(0, times.size - 1))?.format(timeFormatter) ?: ""
+        times.getOrNull(idx.coerceIn(0, times.size - 1))?.formatTime(locale, is24Hour) ?: ""
     }
 }
 
-private fun formatEstimatedEnd(hoursRemaining: Double): String {
+private fun formatEstimatedEnd(hoursRemaining: Double, is24Hour: Boolean? = null): String {
     val totalMinutes = (hoursRemaining * 60).roundToInt()
     val now = java.time.LocalDateTime.now()
     val endTime = now.plusMinutes(totalMinutes.toLong())
-    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     val h = totalMinutes / 60
     val m = totalMinutes % 60
     val durationStr = if (h > 0) "${h}h ${m}m" else "${m}m"
-    return "${endTime.format(timeFormatter)} ($durationStr)"
+    return "${endTime.formatTime(java.util.Locale.getDefault(), is24Hour)} ($durationStr)"
 }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -121,6 +121,9 @@ import com.matedroid.data.local.CarImageOverride
 import com.matedroid.ui.components.CarImagePickerDialog
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.createPinMarkerDrawable
+import com.matedroid.util.formatDuration
+import com.matedroid.util.formatShortNoYear
+import com.matedroid.util.formatTime
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.CustomZoomButtonsController
@@ -764,13 +767,7 @@ private fun formatDurationSince(isoTimestamp: String?): String? {
         val duration = java.time.Duration.between(instant, now)
         val totalMinutes = duration.toMinutes()
         if (totalMinutes < 0) return null
-        val hours = totalMinutes / 60
-        val minutes = totalMinutes % 60
-        if (hours > 0) {
-            "${hours}h ${minutes}m"
-        } else {
-            "${minutes}m"
-        }
+        formatDuration(totalMinutes.toInt(), java.util.Locale.getDefault())
     } catch (e: Exception) {
         null
     }
@@ -789,12 +786,13 @@ private fun formatTimeFromTimestamp(isoTimestamp: String?, yesterdayStr: String)
         val localDateTime = dateTime.toLocalDateTime()
         val today = java.time.LocalDate.now()
         val yesterday = today.minusDays(1)
-        val timeStr = String.format("%02d:%02d", localDateTime.hour, localDateTime.minute)
+        val locale = java.util.Locale.getDefault()
+        val timeStr = localDateTime.formatTime(locale)
 
         when (localDateTime.toLocalDate()) {
             today -> timeStr
             yesterday -> "$yesterdayStr $timeStr"
-            else -> String.format("%02d/%02d %s", localDateTime.dayOfMonth, localDateTime.monthValue, timeStr)
+            else -> "${localDateTime.toLocalDate().formatShortNoYear(locale)} $timeStr"
         }
     } catch (e: Exception) {
         null

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -81,11 +81,10 @@ import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Polyline
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.format.FormatStyle
+import com.matedroid.util.formatDurationCompact
+import com.matedroid.util.formatMedium
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -169,6 +168,7 @@ private fun DriveDetailContent(
     onRemoveFromTrip: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
 
@@ -222,7 +222,7 @@ private fun DriveDetailContent(
                 icon = CustomIcons.SteeringWheel,
                 stats = listOf(
                     StatItem(stringResource(R.string.distance), UnitFormatter.formatDistance(s.distance, units)),
-                    StatItem(stringResource(R.string.duration), formatDuration(s.durationMin)),
+                    StatItem(stringResource(R.string.duration), formatDurationCompact(s.durationMin)),
                     StatItem(stringResource(R.string.efficiency), UnitFormatter.formatEfficiency(s.efficiency, units))
                 )
             )
@@ -281,20 +281,12 @@ private fun DriveDetailContent(
                 val positions = detail.positions
                 // Remember expensive computations so they don't re-run on every
                 // recomposition during tooltip swipe interactions
-                val timeLabels = remember(positions) { extractTimeLabels(positions) }
-                val timeFormatter = remember { java.time.format.DateTimeFormatter.ofPattern("HH:mm") }
+                val timeLabels = remember(positions) { extractTimeLabels(positions, is24Hour) }
                 val fractionToTimeLabel: (Float) -> String = remember(positions) {
                     { fraction: Float ->
                         val index = (fraction * positions.lastIndex).roundToInt().coerceIn(0, positions.lastIndex)
                         positions[index].date?.let { dateStr ->
-                            try {
-                                val dt = try {
-                                    java.time.OffsetDateTime.parse(dateStr).toLocalDateTime()
-                                } catch (e: java.time.format.DateTimeParseException) {
-                                    java.time.LocalDateTime.parse(dateStr.replace("Z", ""))
-                                }
-                                dt.format(timeFormatter)
-                            } catch (e: Exception) { "" }
+                            parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
                         } ?: ""
                     }
                 }
@@ -348,6 +340,7 @@ private fun DriveDetailContent(
 
 @Composable
 private fun RouteHeaderCard(detail: DriveDetail) {
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -432,7 +425,7 @@ private fun RouteHeaderCard(detail: DriveDetail) {
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                     )
                     Text(
-                        text = formatDateTime(detail.startDate),
+                        text = formatDateTime(detail.startDate, is24Hour),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
@@ -455,7 +448,7 @@ private fun RouteHeaderCard(detail: DriveDetail) {
                         color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                     )
                     Text(
-                        text = formatDateTime(detail.endDate),
+                        text = formatDateTime(detail.endDate, is24Hour),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
@@ -846,23 +839,12 @@ private fun ChartCard(
  * Returns list of 5 time strings at 0%, 25%, 50%, 75%, and 100% positions.
  * Following the chart guidelines: start, 1st quarter, half, 3rd quarter, end.
  */
-private fun extractTimeLabels(positions: List<DrivePosition>): List<String> {
+private fun extractTimeLabels(positions: List<DrivePosition>, is24Hour: Boolean? = null): List<String> {
     if (positions.isEmpty()) return listOf("", "", "", "", "")
 
-    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    val locale = java.util.Locale.getDefault()
     val times = positions.mapNotNull { position ->
-        position.date?.let { dateStr ->
-            try {
-                val dateTime = try {
-                    OffsetDateTime.parse(dateStr).toLocalDateTime()
-                } catch (e: DateTimeParseException) {
-                    LocalDateTime.parse(dateStr.replace("Z", ""))
-                }
-                dateTime
-            } catch (e: Exception) {
-                null
-            }
-        }
+        position.date?.let { parseIsoDateTime(it) }
     }
 
     if (times.isEmpty()) return listOf("", "", "", "", "")
@@ -870,28 +852,13 @@ private fun extractTimeLabels(positions: List<DrivePosition>): List<String> {
     // 5 positions: start (0%), 1st quarter (25%), half (50%), 3rd quarter (75%), end (100%)
     val indices = listOf(0, times.size / 4, times.size / 2, times.size * 3 / 4, times.size - 1)
     return indices.map { idx ->
-        times.getOrNull(idx.coerceIn(0, times.size - 1))?.format(timeFormatter) ?: ""
+        times.getOrNull(idx.coerceIn(0, times.size - 1))?.formatTime(locale, is24Hour) ?: ""
     }
 }
 
-private fun formatDateTime(dateStr: String?): String {
-    if (dateStr == null) return "Unknown"
-    return try {
-        val dateTime = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        // Use locale-aware formatter for proper date/time localization
-        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
-        dateTime.format(formatter)
-    } catch (e: Exception) {
-        dateStr
-    }
-}
-
-private fun formatDuration(minutes: Int): String {
-    val hours = minutes / 60
-    val mins = minutes % 60
-    return "%d:%02d".format(hours, mins)
+private fun formatDateTime(dateStr: String?, is24Hour: Boolean? = null): String {
+    if (dateStr.isNullOrBlank()) return "Unknown"
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    val locale = java.util.Locale.getDefault()
+    return "${dt.toLocalDate().formatMedium(locale)} ${dt.formatTime(locale, is24Hour)}"
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -75,6 +76,8 @@ import com.matedroid.ui.components.rememberDebouncedLoading
 import com.matedroid.ui.components.formatEditorialDate
 import com.matedroid.ui.components.formatShortDate
 import com.matedroid.ui.components.parseListItemDate
+import com.matedroid.util.formatDuration
+import com.matedroid.util.formatDurationCompact
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
@@ -452,7 +455,7 @@ private fun SummaryCard(summary: DrivesSummary, units: Units?, palette: CarColor
                 SummaryItem(
                     icon = Icons.Default.Timer,
                     label = stringResource(R.string.total_time),
-                    value = formatDuration(summary.totalDurationMin),
+                    value = formatDuration(summary.totalDurationMin, java.util.Locale.getDefault()),
                     palette = palette,
                     modifier = Modifier.weight(1.2f)
                 )
@@ -510,19 +513,21 @@ private fun DriveItem(
     palette: CarColorPalette,
     onClick: () -> Unit
 ) {
+    val context = LocalContext.current
     val unknown = stringResource(R.string.unknown)
     val startCity = drive.startAddress ?: unknown
     val endCity = drive.endAddress ?: unknown
 
+    val is24Hour = android.text.format.DateFormat.is24HourFormat(context)
     EditorialListItem(
         accent = palette.accent,
-        dateline = formatEditorialDate(drive.startDate),
+        dateline = formatEditorialDate(drive.startDate, is24Hour),
         title = "$startCity → $endCity",
         heroValue = "%.0f".format(UnitFormatter.formatDistanceValue(drive.distance ?: 0.0, units)),
         heroUnit = UnitFormatter.getDistanceUnit(units).uppercase(java.util.Locale.getDefault()),
         onClick = onClick,
     ) {
-        EditorialPill(formatDuration(drive.durationMin ?: 0))
+        EditorialPill(formatDuration(drive.durationMin ?: 0, java.util.Locale.getDefault()))
         EditorialPill("${drive.speedMax ?: 0} ${UnitFormatter.getSpeedUnit(units)}")
         val start = drive.startBatteryLevel
         val end = drive.endBatteryLevel
@@ -534,26 +539,6 @@ private fun DriveItem(
                 fontWeight = FontWeight.Bold
             )
         }
-    }
-}
-
-/**
- * Cascading-unit duration: <1h shows minutes, ≥1h shows "Xh Ym" (or just "Xh" if no
- * remaining minutes), ≥1d shows "Xd Yh". Mirrors the trips list so durations across the
- * three lists are formatted consistently.
- */
-private fun formatDuration(minutes: Int): String {
-    val total = minutes.coerceAtLeast(0)
-    val hours = total / 60
-    val mins = total % 60
-    return when {
-        hours >= 24 -> {
-            val days = hours / 24
-            val remH = hours - days * 24
-            if (remH > 0) "${days}d ${remH}h" else "${days}d"
-        }
-        hours >= 1 -> if (mins > 0) "${hours}h ${mins}m" else "${hours}h"
-        else -> "${total}m"
     }
 }
 
@@ -694,7 +679,7 @@ private fun DrivesChartPage(
                 BarChartData(
                     label = data.label,
                     value = data.totalDurationMin.toDouble(),
-                    displayValue = formatDurationChart(data.totalDurationMin)
+                    displayValue = formatDurationCompact(data.totalDurationMin)
                 )
             }
             DrivesChartType.DISTANCE -> chartData.map { data ->
@@ -717,7 +702,7 @@ private fun DrivesChartPage(
 
         val valueFormatter: (Double) -> String = when (chartType) {
             DrivesChartType.COUNT -> { v -> v.toInt().toString() }
-            DrivesChartType.TIME -> { v -> formatDurationChart(v.toInt()) }
+            DrivesChartType.TIME -> { v -> formatDurationCompact(v.toInt()) }
             DrivesChartType.DISTANCE -> { v -> "%.1f $distanceUnit".format(v) }
             DrivesChartType.TOP_SPEED -> { v -> "${v.toInt()} $speedUnit" }
         }
@@ -729,7 +714,7 @@ private fun DrivesChartPage(
             else -> ((barData.size + 5) / 6).coerceAtLeast(1)
         }
         val yAxisFormatter: (Double) -> String = when (chartType) {
-            DrivesChartType.TIME -> { v -> formatDurationChart(v.toInt()) }
+            DrivesChartType.TIME -> { v -> formatDurationCompact(v.toInt()) }
             else -> { v -> if (v >= 1000) "%.0fk".format(v / 1000) else "%.0f".format(v) }
         }
 
@@ -743,10 +728,4 @@ private fun DrivesChartPage(
             yAxisFormatter = yAxisFormatter
         )
     }
-}
-
-private fun formatDurationChart(minutes: Int): String {
-    val hours = minutes / 60
-    val mins = minutes % 60
-    return "%d:%02d".format(hours, mins)
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -20,10 +20,13 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
+import com.matedroid.util.formatMonthYear
+import com.matedroid.util.formatShortNoYear
+import com.matedroid.util.formatWeekLabel
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
-import java.util.Locale
 import javax.inject.Inject
 
 enum class DriveChartGranularity {
@@ -377,7 +380,7 @@ class DrivesViewModel @Inject constructor(
                     val drivesInDay = drivesByDay[key] ?: emptyList()
                     result.add(
                         createChartPoint(
-                            label = current.format(DateTimeFormatter.ofPattern("d/M")),
+                            label = current.formatShortNoYear(Locale.getDefault()),
                             sortKey = key,
                             drives = drivesInDay
                         )
@@ -419,7 +422,7 @@ class DrivesViewModel @Inject constructor(
                     val weekOfYear = currentWeek.get(weekFields.weekOfYear())
                     result.add(
                         createChartPoint(
-                            label = "W$weekOfYear",
+                            label = formatWeekLabel(weekOfYear, Locale.getDefault()),
                             sortKey = key,
                             drives = drivesInWeek
                         )
@@ -458,7 +461,7 @@ class DrivesViewModel @Inject constructor(
                     val drivesInMonth = drivesByMonth[key] ?: emptyList()
                     result.add(
                         createChartPoint(
-                            label = firstDay.format(DateTimeFormatter.ofPattern("MMM yy")),
+                            label = firstDay.formatMonthYear(Locale.getDefault()),
                             sortKey = key,
                             drives = drivesInMonth
                         )

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -35,7 +35,9 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import java.time.format.DateTimeFormatter
+import com.matedroid.util.formatMedium
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -913,8 +915,7 @@ private fun SummaryRow(
 
     // Info dialog explaining the avg/year calculation
     if (showAvgInfoDialog && firstDriveDate != null) {
-        val dateFormatter = DateTimeFormatter.ofPattern("d MMM yyyy", Locale.getDefault())
-        val formattedDate = firstDriveDate.format(dateFormatter)
+        val formattedDate = firstDriveDate.formatMedium(Locale.getDefault())
         val daysSinceFirst = ChronoUnit.DAYS.between(firstDriveDate, LocalDate.now()).toInt()
         val dialogMessage = stringResource(R.string.mileage_avg_year_message, formattedDate, daysSinceFirst)
 
@@ -1674,15 +1675,6 @@ private fun DriveRow(
 }
 
 private fun parseTime(dateStr: String): String {
-    return try {
-        val dateTime = OffsetDateTime.parse(dateStr)
-        "%02d:%02d".format(dateTime.hour, dateTime.minute)
-    } catch (e: Exception) {
-        try {
-            val dateTime = LocalDateTime.parse(dateStr.replace("Z", ""))
-            "%02d:%02d".format(dateTime.hour, dateTime.minute)
-        } catch (e2: Exception) {
-            ""
-        }
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return ""
+    return dt.formatTime(java.util.Locale.getDefault())
 }

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -382,18 +383,8 @@ class MileageViewModel @Inject constructor(
 // caller passes in the snapshot of pre-parsed data they want aggregated.
 // ---------------------------------------------------------------------------
 
-private fun parseDateTime(dateStr: String?): LocalDateTime? {
-    if (dateStr == null) return null
-    return try {
-        OffsetDateTime.parse(dateStr).toLocalDateTime()
-    } catch (_: DateTimeParseException) {
-        try {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        } catch (_: Exception) {
-            null
-        }
-    }
-}
+private fun parseDateTime(dateStr: String?): LocalDateTime? =
+    parseIsoDateTime(dateStr)
 
 private fun computeYearAggregation(
     drives: List<TimedDrive>,

--- a/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
@@ -68,6 +68,7 @@ import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import com.matedroid.util.formatMediumNoYear
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -331,7 +332,11 @@ private fun SentryHeatmap(
             val dayLabel = when (rowDate) {
                 today -> stringResource(R.string.sentry_history_today)
                 today.minusDays(1) -> stringResource(R.string.sentry_history_yesterday)
-                else -> rowDate.format(DateTimeFormatter.ofPattern("EEE d"))
+                else -> {
+            val locale = java.util.Locale.getDefault()
+            val dow = rowDate.dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, locale)
+            "$dow ${rowDate.formatMediumNoYear(locale)}"
+        }
             }
 
             Row(
@@ -519,7 +524,7 @@ private fun AlertRow(
     val time = Instant.ofEpochMilli(alert.detectedAt)
         .atZone(ZoneId.systemDefault())
         .toLocalTime()
-    val timeStr = time.format(DateTimeFormatter.ofPattern("HH:mm"))
+    val timeStr = time.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
 
     val displayText = alert.address?.ifBlank { null }
         ?: stringResource(R.string.sentry_alert_detected)

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -83,7 +83,8 @@ import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Polygon
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import com.matedroid.util.formatMedium
+import com.matedroid.util.parseIsoDateTime
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1086,19 +1087,8 @@ private fun EmptyState(palette: CarColorPalette) {
 }
 
 private fun formatDate(dateStr: String): String {
-    return try {
-        val inputFormatter = DateTimeFormatter.ISO_DATE_TIME
-        val outputFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
-        val dateTime = LocalDateTime.parse(dateStr, inputFormatter)
-        dateTime.format(outputFormatter)
-    } catch (e: Exception) {
-        // Fallback: try parsing just the date portion
-        try {
-            dateStr.take(10)
-        } catch (e2: Exception) {
-            dateStr
-        }
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr.take(10)
+    return dt.toLocalDate().formatMedium(Locale.getDefault())
 }
 
 /**

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -52,9 +52,10 @@ import com.matedroid.domain.LegRef
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -343,16 +344,9 @@ private fun ChargeTypeChip(isDc: Boolean, chipColor: Color) {
 }
 
 private fun formatCandidateDate(dateStr: String): String {
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        dt.format(DateTimeFormatter.ofPattern("d MMM HH:mm"))
-    } catch (e: Exception) {
-        dateStr
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    val locale = Locale.getDefault()
+    return "${dt.toLocalDate().formatMediumNoYear(locale)} ${dt.formatTime(locale)}"
 }
 
 private fun formatMinutes(minutes: Int): String {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -36,9 +36,9 @@ import com.matedroid.R
 import com.matedroid.domain.model.Trip
 import com.matedroid.ui.theme.CarColorPalette
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.parseIsoDateTime
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -154,14 +154,6 @@ private fun formatRange(startIso: String, endIso: String): String {
 }
 
 private fun parseShort(iso: String): String? {
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(iso).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            LocalDateTime.parse(iso.replace("Z", ""))
-        }
-        dt.format(DateTimeFormatter.ofPattern("d MMM"))
-    } catch (e: Exception) {
-        null
-    }
+    val dt = parseIsoDateTime(iso) ?: return null
+    return dt.toLocalDate().formatMediumNoYear(Locale.getDefault())
 }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -97,6 +97,9 @@ import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.ui.theme.StatusError
 import com.matedroid.ui.theme.StatusSuccess
+import com.matedroid.util.formatDuration
+import com.matedroid.util.formatMedium
+import com.matedroid.util.formatMediumNoYear
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
@@ -1406,7 +1409,7 @@ private fun DriveLegCard(
                     fontWeight = FontWeight.Bold
                 )
                 Text(
-                    text = formatDuration(leg.drive.durationMin),
+                    text = formatDuration(leg.drive.durationMin, java.util.Locale.getDefault()),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1478,7 +1481,7 @@ private fun ChargeLegCard(
                     color = chipColor
                 )
                 Text(
-                    text = formatDuration(leg.charge.durationMin),
+                    text = formatDuration(leg.charge.durationMin, java.util.Locale.getDefault()),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1495,34 +1498,20 @@ private fun ChargeLegCard(
 
 // === Formatting ===
 
-private fun formatDuration(minutes: Int): String {
-    val h = minutes / 60
-    val m = minutes % 60
-    return if (h > 0) "${h}h ${m}m" else "${m}m"
-}
-
 private fun formatTripDateRange(startDate: String, endDate: String): String {
     val start = parseTripDate(startDate) ?: return startDate
     val end = parseTripDate(endDate) ?: return endDate
-    val dayMonth = java.time.format.DateTimeFormatter.ofPattern("d MMM")
-    val dayMonthYear = java.time.format.DateTimeFormatter.ofPattern("d MMM yyyy")
+    val locale = java.util.Locale.getDefault()
     val sameDay = start.toLocalDate() == end.toLocalDate()
     val sameMonth = start.year == end.year && start.month == end.month
     val sameYear = start.year == end.year
     return when {
-        sameDay -> start.format(if (sameYear) dayMonth else dayMonthYear)
-        sameMonth -> "${start.dayOfMonth} – ${end.format(dayMonth)}"
-        sameYear -> "${start.format(dayMonth)} – ${end.format(dayMonth)}"
-        else -> "${start.format(dayMonthYear)} – ${end.format(dayMonthYear)}"
+        sameDay -> start.toLocalDate().formatMediumNoYear(locale)
+        sameMonth -> "${start.dayOfMonth} – ${end.toLocalDate().formatMediumNoYear(locale)}"
+        sameYear -> "${start.toLocalDate().formatMediumNoYear(locale)} – ${end.toLocalDate().formatMediumNoYear(locale)}"
+        else -> "${start.toLocalDate().formatMedium(locale)} – ${end.toLocalDate().formatMedium(locale)}"
     }
 }
 
-private fun parseTripDate(value: String): java.time.LocalDateTime? = try {
-    java.time.OffsetDateTime.parse(value).toLocalDateTime()
-} catch (_: java.time.format.DateTimeParseException) {
-    try {
-        java.time.LocalDateTime.parse(value.replace("Z", ""))
-    } catch (_: java.time.format.DateTimeParseException) {
-        null
-    }
-}
+private fun parseTripDate(value: String): java.time.LocalDateTime? =
+    com.matedroid.util.parseIsoDateTime(value)

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
@@ -4,9 +4,8 @@ import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.domain.model.Trip
 import com.matedroid.ui.components.TripTimelineSegment
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 
 private const val MIN_PARKING_GAP_MIN = 5L
@@ -73,14 +72,5 @@ fun buildTimelineSegments(
     return segments
 }
 
-private fun parseTimelineDate(dateStr: String): LocalDateTime? {
-    return try {
-        OffsetDateTime.parse(dateStr).toLocalDateTime()
-    } catch (e: DateTimeParseException) {
-        try {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        } catch (e2: Exception) {
-            null
-        }
-    }
-}
+private fun parseTimelineDate(dateStr: String): LocalDateTime? =
+    parseIsoDateTime(dateStr)

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -68,11 +68,11 @@ import com.matedroid.ui.components.formatShortDate
 import com.matedroid.ui.components.parseListItemDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
+import com.matedroid.util.formatDuration
+import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -326,7 +326,7 @@ private fun SummaryCard(
                 SummaryItem(
                     icon = Icons.Filled.Schedule,
                     label = stringResource(R.string.trip_driving_time),
-                    value = formatDuration(totalDrivingMin),
+                    value = formatDuration(totalDrivingMin, java.util.Locale.getDefault()),
                     palette = palette,
                     modifier = Modifier.weight(1.2f)
                 )
@@ -443,7 +443,7 @@ private fun TripItem(
             // Meta row: duration · stops · kWh
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = formatDuration(trip.totalDurationMin),
+                    text = formatDuration(trip.totalDurationMin, java.util.Locale.getDefault()),
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface
@@ -480,16 +480,8 @@ private fun pluralStopsLabel(count: Int): String =
     else stringResource(R.string.trip_n_stops, count)
 
 private fun formatDateChip(dateStr: String): String {
-    return try {
-        val dt = try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (_: DateTimeParseException) {
-            LocalDateTime.parse(dateStr.replace("Z", ""))
-        }
-        dt.format(DateTimeFormatter.ofPattern("d MMM yy")).uppercase()
-    } catch (_: Exception) {
-        dateStr
-    }
+    val dt = parseIsoDateTime(dateStr) ?: return dateStr
+    return dt.toLocalDate().formatMediumNoYear(Locale.getDefault()).uppercase(Locale.getDefault())
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -588,36 +580,4 @@ internal fun Trip.displayName(): String {
  *  1w–~1mo → "Xw Yd"
  *  ≥30d → "Xmo Yw"
  */
-private fun formatDuration(minutes: Int): String {
-    val totalMinutes = minutes.coerceAtLeast(0)
-    val totalHours = totalMinutes / 60.0
-    val totalDays = totalHours / 24.0
-
-    return when {
-        totalDays >= 30 -> {
-            val weeks = (totalDays / 7.0).toInt().coerceAtLeast(1)
-            val months = weeks / 4
-            val remWeeks = weeks - months * 4
-            if (remWeeks > 0) "${months}mo ${remWeeks}w" else "${months}mo"
-        }
-        totalDays >= 7 -> {
-            val days = Math.round(totalDays).toInt()
-            val weeks = days / 7
-            val remDays = days - weeks * 7
-            if (remDays > 0) "${weeks}w ${remDays}d" else "${weeks}w"
-        }
-        totalHours >= 24 -> {
-            val hours = Math.round(totalHours).toInt()
-            val days = hours / 24
-            val remHours = hours - days * 24
-            if (remHours > 0) "${days}d ${remHours}h" else "${days}d"
-        }
-        totalHours >= 1 -> {
-            val h = totalMinutes / 60
-            val m = totalMinutes % 60
-            if (m > 0) "${h}h ${m}m" else "${h}h"
-        }
-        else -> "${totalMinutes}m"
-    }
-}
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.matedroid.util.parseIsoDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -154,15 +155,6 @@ class TripsViewModel @Inject constructor(
         return parseLocalDate(dateStr)?.year
     }
 
-    private fun parseLocalDate(dateStr: String): LocalDate? {
-        return try {
-            OffsetDateTime.parse(dateStr).toLocalDate()
-        } catch (e: DateTimeParseException) {
-            try {
-                LocalDateTime.parse(dateStr.replace("Z", "")).toLocalDate()
-            } catch (e2: Exception) {
-                null
-            }
-        }
-    }
+    private fun parseLocalDate(dateStr: String): LocalDate? =
+        parseIsoDate(dateStr)
 }

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -59,7 +59,10 @@ import com.matedroid.ui.components.InteractiveBarChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
+import com.matedroid.util.formatDurationCompact
+import com.matedroid.util.formatMedium
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.math.roundToInt
 
 enum class UpdatesDateFilter(val months: Int?) {
@@ -376,7 +379,7 @@ private fun MonthlyUpdatesChart(
 
             val chartData = monthlyData.map { data ->
                 BarChartData(
-                    label = data.yearMonth.format(DateTimeFormatter.ofPattern("MMM")),
+                    label = data.yearMonth.format(DateTimeFormatter.ofPattern("MMM", Locale.getDefault())),
                     value = data.count.toDouble(),
                     displayValue = updatesFormat.format(data.count)
                 )
@@ -423,7 +426,7 @@ private fun SoftwareVersionCard(
     isLongestInstalled: Boolean,
     palette: CarColorPalette
 ) {
-    val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
+    val locale = java.util.Locale.getDefault()
     val uriHandler = LocalUriHandler.current
     val releaseNotesUrl = "https://www.notateslaapp.com/software-updates/version/${update.version}/release-notes"
     val unknownLabel = stringResource(R.string.unknown)
@@ -532,7 +535,7 @@ private fun SoftwareVersionCard(
                         color = if (update.isCurrent) palette.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Text(
-                        text = update.installDate?.format(dateFormatter) ?: unknownLabel,
+                        text = update.installDate?.toLocalDate()?.formatMedium(locale) ?: unknownLabel,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = if (update.isCurrent) palette.onSurface else MaterialTheme.colorScheme.onSurface
@@ -580,7 +583,7 @@ private fun SoftwareVersionCard(
                         )
                     }
                     Text(
-                        text = formatDurationHhMm(update.updateDurationMinutes),
+                        text = formatDurationCompact(update.updateDurationMinutes?.toInt() ?: 0),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = if (update.isCurrent) palette.onSurface else MaterialTheme.colorScheme.onSurface
@@ -594,11 +597,4 @@ private fun SoftwareVersionCard(
 private fun formatDaysInstalled(days: Long?): String {
     if (days == null || days < 0) return "--"
     return "$days"
-}
-
-private fun formatDurationHhMm(minutes: Long?): String {
-    if (minutes == null || minutes < 0) return "--"
-    val hours = minutes / 60
-    val mins = minutes % 60
-    return "%d:%02d".format(hours, mins)
 }

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
@@ -21,7 +21,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import com.matedroid.util.formatTime
+import com.matedroid.util.parseIsoDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.time.format.DateTimeParseException
 import javax.inject.Inject
 
@@ -80,8 +83,10 @@ class WhereWasIViewModel @Inject constructor(
                     return@launch
                 }
 
-                val displayFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm")
-                _uiState.value = _uiState.value.copy(targetDateTime = targetTime.format(displayFormatter))
+                val locale = java.util.Locale.getDefault()
+                val displayDateStr = targetTime.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale))
+                val timeStr = targetTime.formatTime(locale)
+                _uiState.value = _uiState.value.copy(targetDateTime = "$displayDateStr, $timeStr")
 
                 val dateStr = targetTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
                 val dayStart = "${dateStr}T00:00:00Z"
@@ -231,7 +236,9 @@ class WhereWasIViewModel @Inject constructor(
         }
 
         val parkedMinutes = java.time.Duration.between(result.endTime, targetTime).toMinutes()
-        val sinceFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm")
+        val locale = java.util.Locale.getDefault()
+        val sinceDateStr = result.endTime.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale))
+        val sinceTimeStr = result.endTime.formatTime(locale)
 
         _uiState.value = WhereWasIUiState(
             isLoading = false,
@@ -242,7 +249,7 @@ class WhereWasIViewModel @Inject constructor(
             outsideTemp = result.temp,
             units = units,
             parkedDurationMinutes = parkedMinutes,
-            parkedSince = result.endTime.format(sinceFormatter),
+            parkedSince = "$sinceDateStr, $sinceTimeStr",
             lastActivityDriveId = result.driveId,
             lastActivityChargeId = result.chargeId,
             targetDateTime = _uiState.value.targetDateTime,
@@ -447,18 +454,8 @@ class WhereWasIViewModel @Inject constructor(
         }
     }
 
-    private fun parseDateTime(dateStr: String): LocalDateTime? {
-        if (dateStr.isBlank()) return null
-        return try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
-        } catch (e: DateTimeParseException) {
-            try {
-                LocalDateTime.parse(dateStr.replace("Z", ""))
-            } catch (e2: Exception) {
-                null
-            }
-        }
-    }
+    private fun parseDateTime(dateStr: String): LocalDateTime? =
+        parseIsoDateTime(dateStr)
 
     private fun parseEndLatFromAddress(drive: DriveData): Double? = null
     private fun parseEndLonFromAddress(drive: DriveData): Double? = null

--- a/app/src/main/java/com/matedroid/util/DateTimeParse.kt
+++ b/app/src/main/java/com/matedroid/util/DateTimeParse.kt
@@ -1,0 +1,268 @@
+package com.matedroid.util
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
+import java.util.Locale
+
+/**
+ * Parse an ISO-8601 datetime string into a [LocalDateTime].
+ *
+ * Accepts datetime strings with or without a timezone offset, and with or
+ * without a trailing "Z" suffix. TeslaMate emits both forms (RFC 3339
+ * with offset, or ISO with a trailing Z).
+ *
+ * Examples:
+ *   "2026-05-10T15:39:00Z"      → 2026-05-10T15:39
+ *   "2026-05-10T15:39:00+02:00" → 2026-05-10T15:39
+ *   "" or null                   → null
+ */
+fun parseIsoDateTime(dateStr: String?): LocalDateTime? {
+    if (dateStr.isNullOrBlank()) return null
+    return try {
+        try {
+            OffsetDateTime.parse(dateStr).toLocalDateTime()
+        } catch (_: DateTimeParseException) {
+            LocalDateTime.parse(dateStr.replace("Z", ""))
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Parse an ISO-8601 datetime string to a [LocalDate], discarding the time
+ * component.
+ *
+ * Examples:
+ *   "2026-05-10T15:39:00Z" → 2026-05-10
+ *   "" or null              → null
+ */
+fun parseIsoDate(dateStr: String?): LocalDate? =
+    parseIsoDateTime(dateStr)?.toLocalDate()
+
+/**
+ * Format a [LocalDate] as locale-aware short date without the year.
+ *
+ * Formats with the locale's [FormatStyle.SHORT] numeric pattern, then
+ * removes the year segment (2–4 digits) and its adjacent separator.
+ *
+ * Examples for 2026-05-10:
+ *   en-US: "5/10/26"   → "5/10"
+ *   zh-CN: "2026/5/10" → "5/10"
+ *   it-IT: "10/5/26"   → "10/5"
+ *   es-ES: "10/5/26"   → "10/5"
+ *   ca-ES: "10/5/26"   → "10/5"
+ */
+fun LocalDate.formatShortNoYear(locale: Locale = Locale.getDefault()): String {
+    val full = this.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(locale))
+    val sep = full.firstOrNull { !it.isDigit() } ?: return full
+    val parts = full.split(sep)
+    val year4 = this.year.toString()
+    val year2 = (this.year % 100).toString()
+    // Year is always at the first or last position in SHORT numeric formats; remove it.
+    val rest = when {
+        parts.firstOrNull() == year4 || parts.firstOrNull() == year2 -> parts.drop(1)
+        parts.lastOrNull() == year4 || parts.lastOrNull() == year2 -> parts.dropLast(1)
+        else -> return full
+    }
+    return rest.joinToString(sep.toString())
+}
+
+/**
+ * Format a [LocalDateTime] as locale-aware short time.
+ *
+ * When [is24Hour] is `null` (default), uses the locale's built-in
+ * 12h/24h convention. Pass explicit `true`/`false` to override the locale
+ * default — useful for respecting Android's system-level 12/24 hour
+ * setting via [android.text.format.DateFormat.is24HourFormat].
+ *
+ * Examples for 15:39:
+ *   en-US: "3:39 PM"
+ *   zh-CN: "15:39"
+ *   it-IT: "15:39"
+ *   es-ES: "15:39"
+ *   ca-ES: "15:39"
+ */
+fun LocalDateTime.formatTime(
+    locale: Locale = Locale.getDefault(),
+    is24Hour: Boolean? = null
+): String {
+    val fmt = when (is24Hour) {
+        null -> DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
+        true -> DateTimeFormatter.ofPattern("HH:mm", locale)
+        false -> DateTimeFormatter.ofPattern("hh:mm a", locale)
+    }
+    return this.format(fmt)
+}
+
+/**
+ * Format a [LocalDate] as locale-aware medium date.
+ *
+ * Uses the locale's [FormatStyle.MEDIUM] format.
+ *
+ * Examples for 2026-05-10:
+ *   en-US: "May 10, 2026"
+ *   zh-CN: "2026年5月10日"
+ *   it-IT: "10 mag 2026"
+ *   es-ES: "10 may 2026"
+ *   ca-ES: "10 de maig de 2026"
+ */
+fun LocalDate.formatMedium(locale: Locale = Locale.getDefault()): String =
+    this.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale))
+
+/**
+ * Format a [LocalDate] as medium date without the year.
+ *
+ * Formats with [formatMedium], then strips the year digits and
+ * any adjacent year-specific text (prefix or suffix).
+ *
+ * Examples for 2026-05-10:
+ *   en-US: "May 10, 2026"          → "May 10"
+ *   zh-CN: "2026年5月10日"          → "5月10日"
+ *   it-IT: "10 mag 2026"           → "10 mag"
+ *   es-ES: "10 may 2026"           → "10 may"
+ *   ca-ES: "10 de maig de 2026"    → "10 de maig"
+ */
+fun LocalDate.formatMediumNoYear(locale: Locale = Locale.getDefault()): String {
+    val full = formatMedium(locale)
+    // Strip year prefix (e.g. "2026年") and suffix (e.g. ", 2026", " de 2026")
+    return full
+        .replace(Regex("""^\d{4}\p{L}*\s*"""), "")
+        .replace(Regex("""\s*,?\s*\d{4}\s*\p{L}*\s*$"""), "")
+        .trim()
+}
+
+/**
+ * Format a [LocalDateTime] as locale-aware editorial dateline.
+ *
+ * Produces a "DOW · date · time" string uppercased for the locale.
+ * Time respects 12h/24h via [formatTime]; pass [is24Hour] to override the
+ * locale default with the Android system setting.
+ *
+ * Examples for 2026-05-10T15:39 (Sunday):
+ *   en-US: "SUN · MAY 10 · 3:39 PM"
+ *   zh-CN: "周日 · 5月10日 · 15:39"
+ *   it-IT: "DOM · 10 MAG · 15:39"
+ *   es-ES: "DOM · 10 MAY · 15:39"
+ *   ca-ES: "DG · 10 DE MAIG · 15:39"
+ */
+fun LocalDateTime.formatEditorial(
+    locale: Locale = Locale.getDefault(),
+    is24Hour: Boolean? = null
+): String {
+    val dow = this.dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, locale)
+    val date = this.toLocalDate().formatMediumNoYear(locale)
+    val time = this.formatTime(locale, is24Hour)
+    return "$dow · $date · $time".uppercase(locale)
+}
+
+/**
+ * Format a [LocalDate] as a compact chart label.
+ *
+ * Uses "MMM yy" for most locales. For Chinese (zh), uses "M月 d日"
+ * (month+day) since an abbreviated year number is ambiguous in Chinese
+ * without the year-context prefix.
+ *
+ * Examples for 2026-05-10:
+ *   en-US: "May 26"
+ *   zh-CN: "5月 10日"
+ *   it-IT: "mag 26"
+ *   es-ES: "may 26"
+ *   ca-ES: "maig 26"
+ */
+fun LocalDate.formatMonthYear(locale: Locale = Locale.getDefault()): String =
+    if (locale.language == "zh")
+        this.format(DateTimeFormatter.ofPattern("M月 d日", locale))
+    else
+        this.format(DateTimeFormatter.ofPattern("MMM yy", locale))
+
+/**
+ * Format a week-of-year number as a locale-aware chart label.
+ *
+ * Examples for week 23:
+ *   en-US: "W23"
+ *   zh-CN: "第23周"
+ *   it-IT: "W23"
+ *   es-ES: "W23"
+ *   ca-ES: "W23"
+ */
+fun formatWeekLabel(weekOfYear: Int, locale: Locale = Locale.getDefault()): String =
+    when (locale.language) {
+        "zh" -> "第${weekOfYear}周"
+        else -> "W$weekOfYear"
+    }
+
+/**
+ * Format an integer minute count as a human-readable, locale-aware duration.
+ *
+ * Scale adapts to the magnitude: minutes → hours+min → days+hours →
+ * weeks+days → months+weeks.
+ *
+ * Examples for 648 min (10h 48m = 0d 10h 48m):
+ *   en-US: "10h 48m"
+ *   zh-CN: "10小时48分钟"
+ *   it-IT: "10o 48min"
+ *   es-ES: "10h 48min"
+ *   ca-ES: "10h 48min"
+ *
+ * Examples for 1560 min (26h = 1d 2h):
+ *   en-US: "1d 2h"
+ *   zh-CN: "1天2小时"
+ *   it-IT: "1g 2o"
+ *   es-ES: "1d 2h"
+ *   ca-ES: "1d 2h"
+ */
+fun formatDuration(minutes: Int, locale: Locale = Locale.getDefault()): String {
+    val total = minutes.coerceAtLeast(0)
+    val hours = total / 60
+    val mins = total % 60
+    val days = hours / 24
+    val remHours = hours - days * 24
+    val weeks = days / 7
+    val remDays = days - weeks * 7
+    val months = weeks / 4
+    val remWeeks = weeks - months * 4
+
+    return when (locale.language) {
+        "zh" -> when {
+            months >= 1 -> if (remWeeks > 0) "${months}个月${remWeeks}周" else "${months}个月"
+            weeks >= 1 -> if (remDays > 0) "${weeks}周${remDays}天" else "${weeks}周"
+            days >= 1 -> if (remHours > 0) "${days}天${remHours}小时" else "${days}天"
+            hours >= 1 -> if (mins > 0) "${hours}小时${mins}分钟" else "${hours}小时"
+            else -> "${total}分钟"
+        }
+        "it" -> when {
+            months >= 1 -> if (remWeeks > 0) "${months}mesi ${remWeeks}sett" else "${months}mesi"
+            weeks >= 1 -> if (remDays > 0) "${weeks}sett ${remDays}g" else "${weeks}sett"
+            days >= 1 -> if (remHours > 0) "${days}g ${remHours}o" else "${days}g"
+            hours >= 1 -> if (mins > 0) "${hours}o ${mins}min" else "${hours}o"
+            else -> "${total}min"
+        }
+        else -> when {
+            months >= 1 -> if (remWeeks > 0) "${months}mo ${remWeeks}w" else "${months}mo"
+            weeks >= 1 -> if (remDays > 0) "${weeks}w ${remDays}d" else "${weeks}w"
+            days >= 1 -> if (remHours > 0) "${days}d ${remHours}h" else "${days}d"
+            hours >= 1 -> if (mins > 0) "${hours}h ${mins}m" else "${hours}h"
+            else -> "${total}m"
+        }
+    }
+}
+
+/**
+ * Format an integer minute count as a compact "H:MM" string.
+ *
+ * Universally understood across locales; suited for chart tooltips and
+ * detail-stat cards where space is limited.
+ *
+ * Examples for 648 min:
+ *   All locales: "10:48"
+ */
+fun formatDurationCompact(minutes: Int): String {
+    val h = (minutes.coerceAtLeast(0)) / 60
+    val m = minutes % 60
+    return "%d:%02d".format(h, m)
+}


### PR DESCRIPTION
  Summary

  All date, time, and duration formatting is now consolidated in a single utility file (DateTimeParse.kt) and respects
  the system locale. This fixes inconsistent display in non-English locales — for example, durations now show as
  "10小时48分钟" instead of "10h 48m" in zh-CN.

  Changes

  - 12h/24h support — formatTime, formatEditorial, and all detail-screen chart labels now respect Android's system
  12h/24h setting
  - Chinese localization — monthly labels use month+day, week labels use "第X周", durations use Chinese units
  - Italian localization — durations use Italian abbreviations (o/min, g/sett, mesi)
  - Deduplication — removed 9 duplicate ISO datetime parsers and 7 duplicate formatDuration functions
  - Legacy cleanup — migrated SyncLogCollector from SimpleDateFormat to java.time.DateTimeFormatter

  Test plan

  - Set device to zh-CN: verify charge/drive history dates, chart labels, durations
  - Set device to en-US: verify no regression in existing formatting
  - Toggle 12h/24h in system settings: verify time display updates
  - ./gradlew lintDebug passes

Fixes #279