### PR TITLE
fix: keep car selector reachable when a car's status fails to load (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **German translation** — the app is now fully available in German (Deutsch). Thanks to @herrfrei for the contribution.
 
 ### Fixed
+- **Stuck on a car whose data can't load**: if the selected car's status failed to load (e.g. a car removed from your Tesla account that TeslaMate still lists), the dashboard got stuck and the car selector disappeared, so you couldn't switch to a working car. The car selector now stays visible with an inline error + Retry, and switching cars clears the error (#272).
 - **Black Juniper Model Y (and Highland Model 3) showed a white car**: the "Diamond Black" paint is reported by TeslaMate as `DiamondBlack`, which wasn't recognized, so the car image fell back to white. It now renders in black.
 - **"Drives" and "Trips" no longer share the same word** in Spanish, Catalan, Italian, and Chinese, where both were translated identically (e.g. both "Viajes") — making the navigation and stats ambiguous now that Trips exist. Drives now use a distinct term (es "Trayectos", ca "Trajectes", it "Tragitti", zh "行程") while Trips keep the journey word.
 

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.SelectableDates
@@ -301,18 +303,29 @@ fun DashboardScreen(
                         }
                     )
                 }
-                uiState.cars.isEmpty() && uiState.error == null -> {
-                    EmptyContent()
+                uiState.cars.isNotEmpty() -> {
+                    // Cars loaded but the selected car's status hasn't (still loading, or it
+                    // errored — e.g. a car no longer in the account). Keep the selector
+                    // reachable so the user can switch to a working car instead of being
+                    // stuck on a dead-end loading/error screen (issue #272).
+                    CarUnavailableContent(
+                        cars = uiState.cars,
+                        selectedCarId = uiState.selectedCarId,
+                        carImageOverrides = uiState.carImageOverrides,
+                        error = uiState.error,
+                        onSelectCar = { viewModel.selectCar(it) },
+                        onRetry = { viewModel.retryCarStatus() }
+                    )
                 }
                 uiState.error != null -> {
+                    // The car list itself failed to load — full-screen error.
                     ErrorContent(
                         message = uiState.error!!,
                         details = uiState.errorDetails
                     )
                 }
                 else -> {
-                    // Car status still loading after cars loaded
-                    LoadingContent()
+                    EmptyContent()
                 }
             }
         }
@@ -412,6 +425,190 @@ private fun ErrorContent(
                     Text(stringResource(R.string.close))
                 }
             }
