### PR TITLE
Trips list year, editable charge cost from detail, merged-trip name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Edit a charge's cost from its detail screen** — the Cost section now shows an external-link icon and the whole card opens TeslaMate's cost editor (previously possible only from the charges list). It appears even for free/uncosted charges so you can add a cost.
 - **Tap a drive or charge in the trip timeline to open its detail** — selecting a segment now shows a chevron on its info row; tapping it jumps straight to that drive's or charge's detail screen.
 
 ### Changed
+- **The Trips list now shows the year on each trip's date chip**, not just day and month.
 - **"Short" drives are now those under 1 km** (was 0.1 km), so brief repositioning hops stop cluttering the lists and trip timelines when "Show short drives / charges" is off. Charges are unchanged (0.1 kWh or less).
 - **The trip timeline gives brief legs an honest sliver** instead of a fixed minimum block, so a quick 1 km hop no longer looks nearly as wide as a long highway leg.
 - **Time spent driving and charging now headline the trip timeline** as bold accent stat tiles, with the overall total as a quiet caption beneath.
 
 ### Fixed
+- **Drives and charges in a merged-and-renamed trip now show the trip's current name** on their detail screen, instead of the original auto-generated "city → city" name.
 - **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), short legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.
 
 ## [1.9.0] - 2026-06-11

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -498,7 +498,8 @@ class TripRepository @Inject constructor(
         val charges = chargeSummaryDao.getAllForCar(carId).associateBy { it.chargeId }
         val trip = TripAggregator.buildTrip(
             tripDrivesIn(match, drives),
-            tripChargesIn(match, charges)
+            tripChargesIn(match, charges),
+            name = match.trip.name
         ) ?: return null
         return match.trip.id to trip
     }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -188,7 +188,7 @@ private fun ChargeDetailContent(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         // Location header card
-        LocationHeaderCard(detail = detail, currencySymbol = currencySymbol, isDcCharge = isDcCharge)
+        LocationHeaderCard(detail = detail, currencySymbol = currencySymbol, isDcCharge = isDcCharge, onEditCost = onEditCost)
 
         // Part-of-trip banner
         if (containingTrip != null) {
@@ -402,7 +402,12 @@ private fun ChargeDetailContent(
 }
 
 @Composable
-private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isDcCharge: Boolean) {
+private fun LocationHeaderCard(
+    detail: ChargeDetail,
+    currencySymbol: String,
+    isDcCharge: Boolean,
+    onEditCost: (() -> Unit)? = null
+) {
     val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val locationLabel = stringResource(R.string.location)
     val unknownLocationLabel = stringResource(R.string.unknown_location)
@@ -544,10 +549,18 @@ private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isD
                         }
                     }
 
-                    // Cost (right side)
+                    // Cost (right side) — tappable to open TeslaMate's cost editor when configured.
                     detail.cost?.let { cost ->
                         if (cost > 0) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = if (onEditCost != null) {
+                                    Modifier
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .clickable(onClick = onEditCost)
+                                        .padding(4.dp)
+                                } else Modifier
+                            ) {
                                 Column(horizontalAlignment = Alignment.End) {
                                     Text(
                                         text = costLabel,
@@ -563,9 +576,9 @@ private fun LocationHeaderCard(detail: ChargeDetail, currencySymbol: String, isD
                                 }
                                 Spacer(modifier = Modifier.width(12.dp))
                                 Icon(
-                                    imageVector = Icons.Default.Paid,
+                                    imageVector = if (onEditCost != null) Icons.AutoMirrored.Filled.OpenInNew else Icons.Default.Paid,
                                     contentDescription = null,
-                                    modifier = Modifier.size(24.dp),
+                                    modifier = Modifier.size(if (onEditCost != null) 20.dp else 24.dp),
                                     tint = MaterialTheme.colorScheme.onPrimaryContainer
                                 )
                             }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Paid
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.Bolt
@@ -131,6 +132,8 @@ fun ChargeDetailScreen(
         if (uiState.isLoading) {
             MateDroidLoadingPlaceholder(modifier = Modifier.padding(padding))
         } else {
+            val context = LocalContext.current
+            val teslamateBaseUrl = uiState.teslamateBaseUrl
             uiState.chargeDetail?.let { detail ->
                 ChargeDetailContent(
                     detail = detail,
@@ -141,6 +144,12 @@ fun ChargeDetailScreen(
                     containingTrip = uiState.containingTrip,
                     onNavigateToTripDetail = onNavigateToTripDetail,
                     onRemoveFromTrip = viewModel::removeFromTrip,
+                    onEditCost = if (teslamateBaseUrl.isNotBlank()) {
+                        {
+                            val url = "$teslamateBaseUrl/charge-cost/$chargeId"
+                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                        }
+                    } else null,
                     modifier = Modifier.padding(padding)
                 )
             }
@@ -158,6 +167,7 @@ private fun ChargeDetailContent(
     containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
     onNavigateToTripDetail: (String) -> Unit,
     onRemoveFromTrip: () -> Unit,
+    onEditCost: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
@@ -221,6 +231,7 @@ private fun ChargeDetailContent(
             val currentAvgLabel = stringResource(R.string.current_avg)
             val totalLabel = stringResource(R.string.total)
             val perKwhLabel = stringResource(R.string.per_kwh)
+            val freeLabel = stringResource(R.string.charge_free)
 
             // Energy section
             StatsSectionCard(
@@ -288,18 +299,27 @@ private fun ChargeDetailContent(
                 )
             }
 
-            // Cost section
-            s.cost?.let { cost ->
-                if (cost > 0) {
-                    StatsSectionCard(
-                        title = costLabel,
-                        icon = Icons.Default.Paid,
-                        stats = listOf(
-                            StatItem(totalLabel, "$currencySymbol%.2f".format(cost)),
-                            StatItem(perKwhLabel, "$currencySymbol%.3f".format(cost / s.energyAdded.coerceAtLeast(0.001)))
-                        )
-                    )
-                }
+            // Cost section. Tappable (when a TeslaMate URL is configured) so the user can edit
+            // the cost in TeslaMate — including adding one to a free/uncosted charge, which is
+            // why the card still shows for cost == 0 as long as editing is possible.
+            val cost = s.cost ?: 0.0
+            if (cost > 0) {
+                StatsSectionCard(
+                    title = costLabel,
+                    icon = Icons.Default.Paid,
+                    stats = listOf(
+                        StatItem(totalLabel, "$currencySymbol%.2f".format(cost)),
+                        StatItem(perKwhLabel, "$currencySymbol%.3f".format(cost / s.energyAdded.coerceAtLeast(0.001)))
+                    ),
+                    onClick = onEditCost
+                )
+            } else if (onEditCost != null) {
+                StatsSectionCard(
+                    title = costLabel,
+                    icon = Icons.Default.Paid,
+                    stats = listOf(StatItem(totalLabel, freeLabel)),
+                    onClick = onEditCost
+                )
             }
 
             // Charts
@@ -645,7 +665,8 @@ data class StatItem(val label: String, val value: String)
 private fun StatsSectionCard(
     title: String,
     icon: ImageVector,
-    stats: List<StatItem>
+    stats: List<StatItem>,
+    onClick: (() -> Unit)? = null
 ) {
     // Get the current screen settings
     val configuration = LocalConfiguration.current
@@ -659,7 +680,9 @@ private fun StatsSectionCard(
     }
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
         )
@@ -669,7 +692,9 @@ private fun StatsSectionCard(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 12.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
             ) {
                 Icon(
                     imageVector = icon,
@@ -683,6 +708,16 @@ private fun StatsSectionCard(
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
+                // External-link affordance: signals the card opens TeslaMate's cost editor.
+                if (onClick != null) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
             }
 
             // Divide the list of statistics according to the calculated number of columns

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
@@ -29,7 +29,8 @@ data class ChargeDetailUiState(
     val stats: ChargeDetailStats? = null,
     val currencySymbol: String = "€",
     val isDcCharge: Boolean = false,
-    val containingTrip: Pair<Long, Trip>? = null
+    val containingTrip: Pair<Long, Trip>? = null,
+    val teslamateBaseUrl: String = ""
 )
 
 data class ChargeDetailStats(
@@ -76,7 +77,12 @@ class ChargeDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val settings = settingsDataStore.settings.first()
             val currency = Currency.findByCode(settings.currencyCode)
-            _uiState.update { it.copy(currencySymbol = currency.symbol) }
+            _uiState.update {
+                it.copy(
+                    currencySymbol = currency.symbol,
+                    teslamateBaseUrl = settings.teslamateBaseUrl
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -77,7 +77,7 @@ import com.matedroid.ui.components.parseListItemDate
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDuration
-import com.matedroid.util.formatMediumNoYear
+import com.matedroid.util.formatMedium
 import com.matedroid.util.parseIsoDateTime
 import java.time.LocalDate
 import java.util.Locale
@@ -537,7 +537,7 @@ private fun pluralStopsLabel(count: Int): String =
 
 private fun formatDateChip(dateStr: String): String {
     val dt = parseIsoDateTime(dateStr) ?: return dateStr
-    return dt.toLocalDate().formatMediumNoYear(Locale.getDefault()).uppercase(Locale.getDefault())
+    return dt.toLocalDate().formatMedium(Locale.getDefault()).uppercase(Locale.getDefault())
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
Three small fixes/improvements.

### 1. Year on the Trips list
The per-trip date chip now uses the medium date format **with** the year (e.g. `10 MAY 2026`) instead of day/month only.

### 2. Edit charge cost from the charge detail
Previously the TeslaMate cost-editor link existed only on the charges list. The charge **detail** Cost section now:
- shows an external-link icon (`OpenInNew`) in its header, and
- the whole card is tappable → opens `…/charge-cost/<id>` in TeslaMate.

It also renders for **free / uncosted** charges (showing "Free") when a TeslaMate URL is configured, so a missing cost can be added — matching the list's behaviour. Wired `teslamateBaseUrl` into `ChargeDetailViewModel`.

### 3. Merged-and-renamed trips showed a stale name on drive/charge detail
`findTripContaining` built the containing `Trip` via `TripAggregator.buildTrip(...)` without passing the saved trip's `name`, so `displayName()` fell back to the auto "city → city" label. Now it passes `name = match.trip.name`, so drive/charge detail shows the trip's current (renamed) name. Fixes both the drive and charge detail screens (shared code path).

## Verification
- `./gradlew compileDebugKotlin` ✅
- `./gradlew lintDebug` ✅ (only the pre-existing Moshi kapt warning)
- `./gradlew testDebugUnitTest` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)