### PR TITLE
fix: black "DiamondBlack" Juniper/Highland cars rendered as white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **German translation** — the app is now fully available in German (Deutsch). Thanks to @herrfrei for the contribution.
 
 ### Fixed
+- **Black Juniper Model Y (and Highland Model 3) showed a white car**: the "Diamond Black" paint is reported by TeslaMate as `DiamondBlack`, which wasn't recognized, so the car image fell back to white. It now renders in black.
 - **"Drives" and "Trips" no longer share the same word** in Spanish, Catalan, Italian, and Chinese, where both were translated identically (e.g. both "Viajes") — making the navigation and stats ambiguous now that Trips exist. Drives now use a distinct term (es "Trayectos", ca "Trajectes", it "Tragitti", zh "行程") while Trips keep the journey word.
 
 ## [1.8.0-beta1] - 2026-05-31

--- a/app/src/main/java/com/matedroid/domain/model/CarImageResolver.kt
+++ b/app/src/main/java/com/matedroid/domain/model/CarImageResolver.kt
@@ -73,6 +73,9 @@ object CarImageResolver {
         "stealthgray" to "PN01",
         "midnightcherryred" to "PR00",
         "ultrared" to "PR01",
+        // Juniper/Highland "Diamond Black". TeslamateAPI reports it as "DiamondBlack";
+        // "blackdiamond" is kept as a defensive alias for the reversed spelling.
+        "diamondblack" to "PX02",
         "blackdiamond" to "PX02",
         // Juniper Model Y blues (distinct from Legacy PPSB Deep Blue Metallic)
         "glacierblue" to "PB01",

--- a/app/src/test/java/com/matedroid/domain/model/CarImageResolverTest.kt
+++ b/app/src/test/java/com/matedroid/domain/model/CarImageResolverTest.kt
@@ -1,0 +1,32 @@
+package com.matedroid.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CarImageResolverTest {
+
+    @Test
+    fun `DiamondBlack maps to PX02 color code`() {
+        // TeslamateAPI reports the Juniper/Highland black as "DiamondBlack" (one word, no space).
+        // Regression: this used to be unmapped, falling back to white (PPSW).
+        assertEquals("PX02", CarImageResolver.mapColor("DiamondBlack"))
+    }
+
+    @Test
+    fun `reversed and spaced spellings of Diamond Black also map to PX02`() {
+        assertEquals("PX02", CarImageResolver.mapColor("Diamond Black"))
+        assertEquals("PX02", CarImageResolver.mapColor("BlackDiamond"))
+    }
+
+    @Test
+    fun `black Model Y Juniper Premium resolves to the black asset, not white`() {
+        // Real user config: Model Y, DiamondBlack, 19" Crossflow, trim "74" (Long Range/Premium).
+        val path = CarImageResolver.getAssetPath(
+            model = "Y",
+            exteriorColor = "DiamondBlack",
+            wheelType = "Crossflow19",
+            trimBadging = "74",
+        )
+        assertEquals("car_images/myj_PX02_WY19P.png", path)
+    }
+}


### PR DESCRIPTION
## Summary
A user's **black Model Y Long Range Premium** (`exterior_color: "DiamondBlack"`) was auto-detected and rendered as a **white** car.

## Root Cause
`CarImageResolver.COLOR_CODES` mapped the Diamond Black paint under the key `"blackdiamond"`, but TeslamateAPI actually reports it as **`"DiamondBlack"`** (normalized → `"diamondblack"`). So `mapColor("DiamondBlack")` returned `null`, and `getAssetPath()` fell back to the variant default color `PPSW` (Pearl White). Variant/wheel detection was unaffected (Crossflow19 + trim 74 → `myj`), which is why it produced a correctly-shaped *white* Juniper Premium.

This also affected the Highland **Model 3** (its black is the same "Diamond Black" / PX02).

## Solution
- Add the `"diamondblack" → "PX02"` alias (keeping the reversed `"blackdiamond"` as a defensive alias).
- The correct asset (`car_images/myj_PX02_WY19P.png`) already exists, so no assets needed.
- Add `CarImageResolverTest` covering the reported config and the color-name spellings.

## Test Plan
- [x] `./gradlew testDebugUnitTest` passes (new `CarImageResolverTest` included)
- [x] `./gradlew detekt` passes
- [ ] Manual: a DiamondBlack Model Y Juniper now shows a black car in the picker and dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)