### PR TITLE
fix: distinguish "drives" from "trips" in es/ca/it/zh translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **"Drives" and "Trips" no longer share the same word** in Spanish, Catalan, Italian, and Chinese, where both were translated identically (e.g. both "Viajes") — making the navigation and stats ambiguous now that Trips exist. Drives now use a distinct term (es "Trayectos", ca "Trajectes", it "Tragitti", zh "行程") while Trips keep the journey word.
+
 ## [1.8.0-beta1] - 2026-05-31
 
 ### Changed

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -132,7 +132,7 @@
     <string name="nav_charges">Càrregues</string>
 
     <!-- Navigation button to drives list -->
-    <string name="nav_drives">Viatges</string>
+    <string name="nav_drives">Trajectes</string>
 
     <!-- Navigation button to mileage/odometer screen -->
     <string name="nav_mileage">Quilometratge</string>
@@ -207,22 +207,22 @@
     <string name="settings_extra">Configuració extra</string>
 
     <!-- Show short drives/charges toggle -->
-    <string name="settings_show_short_label">Mostra viatges / càrregues curts</string>
-    <string name="settings_show_short_hint">Mostra viatges molt curts i càrregues mínimes a les llistes</string>
+    <string name="settings_show_short_label">Mostra trajectes / càrregues curts</string>
+    <string name="settings_show_short_hint">Mostra trajectes molt curts i càrregues mínimes a les llistes</string>
     <string name="more_information">Més informació</string>
 
     <!-- Short drives/charges info dialog -->
-    <string name="settings_short_dialog_title">Viatges i càrregues curts</string>
-    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els següents elements estan ocults de les llistes:\n\n• Viatges de menys d\'1 minut o menys de 0,1 km\n• Càrregues de 0,1 kWh o menys\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
+    <string name="settings_short_dialog_title">Trajectes i càrregues curts</string>
+    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els següents elements estan ocults de les llistes:\n\n• Trajectes de menys d\'1 minut o menys de 0,1 km\n• Càrregues de 0,1 kWh o menys\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Força resincronització completa</string>
     <string name="settings_resyncing">Resincronitzant…</string>
-    <string name="settings_resync_hint">Torna a descarregar tots els detalls de viatges i càrregues. Usa si les estadístiques semblen incorrectes.</string>
+    <string name="settings_resync_hint">Torna a descarregar tots els detalls de trajectes i càrregues. Usa si les estadístiques semblen incorrectes.</string>
     <string name="settings_resync_dialog_title">Forçar resincronització completa?</string>
     <string name="settings_resync_dialog_text_prefix">Això </string>
     <string name="settings_resync_dialog_text_delete">ELIMINARÀ</string>
-    <string name="settings_resync_dialog_text_suffix"> tots els viatges, càrregues i estadístiques emmagatzemats, després tornarà a descarregar-ho tot del servidor.\n\nEl procés pot trigar diversos minuts depenent de la quantitat de dades.</string>
+    <string name="settings_resync_dialog_text_suffix"> tots els trajectes, càrregues i estadístiques emmagatzemats, després tornarà a descarregar-ho tot del servidor.\n\nEl procés pot trigar diversos minuts depenent de la quantitat de dades.</string>
     <string name="settings_resync_confirm">Resincronitza</string>
 
     <!-- Action buttons -->
@@ -242,16 +242,16 @@
 
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drives_title">Viatges</string>
+    <string name="drives_title">Trajectes</string>
 
     <!-- Content description for back button -->
     <string name="back">Enrere</string>
 
     <!-- Section title for drive history list -->
-    <string name="drive_history">Historial de viatges</string>
+    <string name="drive_history">Historial de trajectes</string>
 
     <!-- Empty state when no drives match filters -->
-    <string name="no_drives_found">No s\'han trobat viatges per al període seleccionat</string>
+    <string name="no_drives_found">No s\'han trobat trajectes per al període seleccionat</string>
 
     <!-- Summary card title -->
     <string name="summary">Resum</string>
@@ -301,9 +301,9 @@
     <string name="filter_road_trip_mi">Viatge llarg (&gt; 60 mi)</string>
 
     <!-- Chart titles - drives per period -->
-    <string name="chart_drives_per_day">Viatges per dia</string>
-    <string name="chart_drives_per_week">Viatges per setmana</string>
-    <string name="chart_drives_per_month">Viatges per mes</string>
+    <string name="chart_drives_per_day">Trajectes per dia</string>
+    <string name="chart_drives_per_week">Trajectes per setmana</string>
+    <string name="chart_drives_per_month">Trajectes per mes</string>
 
     <!-- Chart titles - driving time per period -->
     <string name="chart_time_per_day">Temps de conducció per dia</string>
@@ -322,7 +322,7 @@
 
     <!-- ==================== Drive Detail Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drive_details_title">Detalls del viatge</string>
+    <string name="drive_details_title">Detalls del trajecte</string>
 
     <!-- Route card labels -->
     <string name="from">Des de</string>
@@ -529,10 +529,10 @@
     <string name="stats_empty">No hi ha estadístiques disponibles.\nLlisca cap avall per sincronitzar.</string>
 
     <!-- Sync phase: fetching summary data from server -->
-    <string name="sync_phase_summaries">Obtenint viatges i càrregues…</string>
+    <string name="sync_phase_summaries">Obtenint trajectes i càrregues…</string>
 
     <!-- Sync phase: processing individual drive details -->