+        )
+    }
+}
+
+/**
+ * Shown when the cars list loaded but the selected car's status could not be loaded
+ * (either still loading, or it errored — e.g. a car removed from the Tesla account
+ * that TeslaMate still lists, returning "no info on this car ID"). Keeps the car
+ * selector reachable so the user can switch to a working car instead of being stuck
+ * (issue #272).
+ */
+@Composable
+private fun CarUnavailableContent(
+    cars: List<CarData>,
+    selectedCarId: Int?,
+    carImageOverrides: Map<Int, CarImageOverride>,
+    error: String?,
+    onSelectCar: (Int) -> Unit,
+    onRetry: () -> Unit
+) {
+    val isDarkTheme = isSystemInDarkTheme()
+    val selectedCar = cars.firstOrNull { it.carId == selectedCarId }
+    val palette = CarColorPalettes.forExteriorColor(selectedCar?.carExterior?.exteriorColor, isDarkTheme)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        CarSelectorPager(
+            cars = cars,
+            selectedCarId = selectedCarId,
+            onSelectCar = onSelectCar,
+            carImageOverrides = carImageOverrides,
+            palette = palette,
+            isCharging = false,
+            isDcCharging = false,
+            onNavigateToStats = null,
+            onCarImageLongPress = null,
+            carModel = selectedCar?.carDetails?.model,
+            carTrimBadging = selectedCar?.carDetails?.trimBadging,
+            carExterior = selectedCar?.carExterior,
+            imageOverride = selectedCarId?.let { carImageOverrides[it] }
+        )
+
+        if (error != null) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = palette.surface)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.dashboard_car_unavailable),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = StatusError,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                    Button(onClick = onRetry) {
+                        Text(stringResource(R.string.retry))
+                    }
+                }
+            }
+        } else {
+            // Status still loading for the selected car.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = palette.accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CarSelectorPager(
+    cars: List<CarData>,
+    selectedCarId: Int?,
+    onSelectCar: (Int) -> Unit,
+    carImageOverrides: Map<Int, CarImageOverride>,
+    palette: CarColorPalette,
+    isCharging: Boolean,
+    isDcCharging: Boolean,
+    onNavigateToStats: (() -> Unit)?,
+    onCarImageLongPress: (() -> Unit)?,
+    carModel: String?,
+    carTrimBadging: String?,
+    carExterior: CarExterior?,
+    imageOverride: CarImageOverride?
+) {
+    val isDarkTheme = isSystemInDarkTheme()
+    if (cars.size > 1) {
+        val initialPage = cars.indexOfFirst { it.carId == selectedCarId }.coerceAtLeast(0)
+        val pagerState = rememberPagerState(initialPage = initialPage) { cars.size }
+
+        // Sync pager position when selected car changes externally
+        LaunchedEffect(selectedCarId) {
+            val targetPage = cars.indexOfFirst { it.carId == selectedCarId }.coerceAtLeast(0)
+            if (targetPage != pagerState.currentPage) {
+                pagerState.animateScrollToPage(targetPage)
+            }
+        }
+
+        // Notify viewmodel when user swipes to a new car
+        LaunchedEffect(pagerState.settledPage) {
+            val car = cars.getOrNull(pagerState.settledPage) ?: return@LaunchedEffect
+            if (car.carId != selectedCarId) {
+                onSelectCar(car.carId)
+            }
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth()
+        ) { page ->
+            val car = cars[page]
+            val isSettled = page == pagerState.settledPage
+            val carPalette = CarColorPalettes.forExteriorColor(car.carExterior?.exteriorColor, isDarkTheme)
+            CarImage(
+                carModel = car.carDetails?.model,
+                carTrimBadging = car.carDetails?.trimBadging,
+                carExterior = car.carExterior,
+                palette = carPalette,
+                modifier = Modifier.fillMaxWidth(),
+                isCharging = if (isSettled) isCharging else false,
+                isDcCharging = if (isSettled) isDcCharging else false,
+                accentColor = carPalette.accent,
+                carSurfaceColor = carPalette.surface,
+                imageOverride = carImageOverrides[car.carId],
+                onNavigateToStats = if (isSettled) onNavigateToStats else null,
+                onLongPress = if (isSettled) onCarImageLongPress else null
+            )
+        }
+
+        // Dots indicator
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            repeat(cars.size) { index ->
+                val isSelected = pagerState.currentPage == index
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp)
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) palette.accent
+                            else palette.onSurfaceVariant.copy(alpha = 0.3f)
+                        )
+                )
+            }
+        }
+    } else {
+        // Single car — existing behaviour unchanged
+        CarImage(
+            carModel = carModel,
+            carTrimBadging = carTrimBadging,
+            carExterior = carExterior,
+            palette = palette,
+            modifier = Modifier.fillMaxWidth(),
+            isCharging = isCharging,
+            isDcCharging = isDcCharging,
+            accentColor = palette.accent,
+            carSurfaceColor = palette.surface,
+            imageOverride = imageOverride,
+            onNavigateToStats = onNavigateToStats,
+            onLongPress = onCarImageLongPress
         )
     }
 }
@@ -1084,85 +1281,21 @@ private fun BatteryCard(
             )
 
             // Car image — pager when multiple cars, single image otherwise
