### PR TITLE
Create a trip from scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Menu in the top-right**: the dashboard's lone Settings gear is now a menu with Stats for nerds, Battery health, Where was I?, Sentry events and Settings.
+- **Create a trip by hand**: a + button on the Trips list lets you build a road-trip manually — pick the day, then choose the drives and charges that belong to it (handy when auto-detection misses one).
 
 ### Changed
 - **Redesigned the bottom Activity card**: Trips now headlines the card as a tall tile with the trip count and a peek at your latest road-trip; Mileage and Charges sit alongside it, with Drives and Software below. "Where was I?" moved out of the Location card into the new menu.

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -276,6 +276,77 @@ class TripRepository @Inject constructor(
         return EligibleLegs(drives, charges)
     }
 
+    // === Create from scratch (manual trips) ===
+
+    /**
+     * Drives and charges within [windowDays] of the [anchorStart]..[anchorEnd] range, not already
+     * part of any saved trip on [carId]. Same windowing as [getEligibleNewLegs] but anchored on an
+     * arbitrary date range (a picked day, or a draft trip's span) instead of an existing saved trip.
+     */
+    suspend fun getUnusedLegsAround(
+        carId: Int,
+        anchorStart: String,
+        anchorEnd: String,
+        windowDays: Int = 2
+    ): EligibleLegs {
+        val allDrives = driveSummaryDao.getAllChronological(carId)
+        val allCharges = chargeSummaryDao.getAllForCar(carId)
+        val windowStart = shiftDate(anchorStart, -windowDays.toLong())
+        val windowEnd = shiftDate(anchorEnd, windowDays.toLong())
+
+        val usedDriveIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_DRIVE).toSet()
+        val usedChargeIds = savedTripDao.getUsedLegIds(carId, SavedTripLeg.TYPE_CHARGE).toSet()
+
+        val drives = allDrives.filter {
+            it.driveId !in usedDriveIds &&
+                compareDates(it.startDate, windowStart) >= 0 &&
+                compareDates(it.startDate, windowEnd) <= 0
+        }
+        val charges = allCharges.filter {
+            it.chargeId !in usedChargeIds &&
+                compareDates(it.startDate, windowStart) >= 0 &&
+                compareDates(it.startDate, windowEnd) <= 0
+        }
+        return EligibleLegs(drives, charges)
+    }
+
+    /** Resolve a set of leg refs into their drive/charge summaries (for building a draft preview). */
+    suspend fun resolveLegs(carId: Int, refs: List<LegRef>): EligibleLegs {
+        val drivesById = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val chargesById = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+        val drives = refs.filter { it.type == SavedTripLeg.TYPE_DRIVE }.mapNotNull { drivesById[it.id] }
+        val charges = refs.filter { it.type == SavedTripLeg.TYPE_CHARGE }.mapNotNull { chargesById[it.id] }
+        return EligibleLegs(drives, charges)
+    }
+
+    /**
+     * Create a new user-built trip from a chosen leg set. Legs are sorted chronologically and
+     * persisted as a USER_EDITED trip. Detection rules (≥2 drives / DC charge / 300 km) do NOT
+     * apply to manual creation — the only requirement is ≥1 drive (so [TripAggregator] can build it).
+     * Returns the new trip id, or null if no drive was provided.
+     */
+    suspend fun createTrip(carId: Int, legs: List<LegRef>, name: String?): Long? {
+        if (legs.none { it.type == SavedTripLeg.TYPE_DRIVE }) return null
+        val drives = driveSummaryDao.getAllChronological(carId).associateBy { it.driveId }
+        val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
+        val sorted = legs.distinct().sortedBy { ref -> legStartDate(ref, drives, charges) ?: "" }
+        val now = System.currentTimeMillis()
+        return savedTripDao.insertTripWithLegs(
+            trip = SavedTrip(
+                carId = carId,
+                name = name?.trim()?.takeIf { it.isNotEmpty() },
+                source = SavedTrip.SOURCE_USER_EDITED,
+                createdAt = now,
+                updatedAt = now
+            ),
+            legs = { tripId ->
+                sorted.mapIndexed { index, ref ->
+                    SavedTripLeg(tripId = tripId, position = index, legType = ref.type, legId = ref.id)
+                }
+            }
+        )
+    }
+
     // === Helpers ===
 
     private fun tripDrivesIn(swl: SavedTripWithLegs, drives: Map<Int, DriveSummary>): List<DriveSummary> =

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -38,6 +38,7 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import com.matedroid.ui.screens.sentry.SentryHistoryScreen
+import com.matedroid.ui.screens.trips.CreateTripScreen
 import com.matedroid.ui.screens.trips.TripDetailScreen
 import com.matedroid.ui.screens.trips.TripsScreen
 import com.matedroid.ui.screens.updates.SoftwareVersionsScreen