-    <string name="sync_phase_drives">Processant detalls de viatges…</string>
+    <string name="sync_phase_drives">Processant detalls de trajectes…</string>
 
     <!-- Sync phase: processing individual charge details -->
     <string name="sync_phase_charges">Processant detalls de càrregues…</string>
@@ -553,10 +553,10 @@
     <string name="geocode_progress_status">%1$d de %2$d ubicacions</string>
 
     <!-- Section: Drives Overview - summary statistics about all drives -->
-    <string name="stats_drives_overview">Resum de Viatges</string>
+    <string name="stats_drives_overview">Resum de Trajectes</string>
 
     <!-- Label for total number of drives -->
-    <string name="stats_total_drives">Viatges Totals</string>
+    <string name="stats_total_drives">Trajectes Totals</string>
 
     <!-- Label for number of days with at least one drive -->
     <string name="stats_driving_days">Dies de Conducció</string>
@@ -585,7 +585,7 @@
     <string name="stats_records">Rècords</string>
 
     <!-- Record category: driving-related records -->
-    <string name="stats_category_drives">Viatges</string>
+    <string name="stats_category_drives">Trajectes</string>
 
     <!-- Record category: battery and charging records -->
     <string name="stats_category_battery">Bateria</string>
@@ -597,7 +597,7 @@
     <string name="stats_category_misc">Altres</string>
 
     <!-- Record: longest single drive by distance -->
-    <string name="record_longest_drive">Viatge més llarg</string>
+    <string name="record_longest_drive">Trajecte més llarg</string>
 
     <!-- Record: fastest speed ever recorded -->
     <string name="record_top_speed">Velocitat Màx</string>
@@ -639,10 +639,10 @@
     <string name="record_most_climbing">Major desnivell</string>
 
     <!-- Record: drive with highest outside temperature -->
-    <string name="record_hottest_drive">Viatge més calorós</string>
+    <string name="record_hottest_drive">Trajecte més calorós</string>
 
     <!-- Record: drive with lowest outside temperature -->
-    <string name="record_coldest_drive">Viatge més fred</string>
+    <string name="record_coldest_drive">Trajecte més fred</string>
 
     <!-- Record: charge session with highest outside temperature -->
     <string name="record_hottest_charge">Càrrega més calorosa</string>
@@ -666,7 +666,7 @@
     <string name="format_days">%.1f dies</string>
 
     <!-- Format for number of drives. %d is the count -->
-    <string name="format_drives_count">%d viatges</string>
+    <string name="format_drives_count">%d trajectes</string>
 
     <!-- Section: Temperature extremes recorded while driving and charging -->
     <string name="stats_temperature_extremes">Temperatures Extremes</string>
@@ -711,16 +711,16 @@
     <string name="stats_range_record_title">Autonomia Màxima</string>
 
     <!-- Label for number of drives in range record. %d is the count -->
-    <string name="stats_drives_count">Viatges (%d)</string>
+    <string name="stats_drives_count">Trajectes (%d)</string>
 
     <!-- Empty state when no drives found in range record dialog -->
-    <string name="stats_no_drives_found">No s\'han trobat viatges</string>
+    <string name="stats_no_drives_found">No s\'han trobat trajectes</string>
 
     <!-- Content description for arrow indicating tappable record -->
     <string name="view_details">Veure detalls</string>
 
     <!-- Content description for arrow to view drive details -->
-    <string name="view_drive">Veure viatge</string>
+    <string name="view_drive">Veure trajecte</string>
 
     <!-- ==================== Countries Visited Screen ==================== -->
     <!-- Top bar title for countries visited screen -->
@@ -740,8 +740,8 @@
 
     <!-- Plural for number of drives in a country -->
     <plurals name="drives_count">
-        <item quantity="one">viatge</item>
-        <item quantity="other">viatges</item>
+        <item quantity="one">trajecte</item>
+        <item quantity="other">trajectes</item>
     </plurals>
 
     <!-- Plural for number of charges in a country -->
@@ -757,7 +757,7 @@
     <string name="sort_alphabetically">Alfabèticament</string>
 
     <!-- Sort option: by number of drives -->
-    <string name="sort_by_drive_count">Per viatges</string>
+    <string name="sort_by_drive_count">Per trajectes</string>
 
     <!-- Sort option: sort by total distance -->
     <string name="sort_by_distance">Per distància</string>
@@ -795,13 +795,13 @@
     <!-- Map showing drive start locations in the country -->
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
-        <item quantity="one">%d viatge</item>
-        <item quantity="other">%d viatges</item>
+        <item quantity="one">%d trajecte</item>
+        <item quantity="other">%d trajectes</item>
     </plurals>
 
     <!-- Map mode toggle labels -->
     <string name="map_mode_charges">Càrregues</string>
-    <string name="map_mode_drives">Viatges</string>
+    <string name="map_mode_drives">Trajectes</string>
 
     <!-- Legend label for drive start marker -->
     <string name="drive_start_legend">Inici</string>
@@ -814,10 +814,10 @@
     <string name="mileage_title">Quilometratge</string>
 
     <!-- Empty state when no drive data is available -->
-    <string name="mileage_no_data">No hi ha dades de viatges disponibles</string>
+    <string name="mileage_no_data">No hi ha dades de trajectes disponibles</string>
 
     <!-- Empty state when no drive data for a specific year. %d is the year -->
-    <string name="mileage_no_data_year">No hi ha dades de viatges per al %d</string>
+    <string name="mileage_no_data_year">No hi ha dades de trajectes per al %d</string>
 
     <!-- Chart title: mileage grouped by year -->
     <string name="mileage_by_year">Quilometratge per Any</string>
