### PR TITLE
Explain trip-detection rules on the empty Trips screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Redesigned the bottom Activity card**: Trips now headlines the card as a tall tile with the trip count and a peek at your latest road-trip; Mileage and Charges sit alongside it, with Drives and Software below. "Where was I?" moved out of the Location card into the new menu.
 - **Redesigned the Location card** into an immersive, full-bleed map (muted to match light/dark theme) with the place name and details over it; tap anywhere to open it in your maps app.
 - **Tyre pressure moved into its own card** with a cleaner 2×2 grid — one tile per wheel with its pressure and an OK/low status dot.
+- **The empty Trips screen now explains itself**: when no road-trips have been detected, it lists how one is auto-generated (2+ drives in a row, linked by a DC fast-charge stop, totalling 300 km or more).
 
 ## [1.8.1] - 2026-06-07
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.trips
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -136,7 +139,7 @@ fun TripsScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(padding)
-                        .padding(32.dp),
+                        .padding(horizontal = 32.dp, vertical = 24.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -144,15 +147,32 @@ fun TripsScreen(
                             Icons.Filled.Route,
                             contentDescription = null,
                             modifier = Modifier.size(48.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            tint = palette.accent.copy(alpha = 0.7f)
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
-                            text = stringResource(R.string.trips_empty),
+                            text = stringResource(R.string.trips_empty_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(R.string.trips_empty_intro),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center
                         )
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Column(
+                            modifier = Modifier.widthIn(max = 320.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            TripRuleRow(1, stringResource(R.string.trips_empty_rule_drives), palette)
+                            TripRuleRow(2, stringResource(R.string.trips_empty_rule_charge), palette)
+                            TripRuleRow(3, stringResource(R.string.trips_empty_rule_distance), palette)
+                        }
                     }
                 }
             }
@@ -553,6 +573,32 @@ private fun YearFilterChips(
             },
             initialStart = customStartDate,
             initialEnd = customEndDate
+        )
+    }
+}
+
+/** A numbered rule row for the trips empty-state explainer. */
+@Composable
+private fun TripRuleRow(number: Int, text: String, palette: CarColorPalette) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .background(palette.accent.copy(alpha = 0.16f), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = number.toString(),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                color = palette.accent
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -149,6 +149,14 @@
     <string name="trips_empty_title">Encara no hi ha viatges</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">Els viatges de més de 300 km apareixen aquí</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">Un viatge es detecta automàticament quan tens:</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">2 o més trajectes seguits</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">connectats per almenys una parada de càrrega ràpida DC</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">que sumin 300 km o més en total</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Càrregues</string>
@@ -1071,9 +1079,7 @@
     <string name="sentry_history_yesterday">Ahir</string>
 
     <string name="nav_trips">Viatges</string>
-    <string name="trips_title">Viatges</string>
-    <string name="trips_empty">No s\'han detectat viatges.\nUn viatge requereix almenys 2 trajectes connectats per una càrrega DC.</string>
-    <string name="trip_detail_title">Detalls del viatge</string>
+    <string name="trips_title">Viatges</string>    <string name="trip_detail_title">Detalls del viatge</string>
     <string name="trip_summary">Resum del viatge</string>
     <string name="trip_legs">Etapes del viatge</string>
     <string name="trip_no_stops">sense parades</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -149,6 +149,14 @@
     <string name="trips_empty_title">Noch keine Trips</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">Trips über 300 km erscheinen hier</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">Ein Trip wird automatisch erkannt, wenn du Folgendes hast:</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">2 oder mehr Fahrten hintereinander</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">verbunden durch mindestens einen DC-Schnellladestopp</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">mit insgesamt mindestens 300 km</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Ladevorgänge</string>
@@ -1085,9 +1093,7 @@
     <string name="nav_trips">Trips</string>
     <!-- Trips list screen title -->
     <string name="trips_title">Trips</string>
-    <!-- Empty state when no trips detected -->
-    <string name="trips_empty">Noch keine Roadtrips erkannt.\nEin Trip besteht aus mindestens 2 Fahrten, die durch einen DC-Ladestopp verbunden sind.</string>
-    <!-- Warning when deep sync is incomplete -->
+    <!-- Empty state when no trips detected -->    <!-- Warning when deep sync is incomplete -->
     <!-- Trip detail screen title -->
     <string name="trip_detail_title">Tripdetails</string>
     <!-- Trip summary section header -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -149,6 +149,14 @@
     <string name="trips_empty_title">Aún no hay viajes</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">Los viajes de más de 300 km aparecen aquí</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">Un viaje se detecta automáticamente cuando tienes:</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">2 o más trayectos seguidos</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">conectados por al menos una parada de carga rápida DC</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">que sumen 300 km o más en total</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Cargas</string>
@@ -1071,9 +1079,7 @@
     <string name="sentry_history_yesterday">Ayer</string>
 
     <string name="nav_trips">Viajes</string>
-    <string name="trips_title">Viajes</string>
-    <string name="trips_empty">No se detectaron viajes.\nUn viaje requiere al menos 2 trayectos conectados por una carga DC.</string>
-    <string name="trip_detail_title">Detalles del viaje</string>
+    <string name="trips_title">Viajes</string>    <string name="trip_detail_title">Detalles del viaje</string>
     <string name="trip_summary">Resumen del viaje</string>
     <string name="trip_legs">Etapas del viaje</string>
     <string name="trip_no_stops">sin paradas</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -149,6 +149,14 @@
     <string name="trips_empty_title">Ancora nessun viaggio</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">I viaggi oltre 300 km appaiono qui</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">Un viaggio viene rilevato automaticamente quando hai:</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">2 o più tragitti consecutivi</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">collegati da almeno una sosta di ricarica rapida DC</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">per un totale di almeno 300 km</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Ricariche</string>
@@ -1071,9 +1079,7 @@
     <string name="sentry_history_yesterday">Ieri</string>
 
     <string name="nav_trips">Viaggi</string>
-    <string name="trips_title">Viaggi</string>
-    <string name="trips_empty">Nessun viaggio rilevato.\nUn viaggio richiede almeno 2 tratte collegate da una ricarica DC.</string>
-    <string name="trip_detail_title">Dettagli viaggio</string>
+    <string name="trips_title">Viaggi</string>    <string name="trip_detail_title">Dettagli viaggio</string>
     <string name="trip_summary">Riepilogo viaggio</string>
     <string name="trip_legs">Tappe del viaggio</string>
     <string name="trip_no_stops">nessuna sosta</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -149,6 +149,14 @@
     <string name="trips_empty_title">暂无长途旅程</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">超过 300 公里的旅程会显示在这里</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">满足以下条件时会自动识别为一次旅程：</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">连续 2 段或更多行程</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">由至少一次 DC 快充停留连接</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">总里程达到 300 km 或以上</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">充电记录</string>
@@ -1072,9 +1080,7 @@
     <string name="sentry_history_yesterday">昨天</string>
 
     <string name="nav_trips">旅程</string>
-    <string name="trips_title">旅程</string>
-    <string name="trips_empty">尚未检测到公路旅行。\n旅程需要至少 2 段驾驶和 1 次直流充电。</string>
-    <string name="trip_detail_title">旅程详情</string>
+    <string name="trips_title">旅程</string>    <string name="trip_detail_title">旅程详情</string>
     <string name="trip_summary">旅程概览</string>
     <string name="trip_legs">旅程段落</string>
     <string name="trip_no_stops">无停靠</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,14 @@
     <string name="trips_empty_title">No road-trips yet</string>
     <!-- Trips hero empty state hint -->
     <string name="trips_empty_hint">Trips over 300 km show up here</string>
+    <!-- Trips list empty state: intro before the auto-detection rules -->
+    <string name="trips_empty_intro">A road-trip is detected automatically when you have:</string>
+    <!-- Trips list empty state: rule 1 -->
+    <string name="trips_empty_rule_drives">2 or more drives in a row</string>
+    <!-- Trips list empty state: rule 2 -->
+    <string name="trips_empty_rule_charge">linked by at least one DC fast-charge stop</string>
+    <!-- Trips list empty state: rule 3 -->
+    <string name="trips_empty_rule_distance">covering 300 km or more in total</string>
 
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Charges</string>
@@ -1088,9 +1096,7 @@
     <string name="nav_trips">Trips</string>
     <!-- Trips list screen title -->
     <string name="trips_title">Trips</string>
-    <!-- Empty state when no trips detected -->
-    <string name="trips_empty">No road trips detected yet.\nA trip requires at least 2 drives connected by a DC charge stop.</string>
-    <!-- Warning when deep sync is incomplete -->
+    <!-- Empty state when no trips detected -->    <!-- Warning when deep sync is incomplete -->
     <!-- Trip detail screen title -->
     <string name="trip_detail_title">Trip Details</string>
     <!-- Trip summary section header -->


### PR DESCRIPTION
When no road-trips have been detected yet, tapping the Trips card opens the Trips list — which previously showed only a terse one-liner. It now explains **how trips are generated automatically**.

## What changed
The empty state becomes a friendly explainer: the route icon, a **"No road-trips yet"** title, a short intro, and the three auto-detection rules as a numbered list:

1. **2 or more drives in a row**
2. **linked by at least one DC fast-charge stop**
3. **covering 300 km or more in total**

These mirror `TripDetector` exactly (`≥2 drives`, `≥1 DC charge`, `totalDistance ≥ 300 km`).

## Notes
- New strings (`trips_empty_intro`, `trips_empty_rule_drives/charge/distance`) added across all 6 locales; reuses the existing `trips_empty_title`. Removed the superseded `trips_empty` string.
- `lintDebug` ✅, installed on device.
- Merge with a merge commit (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)