### PR TITLE
fix: auto-shrink dashboard nav labels so long localized words fit one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Long navigation labels no longer wrap on the dashboard**: localized words like the Spanish "Trayectos" or Catalan "Trajectes" overflowed the Drives/Charges/Trips buttons onto a second line. The label now shrinks slightly to stay on one line; labels that already fit are unchanged.
+
 ## [1.8.0-beta2] - 2026-06-06
 
 ### Added

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
@@ -2187,7 +2188,15 @@ private fun NavButton(
                 Text(
                     text = title,
                     style = MaterialTheme.typography.labelSmall,
-                    color = palette.onSurfaceVariant
+                    color = palette.onSurfaceVariant,
+                    // Shrink long localized labels (e.g. Spanish "Trayectos",
+                    // Catalan "Trajectes") to fit one line instead of wrapping.
+                    maxLines = 1,
+                    autoSize = TextAutoSize.StepBased(
+                        minFontSize = 9.sp,
+                        maxFontSize = 11.sp,
+                        stepSize = 0.5.sp
+                    )
                 )
             }
             Icon(


### PR DESCRIPTION
## Summary
After the drives/trips terminology fix (#291), the Spanish "Trayectos" (and Catalan "Trajectes"/"Càrregues") overflowed the dashboard's narrow 3-button nav row (Charges · Drives · Trips), wrapping the trailing letters onto a second line — a lonely "s" under "Trayecto".

## Solution
Give the `NavButton` label a shrink-to-fit font via Material3 `Text(autoSize = TextAutoSize.StepBased(9.sp..11.sp, step 0.5.sp))` + `maxLines = 1`. `maxFontSize = 11.sp` matches the current `labelSmall` size, so labels that already fit (and all English labels) look identical; only over-long localized words shrink a hair to stay on one line. One change fixes every locale (no truncation, no string changes, no layout change).

## Test Plan
- [x] `compileDebugKotlin`, `lintDebug`, `detekt` pass
- [x] Installed on device; Spanish "Trayectos" now fits on one line
- [ ] Spot-check Catalan ("Trajectes"/"Càrregues") and that English is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)