@@ -835,7 +835,7 @@
     <string name="mileage_recent_trips">Viatges recents</string>
 
     <!-- Section header for drives list in day detail -->
-    <string name="mileage_drives">Viatges</string>
+    <string name="mileage_drives">Trajectes</string>
 
     <!-- Summary label: Total distance -->
     <string name="mileage_total">Total</string>
@@ -847,13 +847,13 @@
     <string name="mileage_avg_month">Mitjana/Mes</string>
 
     <!-- Summary label: number of drives -->
-    <string name="mileage_drive_count">N° de viatges</string>
+    <string name="mileage_drive_count">N° de trajectes</string>
 
     <!-- Info dialog title for average per year calculation -->
     <string name="mileage_avg_year_title">Mitjana Anual</string>
 
     <!-- Info dialog explaining average per year calculation. %1$s is the date, %2$d is the number of days -->
-    <string name="mileage_avg_year_message">Basat en la teva mitjana diària des del primer viatge registrat el %1$s (fa %2$d dies).\n\nCàlcul: distància total ÷ dies × 365</string>
+    <string name="mileage_avg_year_message">Basat en la teva mitjana diària des del primer trajecte registrat el %1$s (fa %2$d dies).\n\nCàlcul: distància total ÷ dies × 365</string>
 
     <!-- Content description for info button explaining calculation -->
     <string name="info_about_calculation">Info sobre el càlcul</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -132,7 +132,7 @@
     <string name="nav_charges">Cargas</string>
 
     <!-- Navigation button to drives list -->
-    <string name="nav_drives">Viajes</string>
+    <string name="nav_drives">Trayectos</string>
 
     <!-- Navigation button to mileage/odometer screen -->
     <string name="nav_mileage">Kilometraje</string>
@@ -207,22 +207,22 @@
     <string name="settings_extra">Ajustes extra</string>
 
     <!-- Show short drives/charges toggle -->
-    <string name="settings_show_short_label">Mostrar viajes / cargas cortos</string>
-    <string name="settings_show_short_hint">Mostrar viajes muy cortos y cargas mínimas en las listas</string>
+    <string name="settings_show_short_label">Mostrar trayectos / cargas cortos</string>
+    <string name="settings_show_short_hint">Mostrar trayectos muy cortos y cargas mínimas en las listas</string>
     <string name="more_information">Más información</string>
 
     <!-- Short drives/charges info dialog -->
-    <string name="settings_short_dialog_title">Viajes y cargas cortos</string>
-    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los siguientes elementos están ocultos de las listas:\n\n• Viajes de menos de 1 minuto o menos de 0,1 km\n• Cargas de 0,1 kWh o menos\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
+    <string name="settings_short_dialog_title">Trayectos y cargas cortos</string>
+    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los siguientes elementos están ocultos de las listas:\n\n• Trayectos de menos de 1 minuto o menos de 0,1 km\n• Cargas de 0,1 kWh o menos\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forzar resincronización completa</string>
     <string name="settings_resyncing">Resincronizando…</string>
-    <string name="settings_resync_hint">Vuelve a descargar todos los detalles de viajes y cargas. Usa si las estadísticas parecen incorrectas.</string>
+    <string name="settings_resync_hint">Vuelve a descargar todos los detalles de trayectos y cargas. Usa si las estadísticas parecen incorrectas.</string>
     <string name="settings_resync_dialog_title">¿Forzar resincronización completa?</string>
     <string name="settings_resync_dialog_text_prefix">Esto </string>
     <string name="settings_resync_dialog_text_delete">ELIMINARÁ</string>
-    <string name="settings_resync_dialog_text_suffix"> todos los viajes, cargas y estadísticas en caché, luego volverá a descargar todo del servidor.\n\nEl proceso puede tardar varios minutos dependiendo de la cantidad de datos.</string>
+    <string name="settings_resync_dialog_text_suffix"> todos los trayectos, cargas y estadísticas en caché, luego volverá a descargar todo del servidor.\n\nEl proceso puede tardar varios minutos dependiendo de la cantidad de datos.</string>
     <string name="settings_resync_confirm">Resincronizar</string>
 
     <!-- Action buttons -->
@@ -242,16 +242,16 @@
 
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drives_title">Viajes</string>
+    <string name="drives_title">Trayectos</string>
 
     <!-- Content description for back button -->
     <string name="back">Atrás</string>
 
     <!-- Section title for drive history list -->
-    <string name="drive_history">Historial de viajes</string>
+    <string name="drive_history">Historial de trayectos</string>
 
     <!-- Empty state when no drives match filters -->
-    <string name="no_drives_found">No se encontraron viajes para el período seleccionado</string>
+    <string name="no_drives_found">No se encontraron trayectos para el período seleccionado</string>
 
     <!-- Summary card title -->
     <string name="summary">Resumen</string>
@@ -301,9 +301,9 @@
     <string name="filter_road_trip_mi">Viaje largo (&gt; 60 mi)</string>
 
     <!-- Chart titles - drives per period -->
-    <string name="chart_drives_per_day">Viajes por día</string>
-    <string name="chart_drives_per_week">Viajes por semana</string>
-    <string name="chart_drives_per_month">Viajes por mes</string>
+    <string name="chart_drives_per_day">Trayectos por día</string>
+    <string name="chart_drives_per_week">Trayectos por semana</string>
+    <string name="chart_drives_per_month">Trayectos por mes</string>
 
     <!-- Chart titles - driving time per period -->
     <string name="chart_time_per_day">Tiempo de conducción por día</string>
@@ -322,7 +322,7 @@
 
     <!-- ==================== Drive Detail Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drive_details_title">Detalles del viaje</string>
