### PR TITLE
refactor: extract LocalDayBoundaries helper for local-day RFC3339 windows

### DIFF
--- a/app/src/main/java/com/matedroid/domain/LocalDayBoundaries.kt
+++ b/app/src/main/java/com/matedroid/domain/LocalDayBoundaries.kt
@@ -1,0 +1,30 @@
+package com.matedroid.domain
+
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Builds RFC3339 timestamps for the start and end of a *local* calendar day.
+ *
+ * The TeslaMate API expects RFC3339 (`2006-01-02T15:04:05Z` for UTC, or
+ * `2006-01-02T15:04:05+nn:00` with an explicit offset for local time). Sending a hardcoded
+ * `Z` makes "today" mean the UTC day, which is shifted from the user's local day by their UTC
+ * offset — so date filters pulled in the adjacent day's drives/charges for users far from UTC.
+ *
+ * These helpers attach the device's local offset instead, computed *per boundary* so that days
+ * containing a DST transition use the correct offset at each end.
+ */
+object LocalDayBoundaries {
+
+    /** e.g. `2026-05-30T00:00:00+02:00` — midnight at the start of [date] in [zoneId]. */
+    fun startOfDay(date: LocalDate, zoneId: ZoneId = ZoneId.systemDefault()): String {
+        val offset = zoneId.rules.getOffset(date.atStartOfDay())
+        return "${date}T00:00:00$offset"
+    }
+
+    /** e.g. `2026-05-30T23:59:59+02:00` — the last second of [date] in [zoneId]. */
+    fun endOfDay(date: LocalDate, zoneId: ZoneId = ZoneId.systemDefault()): String {
+        val offset = zoneId.rules.getOffset(date.atTime(23, 59, 59))
+        return "${date}T23:59:59$offset"
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -10,6 +10,7 @@ import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.LocalDayBoundaries
 import com.matedroid.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -314,18 +315,9 @@ class ChargesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format:
-            // 2006-01-02T15:04:05Z for UTC time
-            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
-            val zoneId = java.time.ZoneId.systemDefault()
-            val startDateStr = startDate?.let {
-                val offset = zoneId.rules.getOffset(it.atStartOfDay())
-                "${it}T00:00:00${offset.toString()}"
-            }
-            val endDateStr = endDate?.let {
-                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
-                "${it}T23:59:59${offset.toString()}"
-            }
+            // Local-day RFC3339 boundaries (see LocalDayBoundaries for why not UTC).
+            val startDateStr = startDate?.let { LocalDayBoundaries.startOfDay(it) }
+            val endDateStr = endDate?.let { LocalDayBoundaries.endOfDay(it) }
 
             // Fetch charge IDs from local database aggregates
             val dcChargeIds = try {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -9,6 +9,7 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.LocalDayBoundaries
 import com.matedroid.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -259,18 +260,9 @@ class DrivesViewModel @Inject constructor(
             // Load the display setting
             showShortDrivesCharges = settingsDataStore.showShortDrivesCharges.first()
 
-            // API expects RFC3339 format:
-            // 2006-01-02T15:04:05Z for UTC time
-            // 2006-01-02T15:04:05+nn:00 for local time, with nn the timezone offset
-            val zoneId = java.time.ZoneId.systemDefault()
-            val startDateStr = startDate?.let {
-                val offset = zoneId.rules.getOffset(it.atStartOfDay())
-                "${it}T00:00:00${offset.toString()}"
-            }
-            val endDateStr = endDate?.let {
-                val offset = zoneId.rules.getOffset(it.atTime(23, 59, 59))
-                "${it}T23:59:59${offset.toString()}"
-            }
+            // Local-day RFC3339 boundaries (see LocalDayBoundaries for why not UTC).
+            val startDateStr = startDate?.let { LocalDayBoundaries.startOfDay(it) }
+            val endDateStr = endDate?.let { LocalDayBoundaries.endOfDay(it) }
 
             when (val result = repository.getDrives(id, startDateStr, endDateStr)) {
                 is ApiResult.Success -> {

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
@@ -12,6 +12,7 @@ import com.matedroid.data.repository.GeocodedLocation
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.data.repository.WeatherCondition
+import com.matedroid.domain.LocalDayBoundaries
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -84,8 +85,8 @@ class WhereWasIViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(targetDateTime = targetTime.format(displayFormatter))
 
                 val targetDate = targetTime.toLocalDate()
-                val dayStart = startOfDayRfc3339(targetDate)
-                val dayEnd = endOfDayRfc3339(targetDate)
+                val dayStart = LocalDayBoundaries.startOfDay(targetDate)
+                val dayEnd = LocalDayBoundaries.endOfDay(targetDate)
 
                 // Fetch drives, charges, and units in parallel
                 val drivesDeferred = async { repository.getDrives(carId, dayStart, dayEnd) }
@@ -333,8 +334,8 @@ class WhereWasIViewModel @Inject constructor(
      * The API returns results most-recent-first, so show=1 is a cheap query.
      */
     private suspend fun findLastActivityInHistory(carId: Int, targetTime: LocalDateTime): ActivityEnd? = coroutineScope {
-        val searchEnd = startOfDayRfc3339(targetTime.toLocalDate())
-        val searchStart = startOfDayRfc3339(targetTime.toLocalDate().minusYears(1))
+        val searchEnd = LocalDayBoundaries.startOfDay(targetTime.toLocalDate())
+        val searchStart = LocalDayBoundaries.startOfDay(targetTime.toLocalDate().minusYears(1))
 
         val drivesDeferred = async {
             repository.getDrives(carId, searchStart, searchEnd, page = 1, show = 1)
@@ -464,21 +465,6 @@ class WhereWasIViewModel @Inject constructor(
 
     private fun parseEndLatFromAddress(drive: DriveData): Double? = null
     private fun parseEndLonFromAddress(drive: DriveData): Double? = null
-
-    // RFC3339 day boundaries in the device's local timezone. Using an explicit offset
-    // (e.g. +02:00) instead of a hardcoded Z keeps the "this date" window aligned with the
-    // user's local day — without it, the query window is shifted by the UTC offset and pulls
-    // in (or drops) activity from the adjacent local day. Offset is computed per boundary so
-    // DST transition days are handled correctly.
-    private fun startOfDayRfc3339(date: java.time.LocalDate): String {
-        val offset = java.time.ZoneId.systemDefault().rules.getOffset(date.atStartOfDay())
-        return "${date}T00:00:00$offset"
-    }
-
-    private fun endOfDayRfc3339(date: java.time.LocalDate): String {
-        val offset = java.time.ZoneId.systemDefault().rules.getOffset(date.atTime(23, 59, 59))
-        return "${date}T23:59:59$offset"
-    }
 
     companion object {
         private const val TAG = "WhereWasIViewModel"

--- a/app/src/test/java/com/matedroid/domain/LocalDayBoundariesTest.kt
+++ b/app/src/test/java/com/matedroid/domain/LocalDayBoundariesTest.kt
@@ -1,0 +1,41 @@
+package com.matedroid.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+class LocalDayBoundariesTest {
+
+    private val date = LocalDate.of(2026, 5, 30)
+
+    @Test
+    fun `start and end of day carry a positive offset ahead of UTC`() {
+        val madrid = ZoneId.of("Europe/Madrid") // CEST = +02:00 in summer
+        assertEquals("2026-05-30T00:00:00+02:00", LocalDayBoundaries.startOfDay(date, madrid))
+        assertEquals("2026-05-30T23:59:59+02:00", LocalDayBoundaries.endOfDay(date, madrid))
+    }
+
+    @Test
+    fun `start and end of day carry a negative offset behind UTC`() {
+        val toronto = ZoneId.of("America/Toronto") // EDT = -04:00 in summer
+        assertEquals("2026-05-30T00:00:00-04:00", LocalDayBoundaries.startOfDay(date, toronto))
+        assertEquals("2026-05-30T23:59:59-04:00", LocalDayBoundaries.endOfDay(date, toronto))
+    }
+
+    @Test
+    fun `UTC renders as Z`() {
+        val utc = ZoneId.of("UTC")
+        assertEquals("2026-05-30T00:00:00Z", LocalDayBoundaries.startOfDay(date, utc))
+        assertEquals("2026-05-30T23:59:59Z", LocalDayBoundaries.endOfDay(date, utc))
+    }
+
+    @Test
+    fun `spring-forward DST day uses the pre-transition offset at start and post at end`() {
+        // Europe/Madrid sprang forward on 2026-03-29 (02:00 -> 03:00): +01:00 before, +02:00 after.
+        val madrid = ZoneId.of("Europe/Madrid")
+        val dstDay = LocalDate.of(2026, 3, 29)
+        assertEquals("2026-03-29T00:00:00+01:00", LocalDayBoundaries.startOfDay(dstDay, madrid))
+        assertEquals("2026-03-29T23:59:59+02:00", LocalDayBoundaries.endOfDay(dstDay, madrid))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #145. That fix (and its extension to the "Where was I?" screen) replaced hardcoded-`Z` API date boundaries with local-timezone offsets — but the same ~6-line offset computation ended up duplicated across **8 call sites in 3 files**. This extracts it into one place so the next screen that needs a day window can't reintroduce the bug.

**No behavior change** — identical RFC3339 output.

## Changes

- New `com.matedroid.domain.LocalDayBoundaries` with `startOfDay(date, zoneId)` / `endOfDay(date, zoneId)`. `zoneId` defaults to `ZoneId.systemDefault()` and is injectable purely for testing. Offset is computed per boundary, so DST-transition days get the correct offset at each end.
- `DrivesViewModel`, `ChargesViewModel`, `WhereWasIViewModel` now call the helper instead of inlining the logic (the two private helpers added during the #145 extension are removed).
- Unit tests (`LocalDayBoundariesTest`): positive offset (Madrid +02:00), negative offset (Toronto −04:00), UTC rendering as `Z`, and a spring-forward DST day where start is +01:00 and end is +02:00.

## Test plan
- [x] `./gradlew lintDebug testDebugUnitTest assembleDebug` — all green locally
- [x] `LocalDayBoundariesTest` — 4/4 pass
- [x] No remaining `T00:00:00Z` / `T23:59:59Z` day boundaries in `app/src/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)