### PR TITLE
Hide short drives/charges on trip screens; centralize the rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), tiny legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.
+
 ## [1.9.0] - 2026-06-11
 
 A reorganized dashboard with a new top-right menu, manual trip creation, an immersive Location map, plus live-charge reliability and security hardening.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Tap a drive or charge in the trip timeline to open its detail** — selecting a segment now shows a chevron on its info row; tapping it jumps straight to that drive's or charge's detail screen.
+
+### Changed
+- **"Short" drives are now those under 1 km** (was 0.1 km), so brief repositioning hops stop cluttering the lists and trip timelines when "Show short drives / charges" is off. Charges are unchanged (0.1 kWh or less).
+
 ### Fixed
-- **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), tiny legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.
+- **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), short legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.
 
 ## [1.9.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **"Short" drives are now those under 1 km** (was 0.1 km), so brief repositioning hops stop cluttering the lists and trip timelines when "Show short drives / charges" is off. Charges are unchanged (0.1 kWh or less).
+- **The trip timeline gives brief legs an honest sliver** instead of a fixed minimum block, so a quick 1 km hop no longer looks nearly as wide as a long highway leg.
+- **Time spent driving and charging now headline the trip timeline** as bold accent stat tiles, with the overall total as a quiet caption beneath.
 
 ### Fixed
 - **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), short legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.

--- a/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
+++ b/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
@@ -1,0 +1,53 @@
+package com.matedroid.domain
+
+import com.matedroid.data.api.models.ChargeData
+import com.matedroid.data.api.models.DriveData
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+
+/**
+ * Single source of truth for the "short drive / charge" rule behind the
+ * `showShortDrivesCharges` setting (Settings → "Show short drives / charges").
+ *
+ * When the setting is OFF (the default), entries matching the "short" definition are hidden
+ * from every list-like surface: the drives list, the charges list, and the trip timelines /
+ * leg lists. They are still counted in totals, averages and statistics.
+ *
+ * IMPORTANT: keep ALL thresholds and the predicate logic here, and never re-implement them at a
+ * call site. Any new screen that renders individual drives/charges MUST filter through one of the
+ * [isSignificant] helpers below — that is what keeps the behaviour from silently diverging again
+ * (it previously did: the trip timeline shipped without this filter and showed short legs).
+ */
+object ShortEntryFilter {
+    /** A drive shorter than this many minutes is "short". */
+    const val MIN_DRIVE_DURATION_MIN = 1
+
+    /** A drive shorter than this many km is "short". */
+    const val MIN_DRIVE_DISTANCE_KM = 0.1
+
+    /** A charge that added this much energy (kWh) or less is "short". */
+    const val MIN_CHARGE_ENERGY_KWH = 0.1
+
+    /** True when a drive is significant enough to show in lists. */
+    fun isSignificantDrive(durationMin: Int?, distanceKm: Double?): Boolean =
+        (durationMin ?: 0) >= MIN_DRIVE_DURATION_MIN &&
+            (distanceKm ?: 0.0) >= MIN_DRIVE_DISTANCE_KM
+
+    /** True when a charge is significant enough to show in lists. */
+    fun isSignificantCharge(energyKwh: Double?): Boolean =
+        (energyKwh ?: 0.0) > MIN_CHARGE_ENERGY_KWH
+}
+
+// Typed helpers — one per model that carries drives/charges. Adding a new drive/charge model?
+// Add its helper here so every call site stays uniform and the rule can't drift.
+fun DriveData.isSignificant(): Boolean =
+    ShortEntryFilter.isSignificantDrive(durationMin, distance)
+
+fun DriveSummary.isSignificant(): Boolean =
+    ShortEntryFilter.isSignificantDrive(durationMin, distance)
+
+fun ChargeData.isSignificant(): Boolean =
+    ShortEntryFilter.isSignificantCharge(chargeEnergyAdded)
+
+fun ChargeSummary.isSignificant(): Boolean =
+    ShortEntryFilter.isSignificantCharge(energyAdded)

--- a/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
+++ b/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
@@ -13,6 +13,8 @@ import com.matedroid.data.local.entity.DriveSummary
  * from every list-like surface: the drives list, the charges list, and the trip timelines /
  * leg lists. They are still counted in totals, averages and statistics.
  *
+ * "Short" means a drive under 1 minute OR under 1 km, or a charge that added 0.1 kWh or less.
+ *
  * IMPORTANT: keep ALL thresholds and the predicate logic here, and never re-implement them at a
  * call site. Any new screen that renders individual drives/charges MUST filter through one of the
  * [isSignificant] helpers below — that is what keeps the behaviour from silently diverging again