+    <string name="drive_details_title">Detalles del trayecto</string>
 
     <!-- Route card labels -->
     <string name="from">Desde</string>
@@ -529,10 +529,10 @@
     <string name="stats_empty">No hay estadísticas disponibles.\nDesliza hacia abajo para sincronizar.</string>
 
     <!-- Sync phase: fetching summary data from server -->
-    <string name="sync_phase_summaries">Obteniendo viajes y cargas…</string>
+    <string name="sync_phase_summaries">Obteniendo trayectos y cargas…</string>
 
     <!-- Sync phase: processing individual drive details -->
-    <string name="sync_phase_drives">Procesando detalles de viajes…</string>
+    <string name="sync_phase_drives">Procesando detalles de trayectos…</string>
 
     <!-- Sync phase: processing individual charge details -->
     <string name="sync_phase_charges">Procesando detalles de cargas…</string>
@@ -553,10 +553,10 @@
     <string name="geocode_progress_status">%1$d de %2$d ubicaciones</string>
 
     <!-- Section: Drives Overview - summary statistics about all drives -->
-    <string name="stats_drives_overview">Resumen de Viajes</string>
+    <string name="stats_drives_overview">Resumen de Trayectos</string>
 
     <!-- Label for total number of drives -->
-    <string name="stats_total_drives">Viajes Totales</string>
+    <string name="stats_total_drives">Trayectos Totales</string>
 
     <!-- Label for number of days with at least one drive -->
     <string name="stats_driving_days">Días de Conducción</string>
@@ -585,7 +585,7 @@
     <string name="stats_records">Récords</string>
 
     <!-- Record category: driving-related records -->
-    <string name="stats_category_drives">Viajes</string>
+    <string name="stats_category_drives">Trayectos</string>
 
     <!-- Record category: battery and charging records -->
     <string name="stats_category_battery">Batería</string>
@@ -597,7 +597,7 @@
     <string name="stats_category_misc">Otros</string>
 
     <!-- Record: longest single drive by distance -->
-    <string name="record_longest_drive">Viaje más largo</string>
+    <string name="record_longest_drive">Trayecto más largo</string>
 
     <!-- Record: fastest speed ever recorded -->
     <string name="record_top_speed">Velocidad Máx</string>
@@ -639,10 +639,10 @@
     <string name="record_most_climbing">Mayor desnivel</string>
 
     <!-- Record: drive with highest outside temperature -->
-    <string name="record_hottest_drive">Viaje más caluroso</string>
+    <string name="record_hottest_drive">Trayecto más caluroso</string>
 
     <!-- Record: drive with lowest outside temperature -->
-    <string name="record_coldest_drive">Viaje más frío</string>
+    <string name="record_coldest_drive">Trayecto más frío</string>
 
     <!-- Record: charge session with highest outside temperature -->
     <string name="record_hottest_charge">Carga más calurosa</string>
@@ -666,7 +666,7 @@
     <string name="format_days">%.1f días</string>
 
     <!-- Format for number of drives. %d is the count -->
-    <string name="format_drives_count">%d viajes</string>
+    <string name="format_drives_count">%d trayectos</string>
 
     <!-- Section: Temperature extremes recorded while driving and charging -->
     <string name="stats_temperature_extremes">Temperaturas Extremas</string>
@@ -711,16 +711,16 @@
     <string name="stats_range_record_title">Autonomía Máxima</string>
 
     <!-- Label for number of drives in range record. %d is the count -->
-    <string name="stats_drives_count">Viajes (%d)</string>
+    <string name="stats_drives_count">Trayectos (%d)</string>
 
     <!-- Empty state when no drives found in range record dialog -->
-    <string name="stats_no_drives_found">No se encontraron viajes</string>
+    <string name="stats_no_drives_found">No se encontraron trayectos</string>
 
     <!-- Content description for arrow indicating tappable record -->
     <string name="view_details">Ver detalles</string>
 
     <!-- Content description for arrow to view drive details -->
-    <string name="view_drive">Ver viaje</string>
+    <string name="view_drive">Ver trayecto</string>
 
     <!-- ==================== Countries Visited Screen ==================== -->
     <!-- Top bar title for countries visited screen -->
@@ -740,8 +740,8 @@
 
     <!-- Plural for number of drives in a country -->
     <plurals name="drives_count">
-        <item quantity="one">viaje</item>
-        <item quantity="other">viajes</item>
+        <item quantity="one">trayecto</item>
+        <item quantity="other">trayectos</item>
     </plurals>
 
     <!-- Plural for number of charges in a country -->
@@ -757,7 +757,7 @@
     <string name="sort_alphabetically">Alfabéticamente</string>
 
     <!-- Sort option: by number of drives -->
-    <string name="sort_by_drive_count">Por viajes</string>
+    <string name="sort_by_drive_count">Por trayectos</string>
 
     <!-- Sort option: sort by total distance -->
     <string name="sort_by_distance">Por distancia</string>
@@ -795,13 +795,13 @@
     <!-- Map showing drive start locations in the country -->
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
-        <item quantity="one">%d viaje</item>
-        <item quantity="other">%d viajes</item>
+        <item quantity="one">%d trayecto</item>
+        <item quantity="other">%d trayectos</item>
     </plurals>
 
     <!-- Map mode toggle labels -->
     <string name="map_mode_charges">Cargas</string>
-    <string name="map_mode_drives">Viajes</string>
+    <string name="map_mode_drives">Trayectos</string>
 
     <!-- Legend label for drive start marker -->
     <string name="drive_start_legend">Inicio</string>