@@ -177,6 +178,12 @@ sealed class Screen(val route: String) {
             val encoded = java.net.URLEncoder.encode(tripStartDate, "UTF-8")
             return if (exteriorColor != null) "trips/$carId/detail/$encoded?exteriorColor=$exteriorColor"
             else "trips/$carId/detail/$encoded"
+        }
+    }
+    data object CreateTrip : Screen("trips/{carId}/new?exteriorColor={exteriorColor}") {
+        fun createRoute(carId: Int, exteriorColor: String? = null): String {
+            return if (exteriorColor != null) "trips/$carId/new?exteriorColor=$exteriorColor"
+            else "trips/$carId/new"
         }
     }
     data object SentryHistory : Screen("sentry/{carId}?exteriorColor={exteriorColor}") {
@@ -682,6 +689,34 @@ fun NavGraph(
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToTripDetail = { tripStartDate ->
                     navController.navigate(Screen.TripDetail.createRoute(carId, tripStartDate, exteriorColor))
+                },
+                onNavigateToCreateTrip = {
+                    navController.navigate(Screen.CreateTrip.createRoute(carId, exteriorColor))
+                }
+            )
+        }
+
+        composable(
+            route = Screen.CreateTrip.route,
+            arguments = listOf(
+                navArgument("carId") { type = NavType.IntType },
+                navArgument("exteriorColor") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
+        ) { backStackEntry ->
+            val carId = backStackEntry.arguments?.getInt("carId") ?: return@composable
+            val exteriorColor = backStackEntry.arguments?.getString("exteriorColor")
+            CreateTripScreen(
+                carId = carId,
+                exteriorColor = exteriorColor,
+                onNavigateBack = { navController.popBackStack() },
+                onTripCreated = { startDate ->
+                    navController.navigate(Screen.TripDetail.createRoute(carId, startDate, exteriorColor)) {
+                        popUpTo(Screen.CreateTrip.route) { inclusive = true }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -111,7 +111,11 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -214,6 +218,20 @@ fun DashboardScreen(
             snackbarHostState.showSnackbar(it)
             viewModel.clearError()
         }
+    }
+
+    // Refresh the trip count + latest-trip teaser when returning to the dashboard (e.g. after
+    // creating a trip). Skip the first resume so we don't double-load right after the initial load.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        var firstResume = true
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (firstResume) firstResume = false else viewModel.refreshTripCount()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Scaffold(

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -220,15 +220,13 @@ fun DashboardScreen(
         }
     }
 
-    // Refresh the trip count + latest-trip teaser when returning to the dashboard (e.g. after
-    // creating a trip). Skip the first resume so we don't double-load right after the initial load.
+    // Refresh the trip count + latest-trip teaser on every resume so a trip created (or edited)
+    // elsewhere shows up on return. refreshTripCount() no-ops until a car is selected, so the
+    // initial load (driven by selectCar) isn't disturbed.
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
-        var firstResume = true
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                if (firstResume) firstResume = false else viewModel.refreshTripCount()
-            }
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshTripCount()
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -224,6 +224,9 @@ class DashboardViewModel @Inject constructor(
                 }
             }
 
+            // Pull-to-refresh also re-reads the trip count + latest trip.
+            loadTripCount(carId)
+
             _uiState.update { it.copy(isRefreshing = false) }
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -356,6 +356,11 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
+    /** Re-read the trip count + latest trip — e.g. after returning from creating/editing a trip. */
+    fun refreshTripCount() {
+        _uiState.value.selectedCarId?.let { loadTripCount(it) }
+    }
+
     private fun loadTripCount(carId: Int) {
         viewModelScope.launch {
             // Show cached value instantly

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -65,11 +65,12 @@ fun AddLegSheet(
     dcChargeIds: Set<Int>,
     palette: CarColorPalette,
     onPickLegs: (List<LegRef>) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    startInMultiSelect: Boolean = false
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    var multiMode by remember { mutableStateOf(false) }
+    var multiMode by remember { mutableStateOf(startInMultiSelect) }
     var selected by remember { mutableStateOf<Set<LegRef>>(emptySet()) }
 
     val merged = remember(eligible) { buildCandidateList(eligible) }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
@@ -1,0 +1,404 @@
+package com.matedroid.ui.screens.trips
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.matedroid.R
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.data.local.entity.SavedTripLeg
+import com.matedroid.domain.LegRef
+import com.matedroid.domain.model.Trip
+import com.matedroid.domain.model.UnitFormatter
+import com.matedroid.ui.icons.CustomIcons
+import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.ui.theme.CarColorPalettes
+import com.matedroid.util.formatDuration
+import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.parseIsoDateTime
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateTripScreen(
+    carId: Int,
+    exteriorColor: String? = null,
+    onNavigateBack: () -> Unit = {},
+    onTripCreated: (startDate: String) -> Unit = {},
+    viewModel: CreateTripViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val isDark = isSystemInDarkTheme()
+    val palette = CarColorPalettes.forExteriorColor(exteriorColor, isDark)
+
+    LaunchedEffect(carId) { viewModel.start(carId) }
+    LaunchedEffect(uiState.createdStartDate) {
+        uiState.createdStartDate?.let { onTripCreated(it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.trip_create_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { viewModel.save() },
+                        enabled = uiState.preview != null && !uiState.isSaving
+                    ) {
+                        Text(stringResource(R.string.trip_create_save))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            OutlinedTextField(
+                value = uiState.name,
+                onValueChange = viewModel::setName,
+                label = { Text(stringResource(R.string.trip_create_name_hint)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            PreviewSummary(uiState.preview, uiState.units, palette)
+
+            if (uiState.drives.isEmpty() && uiState.charges.isEmpty()) {
+                EmptyCue(palette)
+            } else {
+                LegList(
+                    drives = uiState.drives,
+                    charges = uiState.charges,
+                    dcChargeIds = uiState.dcChargeIds,
+                    palette = palette,
+                    onRemove = viewModel::removeLeg
+                )
+            }
+
+            OutlinedButton(
+                onClick = { viewModel.openAddLegSheet() },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.trip_create_add_legs))
+            }
+        }
+    }
+
+    // Step 1: pick the trip's day. Cancelling backs out of creation.
+    if (uiState.showDatePicker) {
+        TripDatePicker(
+            onConfirm = viewModel::onDatePicked,
+            onDismiss = onNavigateBack
+        )
+    }
+
+    if (uiState.showAddLegSheet && uiState.eligibleLegs != null) {
+        AddLegSheet(
+            eligible = uiState.eligibleLegs!!,
+            dcChargeIds = uiState.dcChargeIds,
+            palette = palette,
+            startInMultiSelect = true,
+            onPickLegs = viewModel::pickLegs,
+            onDismiss = viewModel::closeAddLegSheet
+        )
+    }
+}
+
+@Composable
+private fun PreviewSummary(preview: Trip?, units: com.matedroid.data.api.models.Units?, palette: CarColorPalette) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = palette.surface)
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Text(
+                text = preview?.displayName() ?: "—",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = palette.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(4.dp))
+            val meta = if (preview != null) {
+                val dist = "%,.0f %s".format(
+                    UnitFormatter.formatDistanceValue(preview.totalDistance, units, 0),
+                    UnitFormatter.getDistanceUnit(units)
+                )
+                val dur = formatDuration(LocalContext.current.resources, preview.totalDurationMin)
+                val day = parseIsoDateTime(preview.startDate)?.toLocalDate()
+                    ?.formatMediumNoYear(Locale.getDefault()) ?: ""
+                "$dist · $dur · $day"
+            } else {
+                "—"
+            }
+            Text(
+                text = meta,
+                style = MaterialTheme.typography.bodyMedium,
+                color = palette.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyCue(palette: CarColorPalette) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(palette.onSurface.copy(alpha = 0.04f))
+            .padding(vertical = 20.dp, horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.trip_create_empty),
+            style = MaterialTheme.typography.bodyMedium,
+            color = palette.onSurfaceVariant
+        )
+        GhostRow(CustomIcons.SteeringWheel, stringResource(R.string.nav_drives), palette)
+        GhostRow(Icons.Filled.ElectricBolt, stringResource(R.string.nav_charges), palette)
+    }
+}
+
+@Composable
+private fun GhostRow(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, palette: CarColorPalette) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = palette.onSurfaceVariant.copy(alpha = 0.35f)
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = palette.onSurfaceVariant.copy(alpha = 0.35f)
+        )
+    }
+}
+
+private sealed interface DraftEntry { val startDate: String }
+private data class DraftDrive(val drive: DriveSummary) : DraftEntry {
+    override val startDate get() = drive.startDate
+}
+private data class DraftCharge(val charge: ChargeSummary) : DraftEntry {
+    override val startDate get() = charge.startDate
+}
+
+@Composable
+private fun LegList(
+    drives: List<DriveSummary>,
+    charges: List<ChargeSummary>,
+    dcChargeIds: Set<Int>,
+    palette: CarColorPalette,
+    onRemove: (LegRef) -> Unit
+) {
+    val context = LocalContext.current
+    val entries = (drives.map { DraftDrive(it) } + charges.map { DraftCharge(it) })
+        .sortedBy { it.startDate }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (entry in entries) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(palette.onSurface.copy(alpha = 0.05f))
+                    .padding(start = 12.dp, top = 10.dp, bottom = 10.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                when (entry) {
+                    is DraftDrive -> {
+                        val d = entry.drive
+                        Icon(
+                            CustomIcons.SteeringWheel,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                            tint = palette.accent
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "${extractCity(d.startAddress)} → ${extractCity(d.endAddress)}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = palette.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = "%.1f km · %s".format(
+                                    d.distance,
+                                    formatDuration(context.resources, d.durationMin)
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = palette.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { onRemove(LegRef(SavedTripLeg.TYPE_DRIVE, d.driveId)) }) {
+                            Icon(
+                                Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.trip_create_remove),
+                                modifier = Modifier.size(18.dp),
+                                tint = palette.onSurfaceVariant
+                            )
+                        }
+                    }
+                    is DraftCharge -> {
+                        val c = entry.charge
+                        val isDc = c.chargeId in dcChargeIds
+                        val chip = if (isDc) palette.dcColor else palette.acColor
+                        Icon(
+                            Icons.Filled.ElectricBolt,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                            tint = chip
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = extractCity(c.address),
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = palette.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = "%s · +%.1f kWh · %s".format(
+                                    if (isDc) "DC" else "AC",
+                                    c.energyAdded,
+                                    formatDuration(context.resources, c.durationMin)
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = palette.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { onRemove(LegRef(SavedTripLeg.TYPE_CHARGE, c.chargeId)) }) {
+                            Icon(
+                                Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.trip_create_remove),
+                                modifier = Modifier.size(18.dp),
+                                tint = palette.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TripDatePicker(onConfirm: (LocalDate) -> Unit, onDismiss: () -> Unit) {
+    val state = rememberDatePickerState(
+        selectableDates = object : SelectableDates {
+            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                val todayUtc = LocalDate.now(ZoneId.systemDefault())
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant()
+                    .toEpochMilli()
+                return utcTimeMillis <= todayUtc
+            }
+        }
+    )
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                val millis = state.selectedDateMillis
+                if (millis != null) {
+                    onConfirm(Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate())
+                } else {
+                    onDismiss()
+                }
+            }) { Text(stringResource(R.string.ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    ) {
+        DatePicker(
+            state = state,
+            title = {
+                Text(
+                    text = stringResource(R.string.trip_create_pick_day),
+                    modifier = Modifier.padding(start = 24.dp, end = 12.dp, top = 16.dp)
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripViewModel.kt
@@ -93,7 +93,7 @@ class CreateTripViewModel @Inject constructor(
                     st.charges.flatMap { listOf(it.startDate, it.endDate) }
                 (dates.minOrNull() ?: return@launch) to (dates.maxOrNull() ?: return@launch)
             }
-            val eligible = tripRepository.getUnusedLegsAround(carId, anchorStart, anchorEnd)
+            val eligible = tripRepository.getUnusedLegsAround(carId, anchorStart, anchorEnd, windowDays = 1)
             val draftSet = st.draftLegs.toSet()
             val filtered = EligibleLegs(
                 drives = eligible.drives.filter { LegRef(SavedTripLeg.TYPE_DRIVE, it.driveId) !in draftSet },

--- a/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripViewModel.kt
@@ -1,0 +1,160 @@
+package com.matedroid.ui.screens.trips
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.data.local.entity.SavedTripLeg
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.EligibleLegs
+import com.matedroid.domain.LegRef
+import com.matedroid.domain.TripAggregator
+import com.matedroid.domain.TripRepository
+import com.matedroid.domain.model.Trip
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+data class CreateTripUiState(
+    val showDatePicker: Boolean = true,
+    val anchorStart: String? = null,
+    val anchorEnd: String? = null,
+    val draftLegs: List<LegRef> = emptyList(),
+    val drives: List<DriveSummary> = emptyList(),
+    val charges: List<ChargeSummary> = emptyList(),
+    val preview: Trip? = null,
+    val name: String = "",
+    val units: Units? = null,
+    val dcChargeIds: Set<Int> = emptySet(),
+    val showAddLegSheet: Boolean = false,
+    val eligibleLegs: EligibleLegs? = null,
+    val isSaving: Boolean = false,
+    val createdStartDate: String? = null
+)
+
+@HiltViewModel
+class CreateTripViewModel @Inject constructor(
+    private val tripRepository: TripRepository,
+    private val aggregateDao: AggregateDao,
+    private val repository: TeslamateRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CreateTripUiState())
+    val uiState: StateFlow<CreateTripUiState> = _uiState.asStateFlow()
+
+    private var carId: Int = -1
+    private var started = false
+
+    fun start(carId: Int) {
+        if (started) return
+        started = true
+        this.carId = carId
+        viewModelScope.launch {
+            val dcIds = try { aggregateDao.getDcChargeIds(carId).toSet() } catch (_: Exception) { emptySet() }
+            _uiState.update { it.copy(dcChargeIds = dcIds) }
+        }
+        viewModelScope.launch {
+            when (val result = repository.getCarStatus(carId)) {
+                is ApiResult.Success -> _uiState.update { it.copy(units = result.data.units) }
+                is ApiResult.Error -> {}
+            }
+        }
+    }
+
+    /** The user picked the trip's day → anchor the candidate window and open the leg picker. */
+    fun onDatePicked(date: LocalDate) {
+        _uiState.update {
+            it.copy(
+                showDatePicker = false,
+                anchorStart = date.atStartOfDay().toString(),
+                anchorEnd = date.atTime(23, 59, 59).toString()
+            )
+        }
+        openAddLegSheet()
+    }
+
+    fun openAddLegSheet() {
+        viewModelScope.launch {
+            val st = _uiState.value
+            val (anchorStart, anchorEnd) = if (st.draftLegs.isEmpty()) {
+                val s = st.anchorStart ?: return@launch
+                val e = st.anchorEnd ?: return@launch
+                s to e
+            } else {
+                val dates = st.drives.flatMap { listOf(it.startDate, it.endDate) } +
+                    st.charges.flatMap { listOf(it.startDate, it.endDate) }
+                (dates.minOrNull() ?: return@launch) to (dates.maxOrNull() ?: return@launch)
+            }
+            val eligible = tripRepository.getUnusedLegsAround(carId, anchorStart, anchorEnd)
+            val draftSet = st.draftLegs.toSet()
+            val filtered = EligibleLegs(
+                drives = eligible.drives.filter { LegRef(SavedTripLeg.TYPE_DRIVE, it.driveId) !in draftSet },
+                charges = eligible.charges.filter { LegRef(SavedTripLeg.TYPE_CHARGE, it.chargeId) !in draftSet }
+            )
+            _uiState.update { it.copy(showAddLegSheet = true, eligibleLegs = filtered) }
+        }
+    }
+
+    fun closeAddLegSheet() {
+        _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
+    }
+
+    fun pickLegs(refs: List<LegRef>) {
+        if (refs.isEmpty()) {
+            closeAddLegSheet()
+            return
+        }
+        viewModelScope.launch {
+            rebuild((_uiState.value.draftLegs + refs).distinct())
+            _uiState.update { it.copy(showAddLegSheet = false, eligibleLegs = null) }
+        }
+    }
+
+    fun removeLeg(ref: LegRef) {
+        viewModelScope.launch {
+            rebuild(_uiState.value.draftLegs.filterNot { it == ref })
+        }
+    }
+
+    fun setName(name: String) {
+        _uiState.update {
+            it.copy(
+                name = name,
+                preview = TripAggregator.buildTrip(it.drives, it.charges, name.trim().ifEmpty { null })
+            )
+        }
+    }
+
+    fun save() {
+        val st = _uiState.value
+        val startDate = st.preview?.startDate ?: return
+        if (st.isSaving) return
+        _uiState.update { it.copy(isSaving = true) }
+        viewModelScope.launch {
+            tripRepository.createTrip(carId, st.draftLegs, st.name.trim().ifEmpty { null })
+            _uiState.update { it.copy(isSaving = false, createdStartDate = startDate) }
+        }
+    }
+
+    private suspend fun rebuild(draft: List<LegRef>) {
+        val resolved = tripRepository.resolveLegs(carId, draft)
+        val drives = resolved.drives.sortedBy { it.startDate }
+        val charges = resolved.charges.sortedBy { it.startDate }
+        _uiState.update {
+            it.copy(
+                draftLegs = draft,
+                drives = drives,
+                charges = charges,
+                preview = TripAggregator.buildTrip(drives, charges, it.name.trim().ifEmpty { null })
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Schedule
@@ -85,6 +88,7 @@ fun TripsScreen(
     exteriorColor: String? = null,
     onNavigateBack: () -> Unit = {},
     onNavigateToTripDetail: (tripStartDate: String) -> Unit = {},
+    onNavigateToCreateTrip: () -> Unit = {},
     viewModel: TripsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -125,6 +129,18 @@ fun TripsScreen(
                     containerColor = MaterialTheme.colorScheme.primaryContainer
                 )
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onNavigateToCreateTrip,
+                containerColor = palette.accent,
+                contentColor = Color.White
+            ) {
+                Icon(
+                    Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.trip_create_cd)
+                )
+            }
         }
     ) { padding ->
         when {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -189,6 +189,13 @@ fun TripsScreen(
                             TripRuleRow(2, stringResource(R.string.trips_empty_rule_charge), palette)
                             TripRuleRow(3, stringResource(R.string.trips_empty_rule_distance), palette)
                         }
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Text(
+                            text = stringResource(R.string.trips_empty_create_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center
+                        )
                     }
                 }
             }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -158,6 +158,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">que sumin 300 km o més en total</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">Crea viatge</string>
+    <string name="trip_create_title">Nou viatge</string>
+    <string name="trip_create_pick_day">Tria el dia del viatge</string>
+    <string name="trip_create_name_hint">Nom del viatge (opcional)</string>
+    <string name="trip_create_add_legs">Afegeix trams</string>
+    <string name="trip_create_empty">Tria els trajectes i càrregues que formen aquest viatge</string>
+    <string name="trip_create_save">Desa</string>
+    <string name="trip_create_remove">Treu el tram</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Càrregues</string>
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -157,6 +157,8 @@
     <string name="trips_empty_rule_charge">connectats per almenys una parada de càrrega ràpida DC</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">que sumin 300 km o més en total</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">Espera que se\'n detecti un, o toca + per crear-ne un manualment.</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">Crea viatge</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -158,6 +158,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">mit insgesamt mindestens 300 km</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">Trip erstellen</string>
+    <string name="trip_create_title">Neuer Trip</string>
+    <string name="trip_create_pick_day">Tag des Trips wählen</string>
+    <string name="trip_create_name_hint">Trip-Name (optional)</string>
+    <string name="trip_create_add_legs">Etappen hinzufügen</string>
+    <string name="trip_create_empty">Wähle die Fahrten und Ladevorgänge dieses Trips</string>
+    <string name="trip_create_save">Speichern</string>
+    <string name="trip_create_remove">Etappe entfernen</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Ladevorgänge</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -157,6 +157,8 @@
     <string name="trips_empty_rule_charge">verbunden durch mindestens einen DC-Schnellladestopp</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">mit insgesamt mindestens 300 km</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">Warte, bis einer erkannt wird, oder tippe auf +, um selbst einen zu erstellen.</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">Trip erstellen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -157,6 +157,8 @@
     <string name="trips_empty_rule_charge">conectados por al menos una parada de carga rápida DC</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">que sumen 300 km o más en total</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">Espera a que se detecte uno, o toca + para crear uno manualmente.</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">Crear viaje</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -158,6 +158,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">que sumen 300 km o más en total</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">Crear viaje</string>
+    <string name="trip_create_title">Nuevo viaje</string>
+    <string name="trip_create_pick_day">Elige el día del viaje</string>
+    <string name="trip_create_name_hint">Nombre del viaje (opcional)</string>
+    <string name="trip_create_add_legs">Añadir tramos</string>
+    <string name="trip_create_empty">Elige los trayectos y cargas que forman este viaje</string>
+    <string name="trip_create_save">Guardar</string>
+    <string name="trip_create_remove">Quitar tramo</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Cargas</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -158,6 +158,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">per un totale di almeno 300 km</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">Crea viaggio</string>
+    <string name="trip_create_title">Nuovo viaggio</string>
+    <string name="trip_create_pick_day">Scegli il giorno del viaggio</string>
+    <string name="trip_create_name_hint">Nome del viaggio (facoltativo)</string>
+    <string name="trip_create_add_legs">Aggiungi tratte</string>
+    <string name="trip_create_empty">Scegli i tragitti e le ricariche che compongono questo viaggio</string>
+    <string name="trip_create_save">Salva</string>
+    <string name="trip_create_remove">Rimuovi tratta</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Ricariche</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -157,6 +157,8 @@
     <string name="trips_empty_rule_charge">collegati da almeno una sosta di ricarica rapida DC</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">per un totale di almeno 300 km</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">Aspetta che ne venga rilevato uno, o tocca + per crearne uno manualmente.</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">Crea viaggio</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -158,6 +158,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">总里程达到 300 km 或以上</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">创建行程</string>
+    <string name="trip_create_title">新建行程</string>
+    <string name="trip_create_pick_day">选择行程的日期</string>
+    <string name="trip_create_name_hint">行程名称（可选）</string>
+    <string name="trip_create_add_legs">添加路段</string>
+    <string name="trip_create_empty">选择构成此行程的驾驶和充电</string>
+    <string name="trip_create_save">保存</string>
+    <string name="trip_create_remove">移除路段</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">充电记录</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -157,6 +157,8 @@
     <string name="trips_empty_rule_charge">由至少一次 DC 快充停留连接</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">总里程达到 300 km 或以上</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">等待自动识别，或点按 + 手动创建一次行程。</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">创建行程</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,16 @@
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">covering 300 km or more in total</string>
 
+    <!-- Create-trip flow -->
+    <string name="trip_create_cd">Create trip</string>
+    <string name="trip_create_title">New trip</string>
+    <string name="trip_create_pick_day">Pick the trip\'s day</string>
+    <string name="trip_create_name_hint">Trip name (optional)</string>
+    <string name="trip_create_add_legs">Add legs</string>
+    <string name="trip_create_empty">Pick the drives and charges that make up this trip</string>
+    <string name="trip_create_save">Save</string>
+    <string name="trip_create_remove">Remove leg</string>
+
     <!-- Navigation button to charges list -->
     <string name="nav_charges">Charges</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="trips_empty_rule_charge">linked by at least one DC fast-charge stop</string>
     <!-- Trips list empty state: rule 3 -->
     <string name="trips_empty_rule_distance">covering 300 km or more in total</string>
+    <!-- Trips list empty state: closing note about the two ways to get a trip -->
+    <string name="trips_empty_create_hint">Wait for one to be detected, or tap + to build a trip yourself.</string>
 
     <!-- Create-trip flow -->
     <string name="trip_create_cd">Create trip</string>


### PR DESCRIPTION
Adds a UI to build a road-trip by hand, for when auto-detection misses one (or you want to group drives it wouldn't).

## Flow
1. **`+` FAB** on the Trips list → **date picker** ("Pick the trip's day").
2. The picked day anchors the candidate window; a multi-select **leg picker** (reused `AddLegSheet`, opened in multi-select) lists every **unused** drive *and* charge around that date.
3. A **live preview** (name · distance · duration · day) and a **unified chronological timeline** of the chosen legs build up as you add. **Add legs** re-opens the picker windowed around the current draft range — identical logic to the trip editor (`getEligibleNewLegs`), just anchored on the draft.
4. **Save** (enabled at ≥1 drive) persists a `USER_EDITED` `SavedTrip` and opens its detail.

## Implementation
- `TripRepository`: `getUnusedLegsAround(carId, anchorStart, anchorEnd, windowDays)`, `resolveLegs(...)`, `createTrip(carId, legs, name)` — all reuse existing window/used-leg helpers and `insertTripWithLegs`.
- New `CreateTripScreen` + `CreateTripViewModel`; `AddLegSheet` gains a `startInMultiSelect` flag.
- `CreateTrip` nav route; FAB on `TripsScreen`. `trip_create_*` strings in all 6 locales.
- Detection rules (≥2 drives / DC charge / 300 km) intentionally **do not** apply to manual creation; only **≥1 drive** is required. The picker only offers legs not already in another trip.

`lintDebug` ✅. (Couldn't install this round — my test phone rebooted off the fixed ADB port; verifying on device next.)

Merge with a merge commit (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)