-            if (cars.size > 1) {
-                val initialPage = cars.indexOfFirst { it.carId == selectedCarId }.coerceAtLeast(0)
-                val pagerState = rememberPagerState(initialPage = initialPage) { cars.size }
-
-                // Sync pager position when selected car changes externally
-                LaunchedEffect(selectedCarId) {
-                    val targetPage = cars.indexOfFirst { it.carId == selectedCarId }.coerceAtLeast(0)
-                    if (targetPage != pagerState.currentPage) {
-                        pagerState.animateScrollToPage(targetPage)
-                    }
-                }
-
-                // Notify viewmodel when user swipes to a new car
-                LaunchedEffect(pagerState.settledPage) {
-                    val car = cars.getOrNull(pagerState.settledPage) ?: return@LaunchedEffect
-                    if (car.carId != selectedCarId) {
-                        onSelectCar(car.carId)
-                    }
-                }
-
-                HorizontalPager(
-                    state = pagerState,
-                    modifier = Modifier.fillMaxWidth()
-                ) { page ->
-                    val car = cars[page]
-                    val isSettled = page == pagerState.settledPage
-                    val carPalette = CarColorPalettes.forExteriorColor(car.carExterior?.exteriorColor, isDarkTheme)
-                    CarImage(
-                        carModel = car.carDetails?.model,
-                        carTrimBadging = car.carDetails?.trimBadging,
-                        carExterior = car.carExterior,
-                        palette = carPalette,
-                        modifier = Modifier.fillMaxWidth(),
-                        isCharging = if (isSettled) status.isCharging else false,
-                        isDcCharging = if (isSettled) status.isDcCharging else false,
-                        accentColor = carPalette.accent,
-                        carSurfaceColor = carPalette.surface,
-                        imageOverride = carImageOverrides[car.carId],
-                        onNavigateToStats = if (isSettled) onNavigateToStats else null,
-                        onLongPress = if (isSettled) onCarImageLongPress else null
-                    )
-                }
-
-                // Dots indicator
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    repeat(cars.size) { index ->
-                        val isSelected = pagerState.currentPage == index
-                        Box(
-                            modifier = Modifier
-                                .padding(horizontal = 4.dp)
-                                .size(8.dp)
-                                .clip(CircleShape)
-                                .background(
-                                    if (isSelected) palette.accent
-                                    else palette.onSurfaceVariant.copy(alpha = 0.3f)
-                                )
-                        )
-                    }
-                }
-            } else {
-                // Single car — existing behaviour unchanged
-                CarImage(
-                    carModel = carModel,
-                    carTrimBadging = carTrimBadging,
-                    carExterior = carExterior,
-                    palette = palette,
-                    modifier = Modifier.fillMaxWidth(),
-                    isCharging = status.isCharging,
-                    isDcCharging = status.isDcCharging,
-                    accentColor = palette.accent,
-                    carSurfaceColor = palette.surface,
-                    imageOverride = imageOverride,
-                    onNavigateToStats = onNavigateToStats,
-                    onLongPress = onCarImageLongPress
-                )
-            }
+            CarSelectorPager(
+                cars = cars,
+                selectedCarId = selectedCarId,
+                onSelectCar = onSelectCar,
+                carImageOverrides = carImageOverrides,
+                palette = palette,
+                isCharging = status.isCharging,
+                isDcCharging = status.isDcCharging,
+                onNavigateToStats = onNavigateToStats,
+                onCarImageLongPress = onCarImageLongPress,
+                carModel = carModel,
+                carTrimBadging = carTrimBadging,
+                carExterior = carExterior,
+                imageOverride = imageOverride
+            )
 
             // Battery info row - tappable to navigate to battery health
             Row(

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -167,13 +167,32 @@ class DashboardViewModel @Inject constructor(
                 totalCharges = null,
                 totalDrives = null,
                 carImageOverride = currentOverrides[carId],
-                isCurrentChargeAvailable = false
+                isCurrentChargeAvailable = false,
+                // Clear any error from a previously-selected car so switching to a
+                // working car doesn't keep showing the stale error (issue #272).
+                error = null,
+                errorDetails = null
             )
         }
         // Save the selected car for next app launch
         viewModelScope.launch {
             settingsDataStore.saveLastSelectedCarId(carId)
         }
+        loadCarStatus(carId)
+    }
+
+    /**
+     * Retry loading the currently-selected car's status after a failure.
+     * Clears the error first so the UI shows a loading state while retrying.
+     */
+    fun retryCarStatus() {
+        val carId = _uiState.value.selectedCarId
+        if (carId == null) {
+            // No car selected yet (e.g. the car list itself failed to load) — reload everything.
+            loadCars()
+            return
+        }
+        _uiState.update { it.copy(error = null, errorDetails = null) }
         loadCarStatus(carId)
     }
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -38,6 +38,9 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">Mostra detalls</string>
 
+    <string name="retry">Torna-ho a provar</string>
+    <string name="dashboard_car_unavailable">No s\'ha pogut carregar aquest cotxe</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">Detalls de l\'Error</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,6 +38,9 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">Details anzeigen</string>
 
+    <string name="retry">Erneut versuchen</string>
+    <string name="dashboard_car_unavailable">Dieses Auto konnte nicht geladen werden</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">Fehlerdetails</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -38,6 +38,9 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">Mostrar detalles</string>
 
+    <string name="retry">Reintentar</string>
+    <string name="dashboard_car_unavailable">No se pudo cargar este coche</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">Detalles del Error</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -38,6 +38,9 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">Mostra dettagli</string>
 
+    <string name="retry">Riprova</string>
+    <string name="dashboard_car_unavailable">Impossibile caricare questa auto</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">Dettagli Errore</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -38,6 +38,9 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">显示详情</string>
 