@@ -814,10 +814,10 @@
     <string name="mileage_title">Kilometraje</string>
 
     <!-- Empty state when no drive data is available -->
-    <string name="mileage_no_data">No hay datos de viajes disponibles</string>
+    <string name="mileage_no_data">No hay datos de trayectos disponibles</string>
 
     <!-- Empty state when no drive data for a specific year. %d is the year -->
-    <string name="mileage_no_data_year">No hay datos de viajes para %d</string>
+    <string name="mileage_no_data_year">No hay datos de trayectos para %d</string>
 
     <!-- Chart title: mileage grouped by year -->
     <string name="mileage_by_year">Kilometraje por Año</string>
@@ -835,7 +835,7 @@
     <string name="mileage_recent_trips">Viajes recientes</string>
 
     <!-- Section header for drives list in day detail -->
-    <string name="mileage_drives">Viajes</string>
+    <string name="mileage_drives">Trayectos</string>
 
     <!-- Summary label: Total distance -->
     <string name="mileage_total">Total</string>
@@ -847,13 +847,13 @@
     <string name="mileage_avg_month">Media/Mes</string>
 
     <!-- Summary label: number of drives -->
-    <string name="mileage_drive_count">N° de viajes</string>
+    <string name="mileage_drive_count">N° de trayectos</string>
 
     <!-- Info dialog title for average per year calculation -->
     <string name="mileage_avg_year_title">Media Anual</string>
 
     <!-- Info dialog explaining average per year calculation. %1$s is the date, %2$d is the number of days -->
-    <string name="mileage_avg_year_message">Basado en tu media diaria desde tu primer viaje registrado el %1$s (hace %2$d días).\n\nCálculo: distancia total ÷ días × 365</string>
+    <string name="mileage_avg_year_message">Basado en tu media diaria desde tu primer trayecto registrado el %1$s (hace %2$d días).\n\nCálculo: distancia total ÷ días × 365</string>
 
     <!-- Content description for info button explaining calculation -->
     <string name="info_about_calculation">Info sobre el cálculo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -132,7 +132,7 @@
     <string name="nav_charges">Ricariche</string>
 
     <!-- Navigation button to drives list -->
-    <string name="nav_drives">Viaggi</string>
+    <string name="nav_drives">Tragitti</string>
 
     <!-- Navigation button to mileage/odometer screen -->
     <string name="nav_mileage">Chilometraggio</string>
@@ -207,22 +207,22 @@
     <string name="settings_extra">Impostazioni extra</string>
 
     <!-- Show short drives/charges toggle -->
-    <string name="settings_show_short_label">Mostra viaggi / ricariche brevi</string>
-    <string name="settings_show_short_hint">Visualizza viaggi molto brevi e ricariche minime nelle liste</string>
+    <string name="settings_show_short_label">Mostra tragitti / ricariche brevi</string>
+    <string name="settings_show_short_hint">Visualizza tragitti molto brevi e ricariche minime nelle liste</string>
     <string name="more_information">Maggiori informazioni</string>
 
     <!-- Short drives/charges info dialog -->
-    <string name="settings_short_dialog_title">Viaggi e ricariche brevi</string>
-    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i seguenti elementi sono nascosti dalle liste:\n\n• Viaggi sotto 1 minuto o meno di 0,1 km\n• Ricariche di 0,1 kWh o meno\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
+    <string name="settings_short_dialog_title">Tragitti e ricariche brevi</string>
+    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i seguenti elementi sono nascosti dalle liste:\n\n• Tragitti sotto 1 minuto o meno di 0,1 km\n• Ricariche di 0,1 kWh o meno\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forza risincronizzazione completa</string>
     <string name="settings_resyncing">Risincronizzazione…</string>
-    <string name="settings_resync_hint">Riscarica tutti i dettagli di viaggi e ricariche. Usa se le statistiche sembrano errate.</string>
+    <string name="settings_resync_hint">Riscarica tutti i dettagli di tragitti e ricariche. Usa se le statistiche sembrano errate.</string>
     <string name="settings_resync_dialog_title">Forzare risincronizzazione completa?</string>
     <string name="settings_resync_dialog_text_prefix">Questo </string>
     <string name="settings_resync_dialog_text_delete">ELIMINERÀ</string>
-    <string name="settings_resync_dialog_text_suffix"> tutti i viaggi, ricariche e statistiche memorizzati, poi riscaricherà tutto dal server.\n\nIl processo potrebbe richiedere diversi minuti a seconda della quantità di dati.</string>
+    <string name="settings_resync_dialog_text_suffix"> tutti i tragitti, ricariche e statistiche memorizzati, poi riscaricherà tutto dal server.\n\nIl processo potrebbe richiedere diversi minuti a seconda della quantità di dati.</string>
     <string name="settings_resync_confirm">Risincronizza</string>
 
     <!-- Action buttons -->
@@ -242,16 +242,16 @@
 
     <!-- ==================== Drives Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drives_title">Viaggi</string>
+    <string name="drives_title">Tragitti</string>
 
     <!-- Content description for back button -->
     <string name="back">Indietro</string>
 
     <!-- Section title for drive history list -->
-    <string name="drive_history">Cronologia viaggi</string>
+    <string name="drive_history">Cronologia tragitti</string>
 
     <!-- Empty state when no drives match filters -->
-    <string name="no_drives_found">Nessun viaggio trovato per il periodo selezionato</string>
+    <string name="no_drives_found">Nessun tragitto trovato per il periodo selezionato</string>
 
     <!-- Summary card title -->
     <string name="summary">Riepilogo</string>
