### PR TITLE
Fix off-by-one in software version 'days installed'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tyre pressure moved into its own card** with a cleaner 2×2 grid — one tile per wheel with its pressure and an OK/low status dot.
 - **The empty Trips screen now explains itself**: when no road-trips have been detected, it lists how one is auto-generated (2+ drives in a row, linked by a DC fast-charge stop, totalling 300 km or more).
 
+### Fixed
+- **Software updates list showed each version's "days installed" off by one** — a version displayed the duration that actually belonged to the previous one. Each version now shows how long it was installed before the next update.
+
 ## [1.8.1] - 2026-06-07
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsViewModel.kt
@@ -126,10 +126,11 @@ class SoftwareVersionsViewModel @Inject constructor(
             allUpdates
         }
 
-        // Calculate days installed for each version
-        // The first item (index 0) is the current/newest version
-        // Days installed = next version's start date - this version's start date
-        // For current version: now - start date
+        // Calculate days installed for each version.
+        // The list is newest-first, so item index 0 is the current/newest version and the item
+        // at index-1 is the NEWER version that replaced the one at index.
+        // Days installed = (replacing version's start date) - (this version's start date).
+        // For the current version: now - start date.
         val items = filteredUpdates.mapIndexed { index, update ->
             val startDate = parseDate(update.startDate)
             val endDate = parseDate(update.endDate)
@@ -147,11 +148,12 @@ class SoftwareVersionsViewModel @Inject constructor(
             val daysInstalled: Long? = when {
                 startDate == null -> null
                 isCurrent -> Duration.between(startDate, LocalDateTime.now()).toDays()
-                index + 1 < filteredUpdates.size -> {
-                    // Get the next version's start date (which is when this version stopped being used)
-                    val nextVersionStartDate = parseDate(filteredUpdates[index + 1].startDate)
-                    if (nextVersionStartDate != null) {
-                        Duration.between(nextVersionStartDate, startDate).toDays()
+                index - 1 >= 0 -> {
+                    // The newer version that replaced this one is at index-1; this version was
+                    // installed from its own start until that replacing version's start.
+                    val replacedByStart = parseDate(filteredUpdates[index - 1].startDate)
+                    if (replacedByStart != null) {
+                        Duration.between(startDate, replacedByStart).toDays()
                     } else {
                         null
                     }


### PR DESCRIPTION
## Problem
On the Software updates list, each version showed a "days installed" value that actually belonged to the **previous** version.

## Cause
The list is newest-first (index 0 = current). "Days installed" for a version is `(start of the version that replaced it) − (its own start)`. The replacing version is at **index-1**, but the code used **index+1** (the *older* version) and computed `between(older.start, this.start)` — i.e. how long the older version was installed — and showed it on the wrong row.

## Fix
Measure the gap to the newer/replacing version at `index-1`: `between(this.start, replacedByStart)`. The current version (index 0) still uses `now − start`. This also corrects the "longest installed" highlight and the mean-days stat, which derive from the same value.

`lintDebug` ✅, installed on device. Merge with a merge commit (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)