### PR TITLE
Fix slow first load of the Current Charge screen at charge start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Opening the live charge view right after plugging in no longer takes forever**: while TeslaMate hasn't published the new charge yet, the screen now shows a "charge starting" indicator and checks every few seconds instead of silently giving up — the live view appears as soon as the data exists.
+- **A momentary connection problem no longer closes the live charge view** — it shows an error and keeps retrying instead of pretending the car stopped charging.
 - **The voltage & current graph tooltip now shows the values again** — on charges longer than ~12 minutes it only showed the time (and near the start of the chart it could show values from the wrong moment).
 
 ## [1.9.0-beta2] - 2026-06-10

--- a/app/src/main/java/com/matedroid/data/api/models/ChargeModels.kt
+++ b/app/src/main/java/com/matedroid/data/api/models/ChargeModels.kt
@@ -54,7 +54,10 @@ data class ChargeRange(
 
 @JsonClass(generateAdapter = true)
 data class ChargeDetailResponse(
-    @Json(name = "data") val data: ChargeDetailData? = null
+    @Json(name = "data") val data: ChargeDetailData? = null,
+    // TeslamateAPI returns HTTP 200 with this error field (and no data) when
+    // there is no active charge, e.g. "No active charging in progress."
+    @Json(name = "error") val error: String? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -40,6 +40,15 @@ data class CarStatusWithUnits(
 )
 
 /**
+ * Typed outcome of the current-charge endpoint: the server answering
+ * "no active charge" is an authoritative response, distinct from errors.
+ */
+sealed class CurrentChargeOutcome {
+    data class Active(val detail: ChargeDetail) : CurrentChargeOutcome()
+    data object NoActiveCharge : CurrentChargeOutcome()
+}
+
+/**
  * Represents exceptions that should trigger a fallback to the secondary server.
  * These are network-level errors where the server is unreachable, not application-level errors.
  */
@@ -285,16 +294,21 @@ class TeslamateRepository @Inject constructor(
         }
     }
 
-    suspend fun getCurrentCharge(carId: Int): ApiResult<ChargeDetail> {
+    suspend fun getCurrentCharge(carId: Int): ApiResult<CurrentChargeOutcome> {
         return executeWithFallback { api ->
             try {
                 val response = api.getCurrentCharge(carId)
                 if (response.isSuccessful) {
-                    val detail = response.body()?.data?.charge
-                    if (detail != null) {
-                        ApiResult.Success(detail)
-                    } else {
-                        ApiResult.Error("No current charge data returned")
+                    val body = response.body()
+                    val detail = body?.data?.charge
+                    when {
+                        detail != null -> ApiResult.Success(CurrentChargeOutcome.Active(detail))
+                        // TeslamateAPI answers 200 + {"error": "..."} (or 204) when there is
+                        // no active charge — an authoritative answer, not a failure. At charge
+                        // start this is returned for a short while before the charge appears.
+                        body?.error != null || response.code() == 204 ->
+                            ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+                        else -> ApiResult.Error("No current charge data returned")
                     }
                 } else {
                     ApiResult.Error("Failed to fetch current charge: ${response.code()}", response.code())

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -143,6 +143,22 @@ fun CurrentChargeScreen(
             uiState.isLoading -> {
                 MateDroidLoadingPlaceholder(modifier = Modifier.padding(padding))
             }
+            uiState.isChargeStarting && uiState.chargeDetail == null -> {
+                // Car is charging but TeslaMate hasn't published the charge yet —
+                // the ViewModel is polling fast; tell the user instead of bouncing out.
+                Box(modifier = Modifier.padding(padding)) {
+                    MateDroidLoadingPlaceholder()
+                    Text(
+                        text = stringResource(R.string.current_charge_starting),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(horizontal = 32.dp, vertical = 96.dp)
+                    )
+                }
+            }
             uiState.isUnsupportedApi -> {
                 FallbackMessage(
                     message = stringResource(R.string.current_charge_unsupported),

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeViewModel.kt
@@ -7,9 +7,12 @@ import com.matedroid.data.api.models.ChargePoint
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.CurrentChargeOutcome
 import com.matedroid.data.repository.TeslamateRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +30,8 @@ data class CurrentChargeUiState(
     val isDcCharge: Boolean = false,
     val isUnsupportedApi: Boolean = false,
     val isNotCharging: Boolean = false,
+    /** Car status reports charging but the charge isn't in the API yet (TeslaMate DB lag at charge start). */
+    val isChargeStarting: Boolean = false,
     val isDcFinishedPluggedIn: Boolean = false,
     val dcFinishedSince: String? = null,
     val timeToFullCharge: Double? = null,
@@ -43,6 +48,9 @@ class CurrentChargeViewModel @Inject constructor(
 
     companion object {
         private const val REFRESH_INTERVAL_MS = 30_000L
+
+        /** Poll quickly while waiting for a just-started charge to appear in the API. */
+        private const val CHARGE_STARTING_REFRESH_INTERVAL_MS = 4_000L
     }
 
     private val _uiState = MutableStateFlow(CurrentChargeUiState())
@@ -61,7 +69,12 @@ class CurrentChargeViewModel @Inject constructor(
         refreshJob = viewModelScope.launch {
             while (true) {
                 fetchData()
-                delay(REFRESH_INTERVAL_MS)
+                val interval = if (_uiState.value.isChargeStarting) {
+                    CHARGE_STARTING_REFRESH_INTERVAL_MS
+                } else {
+                    REFRESH_INTERVAL_MS
+                }
+                delay(interval)
             }
         }
     }
@@ -74,8 +87,11 @@ class CurrentChargeViewModel @Inject constructor(
         }
 
         // Fetch current charge and car status concurrently
-        val chargeResult = repository.getCurrentCharge(carId)
-        val statusResult = repository.getCarStatus(carId)
+        val (chargeResult, statusResult) = coroutineScope {
+            val charge = async { repository.getCurrentCharge(carId) }
+            val status = async { repository.getCarStatus(carId) }
+            charge.await() to status.await()
+        }
 
         val units = when (statusResult) {
             is ApiResult.Success -> statusResult.data.units
@@ -108,32 +124,76 @@ class CurrentChargeViewModel @Inject constructor(
         val stateSince = status?.stateSince
 
         when (chargeResult) {
-            is ApiResult.Success -> {
-                val detail = chargeResult.data
+            is ApiResult.Success -> when (val outcome = chargeResult.data) {
+                is CurrentChargeOutcome.Active -> {
+                    val detail = outcome.detail
 
-                // API returns charge_details sorted newest-first; reverse to chronological
-                val chronoPoints = detail.chargePoints?.reversed() ?: emptyList()
-                val detailWithChronoPoints = detail.copy(chargePoints = chronoPoints)
+                    // API returns charge_details sorted newest-first; reverse to chronological
+                    val chronoPoints = detail.chargePoints?.reversed() ?: emptyList()
+                    val detailWithChronoPoints = detail.copy(chargePoints = chronoPoints)
 
-                val stats = ChargeStatsCalculator.calculateStats(detailWithChronoPoints)
-                val isDcCharge = isDcChargeFromStatus ?: ChargeStatsCalculator.detectDcCharge(detailWithChronoPoints)
+                    val stats = ChargeStatsCalculator.calculateStats(detailWithChronoPoints)
+                    val isDcCharge = isDcChargeFromStatus ?: ChargeStatsCalculator.detectDcCharge(detailWithChronoPoints)
 
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        chargeDetail = detailWithChronoPoints,
-                        units = units,
-                        stats = stats,
-                        isDcCharge = isDcCharge,
-                        isUnsupportedApi = false,
-                        isNotCharging = detail.isCharging == false && !isDcFinishedPluggedIn,
-                        isDcFinishedPluggedIn = isDcFinishedPluggedIn,
-                        dcFinishedSince = if (isDcFinishedPluggedIn) stateSince else null,
-                        timeToFullCharge = timeToFullCharge,
-                        chargeLimitSoc = chargeLimitSoc,
-                        chronologicalPoints = chronoPoints,
-                        error = null
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isChargeStarting = false,
+                            chargeDetail = detailWithChronoPoints,
+                            units = units,
+                            stats = stats,
+                            isDcCharge = isDcCharge,
+                            isUnsupportedApi = false,
+                            isNotCharging = detail.isCharging == false && !isDcFinishedPluggedIn,
+                            isDcFinishedPluggedIn = isDcFinishedPluggedIn,
+                            dcFinishedSince = if (isDcFinishedPluggedIn) stateSince else null,
+                            timeToFullCharge = timeToFullCharge,
+                            chargeLimitSoc = chargeLimitSoc,
+                            chronologicalPoints = chronoPoints,
+                            error = null
+                        )
+                    }
+                }
+                CurrentChargeOutcome.NoActiveCharge -> when {
+                    status?.isCharging == true -> {
+                        // The car is charging but TeslaMate hasn't materialized the charge
+                        // in the API yet (happens for the first moments of every session).
+                        // Show the "charge starting" state and let the loop poll fast.
+                        _uiState.update {
+                            it.copy(isLoading = false, isChargeStarting = true, error = null)
+                        }
+                    }
+                    isDcFinishedPluggedIn -> {
+                        // DC charge finished but still plugged — keep showing last data with warning
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                isChargeStarting = false,
+                                isNotCharging = false,
+                                isDcFinishedPluggedIn = true,
+                                dcFinishedSince = stateSince,
+                                error = null
+                            )
+                        }
+                        // Keep refresh loop running to detect unplug
+                    }
+                    status == null -> {
+                        // No status to corroborate (its fetch failed). Don't kick the user
+                        // out on a one-off failure — leave the state as is and poll again.
+                    }
+                    else -> {
+                        // Status confirms: charging has stopped and cable unplugged
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                isChargeStarting = false,
+                                isNotCharging = true,
+                                isDcFinishedPluggedIn = false,
+                                error = null
+                            )
+                        }
+                        refreshJob?.cancel()
+                    }
                 }
             }
             is ApiResult.Error -> {
@@ -144,28 +204,9 @@ class CurrentChargeViewModel @Inject constructor(
                         }
                         refreshJob?.cancel()
                     }
-                    null -> {
-                        if (isDcFinishedPluggedIn) {
-                            // DC charge finished but still plugged — keep showing last data with warning
-                            _uiState.update {
-                                it.copy(
-                                    isLoading = false,
-                                    isNotCharging = false,
-                                    isDcFinishedPluggedIn = true,
-                                    dcFinishedSince = stateSince,
-                                    error = null
-                                )
-                            }
-                            // Keep refresh loop running to detect unplug
-                        } else {
-                            // Charging has stopped and cable unplugged
-                            _uiState.update {
-                                it.copy(isLoading = false, isNotCharging = true, isDcFinishedPluggedIn = false, error = null)
-                            }
-                            refreshJob?.cancel()
-                        }
-                    }
                     else -> {
+                        // Network problem or server error — never treat as "not charging".
+                        // Show the error, keep any data on screen and keep polling.
                         _uiState.update {
                             it.copy(isLoading = false, error = chargeResult.message)
                         }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1181,6 +1181,7 @@
     <string name="current_charge_unsupported">La monitorització de càrrega en curs requereix TeslaMate API 1.24 o superior</string>
     <!-- Mostrat quan el cotxe no està carregant actualment -->
     <string name="current_charge_not_charging">El cotxe no està carregant actualment</string>
+    <string name="current_charge_starting">Càrrega iniciant-se — esperant les primeres dades…</string>
     <!-- Títol del gràfic de voltatge i corrent de doble eix -->
     <string name="voltage_and_current_profile">Voltatge &amp; Corrent</string>
     <!-- Etiquetes SoC per a la fila de 3 columnes a la capçalera de càrrega en temps real -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1268,6 +1268,7 @@
     <string name="current_charge_unsupported">Die aktuelle Ladekontrolle erfordert TeslaMate API 1.24 oder neuer</string>
     <!-- Shown when the car is not currently charging -->
     <string name="current_charge_not_charging">Das Auto lädt derzeit nicht</string>
+    <string name="current_charge_starting">Ladevorgang startet — warte auf die ersten Daten…</string>
     <!-- Chart title for voltage and current dual-axis chart -->
     <string name="voltage_and_current_profile">Spannung &amp; Strom</string>
     <!-- SoC labels for the 3-column row in live charge header -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1181,6 +1181,7 @@
     <string name="current_charge_unsupported">La monitorización de carga en curso requiere TeslaMate API 1.24 o superior</string>
     <!-- Mostrado cuando el coche no está cargando actualmente -->
     <string name="current_charge_not_charging">El coche no está cargando actualmente</string>
+    <string name="current_charge_starting">Carga iniciándose — esperando los primeros datos…</string>
     <!-- Título del gráfico de voltaje y corriente de doble eje -->
     <string name="voltage_and_current_profile">Voltaje &amp; Corriente</string>
     <!-- Etiquetas SoC para la fila de 3 columnas en la cabecera de carga en vivo -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1181,6 +1181,7 @@
     <string name="current_charge_unsupported">Il monitoraggio della ricarica in corso richiede TeslaMate API 1.24 o superiore</string>
     <!-- Mostrato quando l\'auto non è in carica -->
     <string name="current_charge_not_charging">L\'auto non è attualmente in carica</string>
+    <string name="current_charge_starting">Ricarica in avvio — in attesa dei primi dati…</string>
     <!-- Titolo grafico tensione e corrente a doppio asse -->
     <string name="voltage_and_current_profile">Tensione &amp; Corrente</string>
     <!-- Etichette SoC per la riga a 3 colonne nell'intestazione della ricarica in tempo reale -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1183,6 +1183,7 @@
     <string name="current_charge_unsupported">实时充电监控需要 TeslaMate API 1.24 或更高版本</string>
     <!-- Shown when the car is not currently charging -->
     <string name="current_charge_not_charging">车辆当前未在充电</string>
+    <string name="current_charge_starting">充电启动中 — 等待首批数据…</string>
     <!-- Chart title for voltage and current dual-axis chart -->
     <string name="voltage_and_current_profile">电压与电流</string>
     <!-- SoC labels for the 3-column row in live charge header -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1271,6 +1271,9 @@
     <string name="current_charge_unsupported">Current charge monitoring requires TeslaMate API 1.24 or newer</string>
     <!-- Shown when the car is not currently charging -->
     <string name="current_charge_not_charging">The car is not currently charging</string>
+
+    <!-- Shown while the car reports charging but the charge data hasn't appeared in the API yet -->
+    <string name="current_charge_starting">Charge starting — waiting for the first data…</string>
     <!-- Chart title for voltage and current dual-axis chart -->
     <string name="voltage_and_current_profile">Voltage &amp; Current</string>
     <!-- SoC labels for the 3-column row in live charge header -->

--- a/app/src/test/java/com/matedroid/ui/screens/charges/CurrentChargeViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/charges/CurrentChargeViewModelTest.kt
@@ -1,0 +1,175 @@
+package com.matedroid.ui.screens.charges
+
+import com.matedroid.data.api.models.CarStatus
+import com.matedroid.data.api.models.ChargeDetail
+import com.matedroid.data.api.models.ChargingDetails
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.ChargeSessionStateDataStore
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.CarStatusWithUnits
+import com.matedroid.data.repository.CurrentChargeOutcome
+import com.matedroid.data.repository.TeslamateRepository
+import androidx.lifecycle.viewModelScope
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CurrentChargeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: TeslamateRepository
+    private lateinit var sessionStore: ChargeSessionStateDataStore
+    private var vm: CurrentChargeViewModel? = null
+
+    private val chargingStatus = CarStatus(
+        displayName = "Test Tesla",
+        state = "charging",
+        chargingDetails = ChargingDetails(
+            pluggedIn = true,
+            chargingState = "Charging"
+        )
+    )
+
+    private val idleStatus = CarStatus(
+        displayName = "Test Tesla",
+        state = "online",
+        chargingDetails = ChargingDetails(
+            pluggedIn = false,
+            chargingState = null
+        )
+    )
+
+    private val activeDetail = ChargeDetail(
+        chargeId = 42,
+        isCharging = true
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk()
+        sessionStore = mockk()
+        coEvery { sessionStore.wasLastSessionDc(any()) } returns false
+        coEvery { sessionStore.setLastSessionDc(any(), any()) } returns Unit
+        coEvery { sessionStore.clear(any()) } returns Unit
+    }
+
+    @After
+    fun teardown() {
+        vm?.viewModelScope?.coroutineContext?.cancelChildren()
+        Dispatchers.resetMain()
+        clearAllMocks()
+    }
+
+    private fun viewModel() = CurrentChargeViewModel(repository, sessionStore).also { vm = it }
+
+    /**
+     * Cancel the ViewModel's endless refresh loop. Must run inside the test body:
+     * runTest's cleanup advances the scheduler until idle, and a still-armed
+     * periodic loop never goes idle (it OOMs accumulating mock recordings).
+     */
+    private fun stopRefreshLoop() {
+        vm?.viewModelScope?.coroutineContext?.cancelChildren()
+    }
+
+    private fun statusResult(status: CarStatus) =
+        ApiResult.Success(CarStatusWithUnits(status, Units()))
+
+    @Test
+    fun `charge starting - no active charge but status says charging shows waiting state`() = runTest(testDispatcher.scheduler) {
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+        coEvery { repository.getCarStatus(1) } returns statusResult(chargingStatus)
+
+        val vm = viewModel()
+        vm.loadCurrentCharge(1)
+        runCurrent()
+
+        val state = vm.uiState.value
+        assertTrue("expected isChargeStarting", state.isChargeStarting)
+        assertFalse("must not bounce out", state.isNotCharging)
+        assertFalse(state.isLoading)
+        stopRefreshLoop()
+    }
+
+    @Test
+    fun `charge starting - transitions to live data when the charge materializes`() = runTest(testDispatcher.scheduler) {
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+        coEvery { repository.getCarStatus(1) } returns statusResult(chargingStatus)
+
+        val vm = viewModel()
+        vm.loadCurrentCharge(1)
+        runCurrent()
+        assertTrue(vm.uiState.value.isChargeStarting)
+
+        // Charge appears in the API; the fast poll (4s) should pick it up well before 30s
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Success(CurrentChargeOutcome.Active(activeDetail))
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        val state = vm.uiState.value
+        assertFalse(state.isChargeStarting)
+        assertNotNull(state.chargeDetail)
+        assertEquals(42, state.chargeDetail?.chargeId)
+        stopRefreshLoop()
+    }
+
+    @Test
+    fun `not charging - no active charge and status agrees bounces out`() = runTest(testDispatcher.scheduler) {
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+        coEvery { repository.getCarStatus(1) } returns statusResult(idleStatus)
+
+        val vm = viewModel()
+        vm.loadCurrentCharge(1)
+        runCurrent()
+
+        val state = vm.uiState.value
+        assertTrue(state.isNotCharging)
+        assertFalse(state.isChargeStarting)
+        stopRefreshLoop()
+    }
+
+    @Test
+    fun `network error - never interpreted as not charging`() = runTest(testDispatcher.scheduler) {
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Error("Connection failed")
+        coEvery { repository.getCarStatus(1) } returns ApiResult.Error("Connection failed")
+
+        val vm = viewModel()
+        vm.loadCurrentCharge(1)
+        runCurrent()
+
+        val state = vm.uiState.value
+        assertFalse("network error must not bounce the user out", state.isNotCharging)
+        assertEquals("Connection failed", state.error)
+        stopRefreshLoop()
+    }
+
+    @Test
+    fun `status fetch failure with no active charge keeps polling without bouncing`() = runTest(testDispatcher.scheduler) {
+        coEvery { repository.getCurrentCharge(1) } returns ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+        coEvery { repository.getCarStatus(1) } returns ApiResult.Error("Connection failed")
+
+        val vm = viewModel()
+        vm.loadCurrentCharge(1)
+        runCurrent()
+
+        assertFalse(vm.uiState.value.isNotCharging)
+        stopRefreshLoop()
+    }
+}


### PR DESCRIPTION
## Summary

Root-caused in the earlier investigation (reproduced on-device with the extended mock server): at charge start, TeslamateAPI's `/charges/current` returns `200 + {"error": "No active charging in progress."}` for a short window while `/status` already reports Charging. The app dropped the `error` field at parse time, mapped the body to `ApiResult.Error(code = null)`, interpreted that as "charging stopped, cable unplugged", silently navigated back to the dashboard and cancelled the poll loop. The perceived 10–15s "slow first load" was the user bouncing off the screen until TeslaMate materialized the charge.

Changes:
- `ChargeDetailResponse` parses the `error` field; `getCurrentCharge()` returns a typed `CurrentChargeOutcome` (`Active` / `NoActiveCharge`, with HTTP 204 also mapping to `NoActiveCharge`). "No active charge" is an authoritative server answer, so it also no longer triggers the secondary-server fallback.
- ViewModel: when status says charging but the charge isn't in the API yet → new `isChargeStarting` state, polled every 4s (instead of 30s) until the charge appears. "Not charging" (navigate back) only happens when the car status agrees.
- Genuine network errors show an error and keep polling — they previously also bounced the user out mid-charge on a WiFi blip.
- The charge + status fetches are now actually concurrent (the comment said so, the code was sequential).
- Screen: new "Charge starting — waiting for the first data…" state (string added in all 6 locales).
- New `CurrentChargeViewModelTest` (5 tests): charge-starting state, transition to live data via fast poll, confirmed not-charging bounce, network errors not misread, status-fetch failure tolerated.

## Test plan
- `./gradlew testDebugUnitTest lintDebug` passes (full suite)
- Live verification at the next real charge start: open the screen immediately after plugging in → expect the "charge starting" indicator, then the live view within a few seconds of TeslaMate publishing the charge
- Mock verification possible via `mockserver --charging --charging-materialize-delay N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)