@@ -301,9 +301,9 @@
     <string name="filter_road_trip_mi">Viaggio lungo (&gt; 60 mi)</string>
 
     <!-- Chart titles - drives per period -->
-    <string name="chart_drives_per_day">Viaggi al giorno</string>
-    <string name="chart_drives_per_week">Viaggi a settimana</string>
-    <string name="chart_drives_per_month">Viaggi al mese</string>
+    <string name="chart_drives_per_day">Tragitti al giorno</string>
+    <string name="chart_drives_per_week">Tragitti a settimana</string>
+    <string name="chart_drives_per_month">Tragitti al mese</string>
 
     <!-- Chart titles - driving time per period -->
     <string name="chart_time_per_day">Tempo di guida al giorno</string>
@@ -322,7 +322,7 @@
 
     <!-- ==================== Drive Detail Screen ==================== -->
     <!-- Top bar title -->
-    <string name="drive_details_title">Dettagli viaggio</string>
+    <string name="drive_details_title">Dettagli tragitto</string>
 
     <!-- Route card labels -->
     <string name="from">Da</string>
@@ -529,10 +529,10 @@
     <string name="stats_empty">Nessuna statistica disponibile.\nScorri verso il basso per sincronizzare.</string>
 
     <!-- Sync phase: fetching summary data from server -->
-    <string name="sync_phase_summaries">Recupero viaggi e ricariche…</string>
+    <string name="sync_phase_summaries">Recupero tragitti e ricariche…</string>
 
     <!-- Sync phase: processing individual drive details -->
-    <string name="sync_phase_drives">Elaborazione dettagli viaggi…</string>
+    <string name="sync_phase_drives">Elaborazione dettagli tragitti…</string>
 
     <!-- Sync phase: processing individual charge details -->
     <string name="sync_phase_charges">Elaborazione dettagli ricariche…</string>
@@ -553,10 +553,10 @@
     <string name="geocode_progress_status">%1$d di %2$d località</string>
 
     <!-- Section: Drives Overview - summary statistics about all drives -->
-    <string name="stats_drives_overview">Panoramica Viaggi</string>
+    <string name="stats_drives_overview">Panoramica Tragitti</string>
 
     <!-- Label for total number of drives -->
-    <string name="stats_total_drives">Viaggi Totali</string>
+    <string name="stats_total_drives">Tragitti Totali</string>
 
     <!-- Label for number of days with at least one drive -->
     <string name="stats_driving_days">Giorni di Guida</string>
@@ -585,7 +585,7 @@
     <string name="stats_records">Record</string>
 
     <!-- Record category: driving-related records -->
-    <string name="stats_category_drives">Viaggi</string>
+    <string name="stats_category_drives">Tragitti</string>
 
     <!-- Record category: battery and charging records -->
     <string name="stats_category_battery">Batteria</string>
@@ -597,7 +597,7 @@
     <string name="stats_category_misc">Altri</string>
 
     <!-- Record: longest single drive by distance -->
-    <string name="record_longest_drive">Viaggio più lungo</string>
+    <string name="record_longest_drive">Tragitto più lungo</string>
 
     <!-- Record: fastest speed ever recorded -->
     <string name="record_top_speed">Velocità Max</string>
@@ -639,10 +639,10 @@
     <string name="record_most_climbing">Maggior dislivello</string>
 
     <!-- Record: drive with highest outside temperature -->
-    <string name="record_hottest_drive">Viaggio più caldo</string>
+    <string name="record_hottest_drive">Tragitto più caldo</string>
 
     <!-- Record: drive with lowest outside temperature -->
-    <string name="record_coldest_drive">Viaggio più freddo</string>
+    <string name="record_coldest_drive">Tragitto più freddo</string>
 
     <!-- Record: charge session with highest outside temperature -->
     <string name="record_hottest_charge">Ricarica più calda</string>
@@ -666,7 +666,7 @@
     <string name="format_days">%.1f giorni</string>
 
     <!-- Format for number of drives. %d is the count -->
-    <string name="format_drives_count">%d viaggi</string>
+    <string name="format_drives_count">%d tragitti</string>
 
     <!-- Section: Temperature extremes recorded while driving and charging -->
     <string name="stats_temperature_extremes">Temperature Estreme</string>
@@ -711,16 +711,16 @@
     <string name="stats_range_record_title">Autonomia Massima</string>
 
     <!-- Label for number of drives in range record. %d is the count -->
-    <string name="stats_drives_count">Viaggi (%d)</string>
+    <string name="stats_drives_count">Tragitti (%d)</string>
 
     <!-- Empty state when no drives found in range record dialog -->
-    <string name="stats_no_drives_found">Nessun viaggio trovato</string>
+    <string name="stats_no_drives_found">Nessun tragitto trovato</string>
 
     <!-- Content description for arrow indicating tappable record -->
     <string name="view_details">Vedi dettagli</string>
 
     <!-- Content description for arrow to view drive details -->
-    <string name="view_drive">Vedi viaggio</string>
+    <string name="view_drive">Vedi tragitto</string>
 
     <!-- ==================== Countries Visited Screen ==================== -->
     <!-- Top bar title for countries visited screen -->
@@ -740,8 +740,8 @@
 
     <!-- Plural for number of drives in a country -->
     <plurals name="drives_count">
-        <item quantity="one">viaggio</item>
-        <item quantity="other">viaggi</item>
+        <item quantity="one">tragitto</item>
+        <item quantity="other">tragitti</item>
     </plurals>
 
     <!-- Plural for number of charges in a country -->
