### PR TITLE
Clarify that 'Add leg' buttons also add charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **The "Add leg" buttons on the trip detail and new-trip screens now say "Add leg or charge"** in every language — the old wording didn't make it obvious that charges can be added too. The button labels shrink automatically if the translation needs more room.
 - **The home-screen widget re-renders its background image only when the car's appearance or charging state changes**, instead of on every update — less memory churn and battery use, especially while charging.
 
 ### Security

--- a/app/src/main/java/com/matedroid/ui/components/TripEditActions.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripEditActions.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Merge
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -16,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.matedroid.R
 
 /** Row of two 50/50 outlined buttons: Add leg + Merge trip. Shown below the legs list. */
@@ -35,7 +37,7 @@ fun TripEditActions(
         ) {
             Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.trip_edit_add_leg))
+            ButtonLabel(stringResource(R.string.trip_edit_add_leg))
         }
         OutlinedButton(
             onClick = onMergeTrip,
@@ -43,7 +45,17 @@ fun TripEditActions(
         ) {
             Icon(Icons.Filled.Merge, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.trip_edit_merge_trip))
+            ButtonLabel(stringResource(R.string.trip_edit_merge_trip))
         }
     }
+}
+
+/** Single-line label that shrinks to fit the space left by the icon in a 50%-width button. */
+@Composable
+private fun ButtonLabel(text: String) {
+    Text(
+        text = text,
+        maxLines = 1,
+        autoSize = TextAutoSize.StepBased(minFontSize = 9.sp, maxFontSize = 14.sp, stepSize = 0.5.sp)
+    )
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -165,7 +165,7 @@
     <string name="trip_create_title">Nou viatge</string>
     <string name="trip_create_pick_day">Tria el dia del viatge</string>
     <string name="trip_create_name_hint">Nom del viatge (opcional)</string>
-    <string name="trip_create_add_legs">Afegeix trams</string>
+    <string name="trip_create_add_legs">Afegeix trams o càrregues</string>
     <string name="trip_create_empty">Tria els trajectes i càrregues que formen aquest viatge</string>
     <string name="trip_create_save">Desa</string>
     <string name="trip_create_remove">Treu el tram</string>
@@ -1109,7 +1109,7 @@
     <string name="trip_timeline_charging_ac">Càrrega AC</string>
     <string name="trip_timeline_parked">Aparcat</string>
 
-    <string name="trip_edit_add_leg">Afegeix tram</string>
+    <string name="trip_edit_add_leg">Afegeix tram o càrrega</string>
     <string name="trip_edit_merge_trip">Uneix viatge</string>
     <string name="trip_edit_add_leg_title">Afegeix a aquest viatge</string>
     <string name="trip_edit_add_leg_empty">No hi ha trajectes o càrregues properes</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,7 +165,7 @@
     <string name="trip_create_title">Neuer Trip</string>
     <string name="trip_create_pick_day">Tag des Trips wählen</string>
     <string name="trip_create_name_hint">Trip-Name (optional)</string>
-    <string name="trip_create_add_legs">Etappen hinzufügen</string>
+    <string name="trip_create_add_legs">Etappen/Ladevorgänge hinzufügen</string>
     <string name="trip_create_empty">Wähle die Fahrten und Ladevorgänge dieses Trips</string>
     <string name="trip_create_save">Speichern</string>
     <string name="trip_create_remove">Etappe entfernen</string>
@@ -1149,7 +1149,7 @@
     <string name="trip_timeline_parked">Geparkt</string>
 
     <!-- Button label: opens a bottom sheet to add a drive or charge to this trip -->
-    <string name="trip_edit_add_leg">Etappe hinzufügen</string>
+    <string name="trip_edit_add_leg">Etappe/Ladevorgang hinzufügen</string>
 
     <!-- Button label: opens a bottom sheet to merge another trip into this one -->
     <string name="trip_edit_merge_trip">Trip zusammenführen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -165,7 +165,7 @@
     <string name="trip_create_title">Nuevo viaje</string>
     <string name="trip_create_pick_day">Elige el día del viaje</string>
     <string name="trip_create_name_hint">Nombre del viaje (opcional)</string>
-    <string name="trip_create_add_legs">Añadir tramos</string>
+    <string name="trip_create_add_legs">Añadir tramos o cargas</string>
     <string name="trip_create_empty">Elige los trayectos y cargas que forman este viaje</string>
     <string name="trip_create_save">Guardar</string>
     <string name="trip_create_remove">Quitar tramo</string>
@@ -1109,7 +1109,7 @@
     <string name="trip_timeline_charging_ac">Carga AC</string>
     <string name="trip_timeline_parked">Estacionado</string>
 
-    <string name="trip_edit_add_leg">Añadir tramo</string>
+    <string name="trip_edit_add_leg">Añadir tramo o carga</string>
     <string name="trip_edit_merge_trip">Combinar viaje</string>
     <string name="trip_edit_add_leg_title">Añadir a este viaje</string>
     <string name="trip_edit_add_leg_empty">Sin trayectos o cargas cercanos</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,7 +165,7 @@
     <string name="trip_create_title">Nuovo viaggio</string>
     <string name="trip_create_pick_day">Scegli il giorno del viaggio</string>
     <string name="trip_create_name_hint">Nome del viaggio (facoltativo)</string>
-    <string name="trip_create_add_legs">Aggiungi tratte</string>
+    <string name="trip_create_add_legs">Aggiungi tratte o ricariche</string>
     <string name="trip_create_empty">Scegli i tragitti e le ricariche che compongono questo viaggio</string>
     <string name="trip_create_save">Salva</string>
     <string name="trip_create_remove">Rimuovi tratta</string>
@@ -1109,7 +1109,7 @@
     <string name="trip_timeline_charging_ac">Ricarica AC</string>
     <string name="trip_timeline_parked">In sosta</string>
 
-    <string name="trip_edit_add_leg">Aggiungi tratta</string>
+    <string name="trip_edit_add_leg">Aggiungi tratta o ricarica</string>
     <string name="trip_edit_merge_trip">Unisci viaggio</string>
     <string name="trip_edit_add_leg_title">Aggiungi a questo viaggio</string>
     <string name="trip_edit_add_leg_empty">Nessuna tratta o ricarica nelle vicinanze</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -165,7 +165,7 @@
     <string name="trip_create_title">新建行程</string>
     <string name="trip_create_pick_day">选择行程的日期</string>
     <string name="trip_create_name_hint">行程名称（可选）</string>
-    <string name="trip_create_add_legs">添加路段</string>
+    <string name="trip_create_add_legs">添加路段或充电</string>
     <string name="trip_create_empty">选择构成此行程的驾驶和充电</string>
     <string name="trip_create_save">保存</string>
     <string name="trip_create_remove">移除路段</string>
@@ -1110,7 +1110,7 @@
     <string name="trip_timeline_charging_ac">AC 充电</string>
     <string name="trip_timeline_parked">已停车</string>
 
-    <string name="trip_edit_add_leg">添加旅程段</string>
+    <string name="trip_edit_add_leg">添加旅程段或充电</string>
     <string name="trip_edit_merge_trip">合并旅程</string>
     <string name="trip_edit_add_leg_title">添加到此旅程</string>
     <string name="trip_edit_add_leg_empty">附近没有驾驶或充电记录</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="trip_create_title">New trip</string>
     <string name="trip_create_pick_day">Pick the trip\'s day</string>
     <string name="trip_create_name_hint">Trip name (optional)</string>
-    <string name="trip_create_add_legs">Add legs</string>
+    <string name="trip_create_add_legs">Add legs or charges</string>
     <string name="trip_create_empty">Pick the drives and charges that make up this trip</string>
     <string name="trip_create_save">Save</string>
     <string name="trip_create_remove">Remove leg</string>
@@ -1152,7 +1152,7 @@
     <string name="trip_timeline_parked">Parked</string>
 
     <!-- Button label: opens a bottom sheet to add a drive or charge to this trip -->
-    <string name="trip_edit_add_leg">Add leg</string>
+    <string name="trip_edit_add_leg">Add leg or charge</string>
 
     <!-- Button label: opens a bottom sheet to merge another trip into this one -->
     <string name="trip_edit_merge_trip">Merge trip</string>


### PR DESCRIPTION
## Summary

- `trip_edit_add_leg` (trip detail) and `trip_create_add_legs` (new trip) now mention both legs and charges in all 6 locales (en, it, es, ca, de, zh) — the bottom sheet they open has always offered both, but only the English "leg" loosely implies charges.
- The two 50/50 buttons in `TripEditActions` now auto-size their labels (`TextAutoSize.StepBased`, 9–14sp, single line) so the longer wording adapts to the available width on any screen size / font scale.

## Test plan
- `./gradlew lintDebug` passes (includes compile + hardcoded-text checks)
- Visual check on device of the trip detail screen in a couple of locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)