+    <string name="retry">重试</string>
+    <string name="dashboard_car_unavailable">无法加载此车辆</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">错误详情</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,12 @@
     <!-- Error details: button to show technical error details -->
     <string name="error_show_details">Show details</string>
 
+    <!-- Generic retry button (e.g. retry loading a car's status) -->
+    <string name="retry">Retry</string>
+
+    <!-- Shown when the selected car's status can't be loaded but other cars are available to pick -->
+    <string name="dashboard_car_unavailable">Couldn\'t load this car</string>
+
     <!-- Error details: dialog title -->
     <string name="error_details_title">Error Details</string>
 

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -255,4 +255,49 @@ class DashboardViewModelTest {
         assertEquals("Status error", viewModel!!.uiState.value.error)
         assertNull(viewModel!!.uiState.value.carStatus)
     }
+
+    @Test
+    fun `selectCar clears a prior status error when switching to a working car`() = runTest {
+        // Regression for #272: car 1's status errors (e.g. removed from the account),
+        // but the user can switch to car 2 and the stale error must be cleared.
+        val car1 = CarData(carId = 1, name = "Car 1")
+        val car2 = CarData(carId = 2, name = "Car 2")
+        val status2WithUnits = CarStatusWithUnits(status = testStatus.copy(displayName = "Car 2"), units = Units())
+
+        coEvery { repository.getCars() } returns ApiResult.Success(listOf(car1, car2))
+        coEvery { repository.getCarStatus(1) } returns ApiResult.Error("no info on this car ID")
+        coEvery { repository.getCarStatus(2) } returns ApiResult.Success(status2WithUnits)
+
+        viewModel = createViewModel()
+        runCurrent()
+        assertEquals("no info on this car ID", viewModel!!.uiState.value.error)
+
+        viewModel!!.selectCar(2)
+        runCurrent()
+        cancelViewModelCoroutines()
+
+        assertEquals(2, viewModel!!.uiState.value.selectedCarId)
+        assertNull(viewModel!!.uiState.value.error)
+        assertEquals("Car 2", viewModel!!.uiState.value.carStatus?.displayName)
+    }
+
+    @Test
+    fun `retryCarStatus clears error and reloads the selected car`() = runTest {
+        // Regression for #272: retrying a transiently-failing car recovers cleanly.
+        coEvery { repository.getCars() } returns ApiResult.Success(listOf(testCar))
+        coEvery { repository.getCarStatus(1) } returns
+            ApiResult.Error("Status error") andThen ApiResult.Success(testStatusWithUnits)
+
+        viewModel = createViewModel()
+        runCurrent()
+        assertEquals("Status error", viewModel!!.uiState.value.error)
+        assertNull(viewModel!!.uiState.value.carStatus)
+
+        viewModel!!.retryCarStatus()
+        runCurrent()
+        cancelViewModelCoroutines()
+
+        assertNull(viewModel!!.uiState.value.error)
+        assertEquals(testStatus, viewModel!!.uiState.value.carStatus)
+    }
 }


### PR DESCRIPTION
## Summary
A user with 3 cars in TeslaMate was stuck: the first car (auto-selected, and no longer in their Tesla account) returns `{"error":"no info on this car ID"}` from `/status`, so the dashboard never finished loading and the car selector never appeared — leaving no way to switch to a working car.

Fixes #272

## Root Cause
The car selector (image pager) lives **inside** `BatteryCard`, which only renders when `carStatus != null`. When the selected car's status call errors, `carStatus` stays `null` and the UI falls through to a dead-end error/loading screen with no selector. Because the selected car id is **persisted** (`lastSelectedCarId`), every relaunch re-selects the broken car and fails again. Additionally, `selectCar()` never cleared `error`, so switching cars would briefly keep showing the stale error.

## Solution
- Extracted the car-image pager into a shared **`CarSelectorPager`** composable (used by `BatteryCard` as before — success layout unchanged).
- Added **`CarUnavailableContent`**: when cars loaded but the selected car's status hasn't, it shows the selector at the top plus either an inline **error + Retry** card or a spinner (while loading). The user can swipe/tap to a working car.
- `selectCar()` now clears `error`/`errorDetails`; added `retryCarStatus()`.
- New strings `retry` + `dashboard_car_unavailable` in **all 6 locales** (en/it/es/ca/de/zh).
- Regression tests: `selectCar` clears a prior status error; `retryCarStatus` reloads and clears the error.

## Test Plan
- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes (2 new DashboardViewModel tests)
- [x] `./gradlew detekt` passes
- [ ] Manual: with a car whose status errors, confirm the selector is visible and swiping to a working car loads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)