@@ -757,7 +757,7 @@
     <string name="sort_alphabetically">Alfabeticamente</string>
 
     <!-- Sort option: sort by number of drives -->
-    <string name="sort_by_drive_count">Per viaggi</string>
+    <string name="sort_by_drive_count">Per tragitti</string>
 
     <!-- Sort option: sort by total distance -->
     <string name="sort_by_distance">Per distanza</string>
@@ -795,13 +795,13 @@
     <!-- Map showing drive start locations in the country -->
     <!-- Plural for number of drives on the map. %d is the count -->
     <plurals name="format_drives_on_map">
-        <item quantity="one">%d viaggio</item>
-        <item quantity="other">%d viaggi</item>
+        <item quantity="one">%d tragitto</item>
+        <item quantity="other">%d tragitti</item>
     </plurals>
 
     <!-- Map mode toggle labels -->
     <string name="map_mode_charges">Ricariche</string>
-    <string name="map_mode_drives">Viaggi</string>
+    <string name="map_mode_drives">Tragitti</string>
 
     <!-- Legend label for drive start marker -->
     <string name="drive_start_legend">Partenza</string>
@@ -814,10 +814,10 @@
     <string name="mileage_title">Chilometraggio</string>
 
     <!-- Empty state when no drive data is available -->
-    <string name="mileage_no_data">Nessun dato di viaggio disponibile</string>
+    <string name="mileage_no_data">Nessun dato di tragitto disponibile</string>
 
     <!-- Empty state when no drive data for a specific year. %d is the year -->
-    <string name="mileage_no_data_year">Nessun dato di viaggio per il %d</string>
+    <string name="mileage_no_data_year">Nessun dato di tragitto per il %d</string>
 
     <!-- Chart title: mileage grouped by year -->
     <string name="mileage_by_year">Chilometraggio per Anno</string>
@@ -835,7 +835,7 @@
     <string name="mileage_recent_trips">Viaggi recenti</string>
 
     <!-- Section header for drives list in day detail -->
-    <string name="mileage_drives">Viaggi</string>
+    <string name="mileage_drives">Tragitti</string>
 
     <!-- Summary label: Total distance -->
     <string name="mileage_total">Totale</string>
@@ -847,13 +847,13 @@
     <string name="mileage_avg_month">Media/Mese</string>
 
     <!-- Summary label: number of drives -->
-    <string name="mileage_drive_count">N° di viaggi</string>
+    <string name="mileage_drive_count">N° di tragitti</string>
 
     <!-- Info dialog title for average per year calculation -->
     <string name="mileage_avg_year_title">Media Annuale</string>
 
     <!-- Info dialog explaining average per year calculation. %1$s is the date, %2$d is the number of days -->
-    <string name="mileage_avg_year_message">Basato sulla tua media giornaliera dal primo viaggio registrato il %1$s (%2$d giorni fa).\n\nCalcolo: distanza totale ÷ giorni × 365</string>
+    <string name="mileage_avg_year_message">Basato sulla tua media giornaliera dal primo tragitto registrato il %1$s (%2$d giorni fa).\n\nCalcolo: distanza totale ÷ giorni × 365</string>
 
     <!-- Content description for info button explaining calculation -->
     <string name="info_about_calculation">Info sul calcolo</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -257,7 +257,7 @@
     <string name="summary">概览</string>
 
     <!-- Summary card labels -->
-    <string name="total_trips">总行程数</string>
+    <string name="total_trips">总旅程数</string>
     <string name="total_distance">总距离</string>
     <string name="total_time">总时间</string>
     <string name="max_speed">最高速度</string>
@@ -338,7 +338,7 @@
 
     <!-- Stats section titles -->
     <string name="speed">速度</string>
-    <string name="trip">行程</string>
+    <string name="trip">旅程</string>
     <string name="power">功率</string>
     <string name="temperature">温度</string>
 
@@ -832,7 +832,7 @@
     <string name="format_days_count">%d 天</string>
 
     <!-- Section header for recent trips list -->
-    <string name="mileage_recent_trips">最近行程</string>
+    <string name="mileage_recent_trips">最近旅程</string>
 
     <!-- Section header for drives list in day detail -->
     <string name="mileage_drives">行程</string>
@@ -1049,12 +1049,12 @@
     <string name="sentry_history_today">今天</string>
     <string name="sentry_history_yesterday">昨天</string>
 
-    <string name="nav_trips">行程</string>
-    <string name="trips_title">行程</string>
-    <string name="trips_empty">尚未检测到公路旅行。\n行程需要至少 2 段驾驶和 1 次直流充电。</string>
-    <string name="trip_detail_title">行程详情</string>
-    <string name="trip_summary">行程概览</string>
-    <string name="trip_legs">行程段落</string>
+    <string name="nav_trips">旅程</string>
+    <string name="trips_title">旅程</string>
+    <string name="trips_empty">尚未检测到公路旅行。\n旅程需要至少 2 段驾驶和 1 次直流充电。</string>
+    <string name="trip_detail_title">旅程详情</string>
+    <string name="trip_summary">旅程概览</string>
+    <string name="trip_legs">旅程段落</string>
     <string name="trip_no_stops">无停靠</string>
     <string name="trip_one_stop">1 个停靠</string>
     <string name="trip_n_stops">%1$d 个停靠</string>
@@ -1070,28 +1070,28 @@
     <string name="trip_timeline_charging_ac">AC 充电</string>
     <string name="trip_timeline_parked">已停车</string>
 