@@ -23,7 +25,7 @@ object ShortEntryFilter {
     const val MIN_DRIVE_DURATION_MIN = 1
 
     /** A drive shorter than this many km is "short". */
-    const val MIN_DRIVE_DISTANCE_KM = 0.1
+    const val MIN_DRIVE_DISTANCE_KM = 1.0
 
     /** A charge that added this much energy (kWh) or less is "short". */
     const val MIN_CHARGE_ENERGY_KWH = 0.1

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -71,7 +71,6 @@ import com.matedroid.util.formatDuration
 import com.matedroid.util.formatTime
 import com.matedroid.util.parseIsoDateTime
 import java.util.Locale
-import kotlin.math.max
 import kotlin.math.sqrt
 
 /** A segment in a trip timeline, representing a slice of the trip's wall-clock time. */
@@ -115,7 +114,15 @@ data class TripTimelineCountry(
 private const val IDLE_LINEAR_THRESHOLD_MIN = 30f
 private const val IDLE_COMPRESSION_SCALE = 0.5f
 
-private const val MIN_SEGMENT_RATIO = 0.02f
+/**
+ * Per-segment "base" share of the bar, added to every segment before the remaining width is
+ * handed out strictly in proportion to duration. Using an *additive* base (instead of a hard
+ * `max(weight, floor)`) keeps the briefest legs visible and tappable without inflating them to
+ * the floor: a 2-minute drive no longer renders nearly as wide as one 40× longer. Capped so the
+ * bases never swallow more than [SEGMENT_BASE_MAX_TOTAL] of the bar when there are many segments.
+ */
+private const val SEGMENT_BASE_FRACTION = 0.012f
+private const val SEGMENT_BASE_MAX_TOTAL = 0.4f
 
 /**
  * Horizontal trip timeline bar. Each segment's width is proportional to its duration,
@@ -520,8 +527,12 @@ private fun Endpoint(
     }
 }
 
-/** Minimum width per segment in the scrollable detail bar. */
-private val DETAIL_MIN_SEGMENT_DP = 28.dp
+/**
+ * Base width every segment gets in the scrollable detail bar, *added* to its proportional width
+ * (not used as a hard floor). Keeps the briefest leg a tappable sliver while a longer leg always
+ * stays proportionally wider — a 2-minute drive no longer matches the width of a 90-minute one.
+ */
+private val DETAIL_BASE_SEGMENT_DP = 6.dp
 
 /** Dp per minute of (compressed) weight when sizing the detail bar. Higher = wider. */
 private const val DETAIL_WEIGHT_TO_DP = 0.5f
@@ -537,12 +548,12 @@ private fun TimelineBar(
     val density = LocalDensity.current
 
     // Pixel widths each segment would occupy in the detail bar (not yet laid out).
+    // Additive base + proportional, so brief legs stay thin instead of snapping to a fat floor.
     val detailWidthsPx = remember(segments, density.density) {
-        val minPx = with(density) { DETAIL_MIN_SEGMENT_DP.toPx() }
+        val basePx = with(density) { DETAIL_BASE_SEGMENT_DP.toPx() }
         val pxPerWeight = DETAIL_WEIGHT_TO_DP * density.density
         segments.map { seg ->
-            val w = segmentWeight(seg)
-            max(w * pxPerWeight, minPx)
+            basePx + segmentWeight(seg) * pxPerWeight
         }
     }
     val totalDetailPx = detailWidthsPx.sum()
@@ -915,17 +926,21 @@ private fun segmentWeight(seg: TripTimelineSegment): Float = when (seg) {
     is TripTimelineSegment.Drive -> seg.durationMin.toFloat().coerceAtLeast(1f)
 }
 
-/** Compute visual width ratios for each segment, with shared compression on idle segments. */
+/**
+ * Compute visual width ratios for each segment. Each segment gets a small fixed base share, and
+ * the remaining width is split strictly in proportion to (compressed) duration. This keeps the
+ * shortest legs as visible slivers while preserving honest proportions — unlike a hard minimum
+ * floor, which would round every brief leg up to the same fat width. Ratios sum to 1.
+ */
 private fun computeSegmentRatios(segments: List<TripTimelineSegment>): List<Float> {
     if (segments.isEmpty()) return emptyList()
     val weights = segments.map { segmentWeight(it) }
     val total = weights.sum().coerceAtLeast(1f)
     val raw = weights.map { it / total }
-    // Lift to minimum and renormalize (cap min so n * min <= 1)
-    val effectiveMin = MIN_SEGMENT_RATIO.coerceAtMost(1f / segments.size)
-    val lifted = raw.map { max(it, effectiveMin) }
-    val liftedSum = lifted.sum()
-    return lifted.map { it / liftedSum }
+    // Per-segment base, capped so all bases together never exceed SEGMENT_BASE_MAX_TOTAL.
+    val base = SEGMENT_BASE_FRACTION.coerceAtMost(SEGMENT_BASE_MAX_TOTAL / segments.size)
+    val proportionalShare = 1f - base * segments.size
+    return raw.map { base + it * proportionalShare }
 }
 
 /** Linear up to 30min, then sqrt-compressed and scaled down. Used for both parking gaps and AC charges. */

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Column
@@ -229,9 +227,7 @@ fun TripTimeline(
 
             Spacer(modifier = Modifier.height(6.dp))
 
-            // Durations on their own full-width line so they never get starved into
-            // wrapping; FlowRow lets them spill to a second line gracefully if a large
-            // font scale leaves no room for all three on one line.
+            // Driving / charging totals as hero tiles, with the overall total beneath.
             DurationSummary(
                 totalDurationMin = totalDurationMin,
                 totalDrivingDurationMin = totalDrivingDurationMin,
@@ -243,7 +239,6 @@ fun TripTimeline(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DurationSummary(
     totalDurationMin: Int,
@@ -253,49 +248,91 @@ private fun DurationSummary(
     modifier: Modifier = Modifier
 ) {
     val resources = LocalContext.current.resources
-    FlowRow(
+    Column(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        DurationItem(
-            icon = CustomIcons.SteeringWheel,
-            text = formatDuration(resources, totalDrivingDurationMin),
-            tint = palette.accent
-        )
-        if (totalChargingDurationMin > 0) {
-            DurationItem(
-                icon = Icons.Filled.ElectricBolt,
-                text = formatDuration(resources, totalChargingDurationMin),
-                tint = palette.accent
+        // Hero tiles: driving + charging are the headline figures.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            DurationTile(
+                icon = CustomIcons.SteeringWheel,
+                label = stringResource(R.string.trip_timeline_driving),
+                value = formatDuration(resources, totalDrivingDurationMin),
+                accent = palette.accent,
+                modifier = Modifier.weight(1f)
+            )
+            if (totalChargingDurationMin > 0) {
+                DurationTile(
+                    icon = Icons.Filled.ElectricBolt,
+                    label = stringResource(R.string.charging),
+                    value = formatDuration(resources, totalChargingDurationMin),
+                    accent = palette.accent,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+        // Overall total — demoted to a quiet caption beneath the tiles.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Filled.Schedule,
+                contentDescription = null,
+                modifier = Modifier.size(13.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "${formatDuration(resources, totalDurationMin)} · ${stringResource(R.string.total)}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                softWrap = false
             )
         }
-        DurationItem(
-            icon = Icons.Filled.Schedule,
-            text = formatDuration(resources, totalDurationMin),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 }
 
 @Composable
-private fun DurationItem(
+private fun DurationTile(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
-    text: String,
-    tint: Color
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(12.dp),
-            tint = tint
-        )
-        Spacer(Modifier.width(3.dp))
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(accent.copy(alpha = 0.12f))
+            .padding(vertical = 12.dp, horizontal = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(15.dp),
+                tint = accent
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = label.uppercase(Locale.getDefault()),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                softWrap = false
+            )
+        }
         Text(
-            text = text,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            text = value,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = accent,
             maxLines = 1,
             softWrap = false
         )

--- a/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripTimeline.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.LocalParking
 import androidx.compose.material.icons.filled.Power
@@ -81,14 +82,16 @@ sealed class TripTimelineSegment {
     data class Drive(
         override val durationMin: Int,
         val index: Int,
-        val distanceKm: Double
+        val distanceKm: Double,
+        val driveId: Int
     ) : TripTimelineSegment()
 
     data class Charge(
         override val durationMin: Int,
         val index: Int,
         val energyKwh: Double,
-        val isDc: Boolean
+        val isDc: Boolean,
+        val chargeId: Int
     ) : TripTimelineSegment()
 
     data class Parking(
@@ -132,6 +135,8 @@ fun TripTimeline(
     totalDrivingDurationMin: Int,
     totalChargingDurationMin: Int,
     onCountryClick: (countryCode: String) -> Unit = {},
+    onDriveClick: (driveId: Int) -> Unit = {},
+    onChargeClick: (chargeId: Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (segments.isEmpty()) return
@@ -172,7 +177,9 @@ fun TripTimeline(
                 countries = countries,
                 palette = palette,
                 parkingColor = parkingColor,
-                onCountryClick = onCountryClick
+                onCountryClick = onCountryClick,
+                onDriveClick = onDriveClick,
+                onChargeClick = onChargeClick
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -296,7 +303,9 @@ private fun InfoPanel(
     countries: List<TripTimelineCountry>,
     palette: CarColorPalette,
     parkingColor: Color,
-    onCountryClick: (countryCode: String) -> Unit
+    onCountryClick: (countryCode: String) -> Unit,
+    onDriveClick: (driveId: Int) -> Unit,
+    onChargeClick: (chargeId: Int) -> Unit
 ) {
     // Reserve a constant height so tapping segments doesn't shift the bar position
     Box(
@@ -309,7 +318,9 @@ private fun InfoPanel(
             SegmentInfoContent(
                 segment = selection.second,
                 palette = palette,
-                parkingColor = parkingColor
+                parkingColor = parkingColor,
+                onDriveClick = onDriveClick,
+                onChargeClick = onChargeClick
             )
         } else {
             RouteHeaderContent(
@@ -326,12 +337,16 @@ private fun InfoPanel(
 private fun SegmentInfoContent(
     segment: TripTimelineSegment,
     palette: CarColorPalette,
-    parkingColor: Color
+    parkingColor: Color,
+    onDriveClick: (driveId: Int) -> Unit,
+    onChargeClick: (chargeId: Int) -> Unit
 ) {
     val resources = LocalContext.current.resources
     val title: String
     val subtitle: String
     val dotColor: Color
+    // Drives and charges link to their detail screen; parking gaps have no detail.
+    val onClick: (() -> Unit)?
     when (segment) {
         is TripTimelineSegment.Drive -> {
             title = "${stringResource(R.string.trip_timeline_driving)} · " +
@@ -341,6 +356,7 @@ private fun SegmentInfoContent(
                 formatDuration(resources, segment.durationMin)
             )
             dotColor = palette.accent
+            onClick = { onDriveClick(segment.driveId) }
         }
         is TripTimelineSegment.Charge -> {
             val chargeLabel = if (segment.isDc) {
@@ -355,14 +371,26 @@ private fun SegmentInfoContent(
                 formatDuration(resources, segment.durationMin)
             )
             dotColor = if (segment.isDc) palette.dcColor else palette.acColor
+            onClick = { onChargeClick(segment.chargeId) }
         }
         is TripTimelineSegment.Parking -> {
             title = stringResource(R.string.trip_timeline_parked)
             subtitle = formatDuration(resources, segment.durationMin)
             dotColor = parkingColor
+            onClick = null
         }
     }
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        modifier = if (onClick != null) {
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onClick)
+        } else {
+            Modifier.fillMaxWidth()
+        },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         Box(
             modifier = Modifier
                 .size(12.dp)
@@ -370,7 +398,7 @@ private fun SegmentInfoContent(
                 .background(dotColor)
         )
         Spacer(modifier = Modifier.width(10.dp))
-        Column {
+        Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.labelMedium,
@@ -380,6 +408,15 @@ private fun SegmentInfoContent(
                 text = subtitle,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        // Chevron signals the detail is tappable (project convention for linked rows).
+        if (onClick != null) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -11,6 +11,7 @@ import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.LocalDayBoundaries
+import com.matedroid.domain.isSignificant
 import android.content.Context
 import com.matedroid.R
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -131,8 +132,6 @@ class ChargesViewModel @Inject constructor(
     private var allCharges: List<ChargeData> = emptyList()
 
     companion object {
-        private const val MIN_ENERGY_KWH = 0.1
-
         private const val KEY_DATE_FILTER = "filter_date"
         private const val KEY_CHARGE_TYPE_FILTER = "filter_charge_type"
         private const val KEY_COST_FILTER = "filter_cost"
@@ -374,13 +373,11 @@ class ChargesViewModel @Inject constructor(
         val dcChargeIds = state.dcChargeIds
         val granularity = state.chartGranularity
 
-        // First apply short charges filter
+        // First apply short charges filter (see ShortEntryFilter for the shared rule)
         var filteredCharges = if (showShortDrivesCharges) {
             allCharges
         } else {
-            allCharges.filter { charge ->
-                (charge.chargeEnergyAdded ?: 0.0) > MIN_ENERGY_KWH
-            }
+            allCharges.filter { it.isSignificant() }
         }
 
         // Apply charge type filter (AC/DC) for list display

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -10,6 +10,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.LocalDayBoundaries
+import com.matedroid.domain.isSignificant
 import com.matedroid.R
 import android.content.Context
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -125,9 +126,6 @@ class DrivesViewModel @Inject constructor(
     private var isInitialized: Boolean = false
 
     companion object {
-        private const val MIN_DURATION_MINUTES = 1
-        private const val MIN_DISTANCE_KM = 0.1
-
         private const val KEY_DATE_FILTER = "filter_date"
         private const val KEY_DISTANCE_FILTER = "filter_distance"
         private const val KEY_CUSTOM_START = "filter_custom_start"
@@ -303,14 +301,11 @@ class DrivesViewModel @Inject constructor(
         val distanceFilter = state.distanceFilter
         val granularity = state.chartGranularity
 
-        // First apply short drives filter
+        // First apply short drives filter (see ShortEntryFilter for the shared rule)
         var filteredDrives = if (showShortDrivesCharges) {
             allDrives
         } else {
-            allDrives.filter { drive ->
-                (drive.durationMin ?: 0) >= MIN_DURATION_MINUTES &&
-                    (drive.distance ?: 0.0) >= MIN_DISTANCE_KM
-            }
+            allDrives.filter { it.isSignificant() }
         }
 
         // Apply distance filter for list display

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
+import com.matedroid.domain.isSignificant
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
@@ -231,7 +232,8 @@ fun TripDetailScreen(
                         onCountryClick = onNavigateToCountryStats,
                         onAddLeg = viewModel::openAddLegSheet,
                         onMergeTrip = viewModel::openMergeSheet,
-                        currencySymbol = uiState.currencySymbol
+                        currencySymbol = uiState.currencySymbol,
+                        showShortDrivesCharges = uiState.showShortDrivesCharges
                     )
                 }
             }
@@ -296,6 +298,7 @@ private fun TripDetailContent(
     onAddLeg: () -> Unit,
     onMergeTrip: () -> Unit,
     currencySymbol: String,
+    showShortDrivesCharges: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -313,7 +316,9 @@ private fun TripDetailContent(
         }
         val startCity = remember(trip.startAddress) { extractCity(trip.startAddress) }
         val endCity = remember(trip.endAddress) { extractCity(trip.endAddress) }
-        val timelineSegments = remember(trip, dcChargeIds) { buildTimelineSegments(trip, dcChargeIds) }
+        val timelineSegments = remember(trip, dcChargeIds, showShortDrivesCharges) {
+            buildTimelineSegments(trip, dcChargeIds, showShort = showShortDrivesCharges)
+        }
         val timelineCountries = remember(countries) {
             countries.map { TripTimelineCountry(it.countryCode, it.flagEmoji) }
         }
@@ -363,7 +368,9 @@ private fun TripDetailContent(
             units = units
         )
 
-        val legs = remember(trip) { buildLegList(trip) }
+        val legs = remember(trip, showShortDrivesCharges) { buildLegList(trip, showShortDrivesCharges) }
+        val driveLegCount = remember(legs) { legs.count { it is TripLeg.Drive } }
+        val chargeLegCount = remember(legs) { legs.count { it is TripLeg.Charge } }
         var legsExpanded by rememberSaveable { mutableStateOf(false) }
         val legsChevronRotation by animateFloatAsState(
             targetValue = if (legsExpanded) 90f else 0f,
@@ -399,7 +406,7 @@ private fun TripDetailContent(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Text(
-                        text = "${trip.drives.size}",
+                        text = "$driveLegCount",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = palette.accent
@@ -411,7 +418,7 @@ private fun TripDetailContent(
                         modifier = Modifier.size(16.dp),
                         tint = palette.accent
                     )
-                    if (trip.charges.isNotEmpty()) {
+                    if (chargeLegCount > 0) {
                         Spacer(Modifier.width(6.dp))
                         Text(
                             text = "+",
@@ -420,7 +427,7 @@ private fun TripDetailContent(
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            text = "${trip.charges.size}",
+                            text = "$chargeLegCount",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
                             color = palette.accent
@@ -1360,13 +1367,16 @@ private sealed class TripLeg {
     ) : TripLeg()
 }
 
-private fun buildLegList(trip: Trip): List<TripLeg> {
+private fun buildLegList(trip: Trip, showShort: Boolean): List<TripLeg> {
     val legs = mutableListOf<TripLeg>()
     var driveIdx = 0
     var chargeIdx = 0
+    // Hide short legs unless the user opted in — same rule as the timeline (ShortEntryFilter).
+    val drives = if (showShort) trip.drives else trip.drives.filter { it.isSignificant() }
+    val charges = if (showShort) trip.charges else trip.charges.filter { it.isSignificant() }
     val allEvents = mutableListOf<Pair<String, Any>>()
-    trip.drives.forEach { allEvents.add(it.startDate to it) }
-    trip.charges.forEach { allEvents.add(it.startDate to it) }
+    drives.forEach { allEvents.add(it.startDate to it) }
+    charges.forEach { allEvents.add(it.startDate to it) }
     allEvents.sortBy { it.first }
     for ((_, event) in allEvents) {
         when (event) {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -347,7 +347,9 @@ private fun TripDetailContent(
             totalDurationMin = trip.totalDurationMin,
             totalDrivingDurationMin = trip.totalDrivingDurationMin,
             totalChargingDurationMin = totalChargingDurationMin,
-            onCountryClick = onCountryClick
+            onCountryClick = onCountryClick,
+            onDriveClick = onDriveClick,
+            onChargeClick = onChargeClick
         )
 
         if ((trip.totalChargeCost ?: 0.0) > 0.0) {

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailViewModel.kt
@@ -72,6 +72,7 @@ data class TripDetailUiState(
     val countries: List<TripCountry> = emptyList(),
     val units: Units? = null,
     val currencySymbol: String = "€",
+    val showShortDrivesCharges: Boolean = false,
 
     // Edit / merge / delete (PR 2)
     val savedTripId: Long? = null,
@@ -118,6 +119,10 @@ class TripDetailViewModel @Inject constructor(
         currentStartDate = tripStartDate
 
         viewModelScope.launch {
+            // Read on every load so a toggle of the setting is reflected after navigating back.
+            val showShort = settingsDataStore.showShortDrivesCharges.first()
+            _uiState.update { it.copy(showShortDrivesCharges = showShort) }
+
             // Skip these on revalidation — units and currency don't change between same-session
             // navigations, and the network call was the slowest step of the reload.
             val isFirstLoad = _uiState.value.units == null

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
@@ -61,7 +61,8 @@ fun buildTimelineSegments(
                     TripTimelineSegment.Drive(
                         durationMin = event.durationMin,
                         index = driveIdx,
-                        distanceKm = event.distance
+                        distanceKm = event.distance,
+                        driveId = event.driveId
                     )
                 )
             }
@@ -72,7 +73,8 @@ fun buildTimelineSegments(
                         durationMin = event.durationMin,
                         index = chargeIdx,
                         energyKwh = event.energyAdded,
-                        isDc = event.chargeId in dcChargeIds
+                        isDc = event.chargeId in dcChargeIds,
+                        chargeId = event.chargeId
                     )
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripTimelineBuilder.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.trips
 
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.domain.isSignificant
 import com.matedroid.domain.model.Trip
 import com.matedroid.ui.components.TripTimelineSegment
 import com.matedroid.util.parseIsoDateTime
@@ -16,14 +17,23 @@ private const val MIN_PARKING_GAP_MIN = 5L
  *
  * [dcChargeIds] is the set of charge IDs that are DC fast chargers, used to color the
  * charge segments correctly (orange for DC, green for AC). For legs not in the set, AC is assumed.
+ *
+ * [showShort] mirrors the `showShortDrivesCharges` setting: when false (the default), short
+ * drives/charges are dropped from the timeline so tiny legs don't clutter the strip. See
+ * [com.matedroid.domain.ShortEntryFilter] for the shared rule. Totals shown elsewhere on the
+ * screen come from the full trip and are unaffected by this flag.
  */
 fun buildTimelineSegments(
     trip: Trip,
-    dcChargeIds: Set<Int> = emptySet()
+    dcChargeIds: Set<Int> = emptySet(),
+    showShort: Boolean
 ): List<TripTimelineSegment> {
+    val drives = if (showShort) trip.drives else trip.drives.filter { it.isSignificant() }
+    val charges = if (showShort) trip.charges else trip.charges.filter { it.isSignificant() }
+
     val allEvents = mutableListOf<Pair<String, Any>>()
-    trip.drives.forEach { allEvents.add(it.startDate to it) }
-    trip.charges.forEach { allEvents.add(it.startDate to it) }
+    drives.forEach { allEvents.add(it.startDate to it) }
+    charges.forEach { allEvents.add(it.startDate to it) }
     allEvents.sortBy { it.first }
 
     val segments = mutableListOf<TripTimelineSegment>()

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
+import com.matedroid.domain.isSignificant
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.DateRangePickerDialog
@@ -216,6 +217,7 @@ fun TripsScreen(
                         units = uiState.units,
                         palette = palette,
                         dcChargeIds = uiState.dcChargeIds,
+                        showShortDrivesCharges = uiState.showShortDrivesCharges,
                         onTripClick = { trip ->
                             viewModel.cacheTrip(trip)
                             onNavigateToTripDetail(trip.startDate)
@@ -243,6 +245,7 @@ private fun TripsContent(
     units: Units?,
     palette: CarColorPalette,
     dcChargeIds: Set<Int>,
+    showShortDrivesCharges: Boolean,
     onTripClick: (Trip) -> Unit
 ) {
     val listState = rememberLazyListState()
@@ -311,6 +314,7 @@ private fun TripsContent(
                 units = units,
                 palette = palette,
                 dcChargeIds = dcChargeIds,
+                showShort = showShortDrivesCharges,
                 onClick = { onTripClick(trip) }
             )
         }
@@ -429,13 +433,17 @@ private fun TripItem(
     units: Units?,
     palette: CarColorPalette,
     dcChargeIds: Set<Int>,
+    showShort: Boolean,
     onClick: () -> Unit
 ) {
     // Segments memoized per trip — pure computation on the in-memory Trip, cheap enough for
     // every visible list row (LazyColumn composes ~10 at a time). Keys include dcChargeIds so
-    // the strip recolors if the DC set ever changes.
-    val segments = remember(trip, dcChargeIds) { buildTimelineSegments(trip, dcChargeIds) }
-    val chargeCount = trip.charges.size
+    // the strip recolors if the DC set ever changes, and showShort so the strip rebuilds when
+    // the short-entries setting is toggled.
+    val segments = remember(trip, dcChargeIds, showShort) {
+        buildTimelineSegments(trip, dcChargeIds, showShort = showShort)
+    }
+    val chargeCount = if (showShort) trip.charges.size else trip.charges.count { it.isSignificant() }
 
     Card(
         modifier = Modifier

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -3,6 +3,7 @@ package com.matedroid.ui.screens.trips
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
@@ -12,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.matedroid.util.parseIsoDate
@@ -30,7 +32,8 @@ data class TripsUiState(
     val customStartDate: LocalDate? = null,
     val customEndDate: LocalDate? = null,
     val units: Units? = null,
-    val dcChargeIds: Set<Int> = emptySet()
+    val dcChargeIds: Set<Int> = emptySet(),
+    val showShortDrivesCharges: Boolean = false
 )
 
 @HiltViewModel
@@ -38,7 +41,8 @@ class TripsViewModel @Inject constructor(
     private val tripRepository: TripRepository,
     private val repository: TeslamateRepository,
     private val tripCache: TripCache,
-    private val aggregateDao: AggregateDao
+    private val aggregateDao: AggregateDao,
+    private val settingsDataStore: SettingsDataStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TripsUiState())
@@ -114,6 +118,10 @@ class TripsViewModel @Inject constructor(
 
     private fun loadTrips(carId: Int) {
         viewModelScope.launch {
+            // Read on each load so toggling the setting is reflected when the screen reloads.
+            val showShort = settingsDataStore.showShortDrivesCharges.first()
+            _uiState.update { it.copy(showShortDrivesCharges = showShort) }
+
             allTrips = tripRepository.getTrips(carId)
 
             val years = allTrips.mapNotNull { parseYear(it.startDate) }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -255,7 +255,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Trajectes i càrregues curts</string>
-    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els següents elements estan ocults de les llistes:\n\n• Trajectes de menys d\'1 minut o menys de 0,1 km\n• Càrregues de 0,1 kWh o menys\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
+    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els següents elements estan ocults de les llistes:\n\n• Trajectes de menys d\'1 minut o menys d\'1 km\n• Càrregues de 0,1 kWh o menys\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Força resincronització completa</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -255,7 +255,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Kurze Fahrten &amp; Ladevorgänge</string>
-    <string name="settings_short_dialog_text">Wenn deaktiviert (Standard), werden die folgenden Einträge in den Listen ausgeblendet:\n\n• Fahrten unter 1 Minute oder weniger als 0,1 km\n• Ladevorgänge von 0,1 kWh oder weniger\n\nDiese Einträge werden weiterhin in Summen, Durchschnitten und Statistiken berücksichtigt. Aktiviere diese Einstellung, um alle Einträge in den Listen zu sehen.</string>
+    <string name="settings_short_dialog_text">Wenn deaktiviert (Standard), werden die folgenden Einträge in den Listen ausgeblendet:\n\n• Fahrten unter 1 Minute oder weniger als 1 km\n• Ladevorgänge von 0,1 kWh oder weniger\n\nDiese Einträge werden weiterhin in Summen, Durchschnitten und Statistiken berücksichtigt. Aktiviere diese Einstellung, um alle Einträge in den Listen zu sehen.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Vollständige Neu-Synchronisierung erzwingen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -255,7 +255,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Trayectos y cargas cortos</string>
-    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los siguientes elementos están ocultos de las listas:\n\n• Trayectos de menos de 1 minuto o menos de 0,1 km\n• Cargas de 0,1 kWh o menos\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
+    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los siguientes elementos están ocultos de las listas:\n\n• Trayectos de menos de 1 minuto o menos de 1 km\n• Cargas de 0,1 kWh o menos\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forzar resincronización completa</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -255,7 +255,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Tragitti e ricariche brevi</string>
-    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i seguenti elementi sono nascosti dalle liste:\n\n• Tragitti sotto 1 minuto o meno di 0,1 km\n• Ricariche di 0,1 kWh o meno\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
+    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i seguenti elementi sono nascosti dalle liste:\n\n• Tragitti sotto 1 minuto o meno di 1 km\n• Ricariche di 0,1 kWh o meno\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forza risincronizzazione completa</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -255,7 +255,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">短途行程和充电</string>
-    <string name="settings_short_dialog_text">关闭时（默认），以下内容将从列表中隐藏：\n\n• 不足 1 分钟或不到 0.1 km 的行程\n• 0.1 kWh 以下的充电\n\n这些记录仍会计入总计、平均值和统计数据。启用此设置可在列表中查看所有记录。</string>
+    <string name="settings_short_dialog_text">关闭时（默认），以下内容将从列表中隐藏：\n\n• 不足 1 分钟或不到 1 km 的行程\n• 0.1 kWh 以下的充电\n\n这些记录仍会计入总计、平均值和统计数据。启用此设置可在列表中查看所有记录。</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">强制全量同步</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,7 +258,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Short drives &amp; charges</string>
-    <string name="settings_short_dialog_text">When disabled (default), the following are hidden from the lists:\n\n• Drives under 1 minute or less than 0.1 km\n• Charges of 0.1 kWh or less\n\nThese entries are still included in totals, averages, and statistics. Enable this setting to see all entries in the lists.</string>
+    <string name="settings_short_dialog_text">When disabled (default), the following are hidden from the lists:\n\n• Drives under 1 minute or less than 1 km\n• Charges of 0.1 kWh or less\n\nThese entries are still included in totals, averages, and statistics. Enable this setting to see all entries in the lists.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Force Full Resync</string>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,7 +86,7 @@ same word in a locale, or the Drives/Trips navigation and stats become ambiguous
 #### Hiding short drives / charges
 
 The "Show short drives / charges" setting (`showShortDrivesCharges`, default off) hides trivial
-entries — drives under 1 min or 0.1 km, and charges of 0.1 kWh or less — from **list-like
+entries — drives under 1 min or 1 km, and charges of 0.1 kWh or less — from **list-like
 surfaces** while still counting them in totals, averages and statistics.
 
 The rule lives in **one place**: `domain/ShortEntryFilter.kt`. It exposes the thresholds plus

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,6 +83,21 @@ When adding a new `drive_*`/`*_drive*` string, translate "drive" with the drive-
 reserve the trip-column term for `trip_*`/`trips_*` strings — never let the two collapse to the
 same word in a locale, or the Drives/Trips navigation and stats become ambiguous.
 
+#### Hiding short drives / charges
+
+The "Show short drives / charges" setting (`showShortDrivesCharges`, default off) hides trivial
+entries — drives under 1 min or 0.1 km, and charges of 0.1 kWh or less — from **list-like
+surfaces** while still counting them in totals, averages and statistics.
+
+The rule lives in **one place**: `domain/ShortEntryFilter.kt`. It exposes the thresholds plus
+`isSignificant()` helpers for every drive/charge model (`DriveData`, `ChargeData`, `DriveSummary`,
+`ChargeSummary`). **Any screen that renders individual drives/charges must filter through these
+helpers** — never re-implement the thresholds at a call site. This is what keeps the behaviour
+consistent (it previously diverged: the trip timeline shipped without the filter and showed short
+legs). Current call sites: `DrivesViewModel`, `ChargesViewModel`, `TripTimelineBuilder` and the
+trip leg list / counts in `TripsScreen` + `TripDetailScreen`. Add a new model? Add its
+`isSignificant()` helper in `ShortEntryFilter.kt`.
+
 #### Adding/Modifying Translations
 
 1. **All user-visible strings must be in string resources** - never hardcode text in Kotlin files


### PR DESCRIPTION
## Problem

The **Show short drives / charges** setting (`showShortDrivesCharges`, default off) is supposed to hide trivial entries — drives under 1 min / 0.1 km and charges of ≤ 0.1 kWh — from list-like surfaces, while still counting them in totals/stats.

It was only ever applied in the **Drives** and **Charges** lists, and each list re-implemented its own thresholds (`MIN_DURATION_MINUTES`/`MIN_DISTANCE_KM` in `DrivesViewModel`, `MIN_ENERGY_KWH` in `ChargesViewModel`). The **Trips** feature never filtered at all, so short legs cluttered the timeline strips on the trip cards and the trip-detail timeline regardless of the setting. That's the reported bug.

## Fix

- **New `domain/ShortEntryFilter.kt`** — single source of truth for the thresholds plus `isSignificant()` helpers for every drive/charge model (`DriveData`, `ChargeData`, `DriveSummary`, `ChargeSummary`). Any new surface that lists drives/charges must filter through these, so the rule can't silently diverge again.
- **`DrivesViewModel` / `ChargesViewModel`** now use the shared helpers (duplicated constants/logic removed).
- **Trips honour the setting** across: the timeline strip on trip cards (`TripsScreen`), the trip-detail timeline, the leg list, and the displayed leg counts. Threaded `showShortDrivesCharges` through `TripsViewModel`/`TripDetailViewModel` state.
- Totals, averages, energy-flow, cost and stats still include short entries (unchanged). Trip editing surfaces (add/merge leg candidates) and the canonical `Trip.drives`/`charges` used for map/route/cache keys are deliberately left unfiltered.

## Scope check ("rest of the app")

Audited every per-entry surface: Mileage is pure aggregates; Stats `rangeRecordDrives` are longest-range records (can't be short). Both are correctly covered by the existing "stats include everything" design and need no change.

## Verification

- `./gradlew compileDebugKotlin` ✅
- `./gradlew lintDebug` ✅ (only the pre-existing Moshi kapt deprecation warning)
- `./gradlew testDebugUnitTest` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)