### PR TITLE
Security hardening: backup exclusion, debug-only receiver, log redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Server credentials are no longer included in Android backups**: the API token and HTTP Basic Auth password are excluded from Google cloud backups and device-to-device transfers.
+- **The debug endpoint-switching receiver no longer exists in release builds** — it was already inert there, but is now only declared in debug builds.
+- **The Authorization header is redacted from debug HTTP logs.**
+
 ## [1.9.0-beta1] - 2026-06-09
 
 ### Added

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!-- Switch API endpoint via ADB broadcast (debug builds only) -->
+        <receiver
+            android:name=".receiver.DebugEndpointReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.matedroid.SET_ENDPOINT" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
     <application
         android:name=".MateDroidApp"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locale_config"
@@ -60,15 +62,6 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
-
-        <!-- Switch API endpoint via ADB broadcast (guarded by BuildConfig.DEBUG in code) -->
-        <receiver
-            android:name=".receiver.DebugEndpointReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.matedroid.SET_ENDPOINT" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -192,6 +192,8 @@ class TeslamateApiFactory(
         if (BuildConfig.DEBUG) {
             val loggingInterceptor = HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.HEADERS
+                // Keep credentials (Bearer token / Basic auth) out of logcat
+                redactHeader("Authorization")
             }
             builder.addInterceptor(loggingInterceptor)
         }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Exclude the settings DataStore (API token, HTTP Basic Auth credentials)
+    from auto backup on API 28-30 (pre dataExtractionRules).
+-->
+<full-backup-content>
+    <exclude
+        domain="file"
+        path="datastore/matedroid_settings.preferences_pb" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Exclude the settings DataStore (API token, HTTP Basic Auth credentials)
+    from cloud backups and device-to-device transfers (API 31+).
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude
+            domain="file"
+            path="datastore/matedroid_settings.preferences_pb" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="file"
+            path="datastore/matedroid_settings.preferences_pb" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

Three small security hardening fixes from the codebase security review:

1. **Credentials excluded from Android backups.** The API token and HTTP Basic Auth password live in the `matedroid_settings` DataStore, which until now was included in Google cloud backups and device-to-device transfers (`allowBackup=\"true\"` with no rules). New `data_extraction_rules.xml` (API 31+) and `backup_rules.xml` (API 28–30) exclude that file. Side effect: server settings won't be restored on a new device — the user re-enters them once.

2. **`DebugEndpointReceiver` removed from release builds.** It was declared `exported=\"true\"` in the main manifest for all builds, relying only on a runtime `BuildConfig.DEBUG` check. The declaration now lives in `src/debug/AndroidManifest.xml`, so the component doesn't exist at all in release APKs. Verified via the merged release manifest (0 occurrences) and debug manifest (present).

3. **`Authorization` header redacted from debug HTTP logs.** `HttpLoggingInterceptor` at `HEADERS` level was printing the Bearer token / Basic auth credentials to logcat in debug builds.

No behavior change for release users beyond the backup exclusion.

## Test plan
- `./gradlew lintDebug assembleRelease` passes
- Merged release manifest verified: no debug receiver, backup attributes present
- ADB endpoint switching still works on debug builds (receiver declared in debug manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)