-    <string name="trip_edit_add_leg">添加行程段</string>
-    <string name="trip_edit_merge_trip">合并行程</string>
-    <string name="trip_edit_add_leg_title">添加到此行程</string>
+    <string name="trip_edit_add_leg">添加旅程段</string>
+    <string name="trip_edit_merge_trip">合并旅程</string>
+    <string name="trip_edit_add_leg_title">添加到此旅程</string>
     <string name="trip_edit_add_leg_empty">附近没有驾驶或充电记录</string>
-    <string name="trip_edit_merge_title">合并另一个行程</string>
-    <string name="trip_edit_merge_empty">2 周内没有其他行程</string>
-    <string name="trip_edit_merge_confirm_title">合并行程？</string>
-    <string name="trip_edit_merge_confirm_body">将这些行程合并为一个。您可以通过删除合并后的行程来撤销。</string>
+    <string name="trip_edit_merge_title">合并另一个旅程</string>
+    <string name="trip_edit_merge_empty">2 周内没有其他旅程</string>
+    <string name="trip_edit_merge_confirm_title">合并旅程？</string>
+    <string name="trip_edit_merge_confirm_body">将这些旅程合并为一个。您可以通过删除合并后的旅程来撤销。</string>
     <string name="trip_edit_merge_confirm">合并</string>
-    <string name="trip_edit_delete">删除行程</string>
-    <string name="trip_edit_delete_confirm_title">删除此行程？</string>
-    <string name="trip_edit_delete_confirm_body">这将删除您的编辑。其中自动检测的行程将重新出现。</string>
+    <string name="trip_edit_delete">删除旅程</string>
+    <string name="trip_edit_delete_confirm_title">删除此旅程？</string>
+    <string name="trip_edit_delete_confirm_body">这将删除您的编辑。其中自动检测的旅程将重新出现。</string>
     <string name="delete">删除</string>
 
     <string name="part_of_trip">属于 %s</string>
     <string name="part_of_trip_remove">移除</string>
-    <string name="part_of_trip_remove_confirm_title">从行程中移除？</string>
-    <string name="part_of_trip_remove_confirm_body">此行程段将不再属于 %s。</string>
+    <string name="part_of_trip_remove_confirm_title">从旅程中移除？</string>
+    <string name="part_of_trip_remove_confirm_body">此旅程段将不再属于 %s。</string>
 
     <string name="trip_rename_action">重命名</string>
-    <string name="trip_rename_dialog_title">重命名行程</string>
-    <string name="trip_rename_field_label">行程名称</string>
+    <string name="trip_rename_dialog_title">重命名旅程</string>
+    <string name="trip_rename_field_label">旅程名称</string>
     <string name="trip_rename_field_hint">留空可使用默认名称</string>
     <string name="save">保存</string>
     <string name="add">添加</string>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -59,6 +59,28 @@ The app supports multiple languages using Android's standard resource-based loca
 - **Italian** - `res/values-it/strings.xml`
 - **Spanish** - `res/values-es/strings.xml`
 - **Catalan** - `res/values-ca/strings.xml`
+- **Chinese (Simplified)** - `res/values-zh/strings.xml`
+
+#### Terminology: "drives" vs "trips"
+
+These are two distinct concepts in the app and **must not collapse to the same word** in any
+locale:
+
+- **drive** — a single driving session (one A→B leg, the "Drives" list/screen).
+- **trip** — a road trip: several drives joined by charge stops (the "Trips" list/screen).
+
+In English they're naturally distinct. In Romance languages "trip" maps to the obvious cognate,
+so "drive" needs a *different* word — otherwise both render identically (e.g. both as "Viajes")
+and the navigation/stats become ambiguous. Established mapping:
+
+| Concept | en | it | es | ca | zh |
+|---------|-----|-----|-----|-----|-----|
+| drive | drive | tragitto | trayecto | trajecte | 行程 |
+| trip | trip | viaggio | viaje | viatge | 旅程 |
+
+When adding a new `drive_*`/`*_drive*` string, translate "drive" with the drive-column term, and
+reserve the trip-column term for `trip_*`/`trips_*` strings — never let the two collapse to the
+same word in a locale, or the Drives/Trips navigation and stats become ambiguous.
 
 #### Adding/Modifying Translations
 


### PR DESCRIPTION
## Summary
Since the Trips feature was added, several locales translated both **"drives"** and **"trips"** to the **same word**, making the navigation tabs and stats ambiguous (e.g. Spanish showed "Viajes" for both the Drives list and the Trips list).

This gives "drives" a distinct term in each affected locale while leaving "trips" on the journey word.

| Concept | en | it | es | ca | zh |
|---------|-----|-----|-----|-----|-----|
| drive | drive | **Tragitti** | **Trayectos** | **Trajectes** | 行程 |
| trip | trip | Viaggi | Viajes | Viatges | **旅程** |

## Scope
- The change is **surgical**: only drive-context strings (those whose English source says "drive(s)") were touched in es/ca/it; in zh the inverse — drives keep 行程 and the trip-context strings move to 旅程. Trip strings keep the journey word everywhere.
- Catalan and Italian were found to have the identical collision during investigation and were fixed in the same pass (confirmed with the maintainer). Chinese too.
- Documented the drives-vs-trips terminology convention in `docs/DEVELOPMENT.md` (and added the previously-missing Chinese entry to the supported-languages list).

## Test Plan
- [x] `./gradlew lintDebug` passes (no missing translations / malformed resources)
- [ ] Manual: switch device to es / ca / it / zh and confirm the Drives and Trips tabs/titles read differently and correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)