### PR TITLE
Fix voltage/current graph tooltip showing only the time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The voltage & current graph tooltip now shows the values again** — on charges longer than ~12 minutes it only showed the time (and near the start of the chart it could show values from the wrong moment).
+
 ## [1.9.0-beta2] - 2026-06-10
 
 ### Changed

--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -78,7 +78,10 @@ fun DualAxisLineChart(
     val chartHeightPx = with(density) { chartHeight.toPx() }
     var canvasWidthPx by remember { mutableStateOf(0f) }
 
-    val dataSize = maxOf(dataLeft.size, dataRight.size)
+    // Selection works in display-space: the rendered curves use the downsampled
+    // points, so tap indices must index those too. Raw indices past
+    // MAX_DISPLAY_POINTS would look up nothing and leave the tooltip valueless.
+    val dataSize = maxOf(chartDataLeft.displayPoints.size, chartDataRight.displayPoints.size)
     val rightLabelWidth = 70f
 
     // Pre-compute smooth paths
@@ -117,14 +120,15 @@ fun DualAxisLineChart(
         val cWidth = canvasWidthPx - rightLabelWidth
         val stepX = cWidth / (dataSize - 1).coerceAtLeast(1)
         val pointX = index * stepX
-        val leftVal = chartDataLeft.displayPoints.getOrNull(index)
+        val fraction = if (dataSize > 1) index.toFloat() / (dataSize - 1) else 0f
+        val leftVal = valueAtFraction(chartDataLeft.displayPoints, fraction)
         val leftY = if (leftVal != null) {
             chartHeightPx * (1 - (leftVal - chartDataLeft.minValue) / chartDataLeft.range)
         } else chartHeightPx / 2
         DualSelectedPoint(
             index = index,
             valueLeft = leftVal,
-            valueRight = chartDataRight.displayPoints.getOrNull(index),
+            valueRight = valueAtFraction(chartDataRight.displayPoints, fraction),
             position = Offset(pointX, leftY)
         )
     }
@@ -157,8 +161,8 @@ fun DualAxisLineChart(
                         val index = ((xOffset / stepX).roundToInt()).coerceIn(0, dataSize - 1)
                         val fraction = if (dataSize > 1) index.toFloat() / (dataSize - 1) else 0f
                         val pointX = index * stepX
-                        val leftVal = chartDataLeft.displayPoints.getOrNull(index)
-                        val rightVal = chartDataRight.displayPoints.getOrNull(index)
+                        val leftVal = valueAtFraction(chartDataLeft.displayPoints, fraction)
+                        val rightVal = valueAtFraction(chartDataRight.displayPoints, fraction)
                         val leftY = if (leftVal != null) {
                             chartHeightPx * (1 - (leftVal - chartDataLeft.minValue) / chartDataLeft.range)
                         } else yOffset
@@ -332,4 +336,14 @@ fun DualAxisLineChart(
             }
         }
     }
+}
+
+/**
+ * Looks up the display point nearest to [fraction] (0..1 across the X axis).
+ * The two series may downsample to different lengths, so each is sampled by
+ * fraction rather than by a shared index.
+ */
+private fun valueAtFraction(points: List<Float>, fraction: Float): Float? {
+    if (points.isEmpty()) return null
+    return points.getOrNull((fraction * (points.size - 1)).roundToInt())
 }


### PR DESCRIPTION
## Summary

On the Current Charge screen's voltage & current graph, tapping showed a tooltip with only the time — no V/A values — on any charge longer than ~12 minutes.

`DualAxisLineChart` computed the selection index against the **raw** series size (`maxOf(dataLeft.size, dataRight.size)`, thousands of points on a long charge) but looked the values up in the **downsampled** `displayPoints` (LTTB-capped at 150). Taps past raw index 149 found `null` → the tooltip's value rows (conditional on non-null) never rendered. Taps near the left edge were worse: a raw index < 150 silently indexed the wrong downsampled point, showing values from the start of the charge.

Fix: selection now works in display-space, mirroring `OptimizedLineChart`, and each series is sampled by X-fraction (the two series can downsample to different lengths). Crosshair, glow indicators and the external-selection sync all use the same display-space index.

## Test plan
- `./gradlew lintDebug` passes
- Root cause confirmed by code comparison with the working `OptimizedLineChart` selection logic
- On-device check against the in-progress AC charge: pending (build installed on the test device; reporter verifying on the live charge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)