### PR TITLE
Performance: widget background bitmap cache + suspend API factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The home-screen widget re-renders its background image only when the car's appearance or charging state changes**, instead of on every update — less memory churn and battery use, especially while charging.
+
 ### Security
 - **Server credentials are no longer included in Android backups**: the API token and HTTP Basic Auth password are excluded from Google cloud backups and device-to-device transfers.
 - **The debug endpoint-switching receiver no longer exists in release builds** — it was already inert there, but is now only declared in debug builds.

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -94,7 +94,7 @@ class TeslamateRepository @Inject constructor(
 
     private suspend fun getSettings(): AppSettings = settingsDataStore.settings.first()
 
-    private fun getApiForUrl(url: String): TeslamateApi? {
+    private suspend fun getApiForUrl(url: String): TeslamateApi? {
         if (url.isBlank()) return null
         return apiFactory.create(url)
     }

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -12,7 +12,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -121,9 +120,9 @@ class TeslamateApiFactory(
      * @param acceptInvalidCerts Override for accepting invalid certificates. If null, uses the setting from DataStore.
      * @return A TeslamateApi instance configured for the given URL
      */
-    fun create(baseUrl: String, acceptInvalidCerts: Boolean? = null): TeslamateApi {
+    suspend fun create(baseUrl: String, acceptInvalidCerts: Boolean? = null): TeslamateApi {
         val normalizedUrl = baseUrl.trimEnd('/') + "/"
-        val settings = runBlocking { settingsDataStore.settings.first() }
+        val settings = settingsDataStore.settings.first()
         val useInsecure = acceptInvalidCerts ?: settings.acceptInvalidCerts
         val apiToken = settings.apiToken
         val basicAuthUsername = settings.httpBasicAuthUsername

--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -240,7 +240,21 @@ class CarWidget : GlanceAppWidget() {
                             val stateIsCharging = stateLower == "charging"
 
                             // -- Background bitmap (car + glow + scrim only) --
-                            val bgBitmap = buildBackgroundBitmap(ctx, prefs)
+                            // Cached by appearance + charge state: battery ticks and
+                            // text changes reuse the previously rendered bitmap.
+                            val bgKey = WidgetBackgroundCache.Key(
+                                exteriorColor = exteriorColor,
+                                model = prefs[MODEL_KEY],
+                                trimBadging = prefs[TRIM_BADGING_KEY],
+                                wheelType = prefs[WHEEL_TYPE_KEY],
+                                overrideVariant = prefs[IMAGE_OVERRIDE_VARIANT_KEY],
+                                overrideWheel = prefs[IMAGE_OVERRIDE_WHEEL_KEY],
+                                isCharging = isCharging,
+                                isDcCharging = isDcCharging
+                            )
+                            val bgBitmap = WidgetBackgroundCache.getOrCreate(ctx, bgKey) {
+                                buildBackgroundBitmap(ctx, prefs)
+                            }
                             Image(
                                 provider = ImageProvider(bgBitmap),
                                 contentDescription = null,

--- a/app/src/main/java/com/matedroid/widget/WidgetBackgroundCache.kt
+++ b/app/src/main/java/com/matedroid/widget/WidgetBackgroundCache.kt
@@ -1,0 +1,86 @@
+package com.matedroid.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.File
+import java.security.MessageDigest
+import java.util.Locale
+
+/**
+ * Two-level cache (memory + disk) for the widget background bitmap.
+ *
+ * Generating the background is expensive while charging (three blurred glow
+ * layers + rim light, ~8-20 MB of transient bitmap allocations), but its
+ * content depends only on the car's appearance and charging state — not on
+ * battery level, widget size or any text. Caching by that key lets most
+ * widget updates (battery ticks, lock state, location) reuse the previous
+ * bitmap instead of re-rendering it.
+ *
+ * The disk layer keeps cache hits across process death between the periodic
+ * widget update jobs.
+ */
+object WidgetBackgroundCache {
+
+    /** Bump to invalidate disk entries whenever the background rendering changes. */
+    private const val CACHE_VERSION = 1
+    private const val MAX_MEMORY_ENTRIES = 3
+    private const val MAX_DISK_ENTRIES = 6
+    private const val DIR_NAME = "widget_bg"
+
+    data class Key(
+        val exteriorColor: String?,
+        val model: String?,
+        val trimBadging: String?,
+        val wheelType: String?,
+        val overrideVariant: String?,
+        val overrideWheel: String?,
+        val isCharging: Boolean,
+        val isDcCharging: Boolean
+    )
+
+    private val memoryCache = object : LinkedHashMap<Key, Bitmap>(MAX_MEMORY_ENTRIES, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Key, Bitmap>): Boolean =
+            size > MAX_MEMORY_ENTRIES
+    }
+
+    @Synchronized
+    fun getOrCreate(context: Context, key: Key, builder: () -> Bitmap): Bitmap {
+        memoryCache[key]?.let { return it }
+
+        val file = diskFile(context, key)
+        if (file.exists()) {
+            BitmapFactory.decodeFile(file.absolutePath)?.let { decoded ->
+                memoryCache[key] = decoded
+                return decoded
+            }
+        }
+
+        val bitmap = builder()
+        memoryCache[key] = bitmap
+        runCatching {
+            file.parentFile?.mkdirs()
+            file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            file.parentFile?.let(::trimDisk)
+        }
+        return bitmap
+    }
+
+    private fun diskFile(context: Context, key: Key): File {
+        val raw = listOf(
+            CACHE_VERSION, key.exteriorColor, key.model, key.trimBadging, key.wheelType,
+            key.overrideVariant, key.overrideWheel, key.isCharging, key.isDcCharging
+        ).joinToString("|")
+        val digest = MessageDigest.getInstance("MD5").digest(raw.toByteArray())
+        val name = digest.joinToString("") { String.format(Locale.ROOT, "%02x", it) }
+        return File(File(context.cacheDir, DIR_NAME), "$name.png")
+    }
+
+    private fun trimDisk(dir: File) {
+        val files = dir.listFiles() ?: return
+        if (files.size <= MAX_DISK_ENTRIES) return
+        files.sortedBy { it.lastModified() }
+            .take(files.size - MAX_DISK_ENTRIES)
+            .forEach { it.delete() }
+    }
+}


### PR DESCRIPTION
## Summary

Two performance fixes from the codebase review:

1. **Widget background bitmap cache.** The widget background (car image + glow layers + scrim) was re-rendered on every widget update (~every 3 minutes), allocating 8–20 MB of transient bitmaps while charging (three blurred glow layers + rim light). The background's content only depends on the car's appearance (model, color, wheels, image override) and AC/DC charging state — not battery level, size or text — so it is now cached by that key in a new `WidgetBackgroundCache`: a 3-entry in-memory LRU plus a small disk cache (PNG in `cacheDir/widget_bg/`, max 6 files) that survives process death between update jobs. Typical updates (battery ticks, lock state, location) now reuse the rendered bitmap; a fresh render happens only when charging starts/stops or the car's look changes.

2. **`TeslamateApiFactory.create()` no longer blocks a thread.** It used `runBlocking { settingsDataStore.settings.first() }` — the only blocking call in the app. It's now a `suspend` function; both call sites (`TeslamateRepository.getApiForUrl`, `testConnection`) were already suspend.

No functional changes — the widget renders pixel-identical output.

## Test plan
- `./gradlew lintDebug testDebugUnitTest` passes
- Cache key covers every input read by `buildBackgroundBitmap`, so a stale hit is impossible by construction; `CACHE_VERSION` constant busts disk entries if the rendering code changes later

🤖 Generated with [Claude Code](https://claude.com/claude-code)