### PR TITLE
Charge detail redesign + DC charge comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tap a drive or charge in the trip timeline to open its detail** — selecting a segment now shows a chevron on its info row; tapping it jumps straight to that drive's or charge's detail screen.
 
 ### Changed
+- **Redesigned the charge detail screen** — a compact hero (energy added and peak power in the car's accent colour) with quick stat tiles and the power curve up front, while the detailed stats and the battery, temperature and AC charts now live behind a "More details" toggle.
 - **The Trips list now shows the year on each trip's date chip**, not just day and month.
 - **"Short" drives are now those under 1 km** (was 0.1 km), so brief repositioning hops stop cluttering the lists and trip timelines when "Show short drives / charges" is off. Charges are unchanged (0.1 kWh or less).
 - **The trip timeline gives brief legs an honest sliver** instead of a fixed minimum block, so a quick 1 km hop no longer looks nearly as wide as a long highway leg.

--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -36,6 +36,9 @@ interface AggregateDao {
     @Query("SELECT * FROM charge_detail_aggregates WHERE chargeId = :chargeId")
     suspend fun getChargeAggregate(chargeId: Int): ChargeDetailAggregate?
 
+    @Query("SELECT * FROM charge_detail_aggregates WHERE carId = :carId")
+    suspend fun getChargeAggregatesForCar(carId: Int): List<ChargeDetailAggregate>
+
     @Query("DELETE FROM charge_detail_aggregates WHERE carId = :carId")
     suspend fun deleteChargeAggregatesForCar(carId: Int)
 

--- a/app/src/main/java/com/matedroid/domain/ChargeComparisonRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/ChargeComparisonRepository.kt
@@ -1,0 +1,110 @@
+package com.matedroid.domain
+
+import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.local.dao.ChargeSummaryDao
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.util.haversineMeters
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** One DC charge in a comparison set, assembled from cached summary + aggregate data. */
+data class ComparableCharge(
+    val chargeId: Int,
+    val startDate: String,
+    val address: String,
+    val brand: String?,
+    val peakKw: Int?,
+    val energyAdded: Double,
+    val durationMin: Int,
+    val cost: Double?,
+    val startBattery: Int,
+    val endBattery: Int,
+    val outsideTempAvg: Double?,
+    val distanceMeters: Double,
+    val isBase: Boolean
+) {
+    /** Cost per kWh, or null when the charge is free/uncosted or has no energy. */
+    val costPerKwh: Double?
+        get() = cost?.takeIf { it > 0 && energyAdded > 0 }?.let { it / energyAdded }
+}
+
+/** A base DC charge plus the other comparable DC charges in the same area. */
+data class ChargeComparison(
+    val base: ComparableCharge,
+    val others: List<ComparableCharge>,
+    val radiusMeters: Double
+) {
+    /** Base + others, for ranking and overlays. */
+    val all: List<ComparableCharge> get() = others + base
+
+    val totalCount: Int get() = others.size + 1
+
+    /** 1-based rank of the base charge by peak power among all sessions (1 = highest peak). */
+    val basePeakRank: Int
+        get() = all.sortedByDescending { it.peakKw ?: -1 }.indexOfFirst { it.isBase } + 1
+}
+
+/**
+ * Finds comparable DC charges for a given charge: same area (within a radius), DC-only. The data
+ * comes entirely from the local cache (charge summaries + detail aggregates), so it's cheap and
+ * works offline. AC charges and charges with no nearby DC sibling return null — nothing to compare.
+ */
+@Singleton
+class ChargeComparisonRepository @Inject constructor(
+    private val chargeSummaryDao: ChargeSummaryDao,
+    private val aggregateDao: AggregateDao
+) {
+    companion object {
+        /** Generous enough to catch multiple CPOs at one motorway stop (e.g. a Supercharger and an Ionity). */
+        const val DEFAULT_RADIUS_METERS = 2_000.0
+    }
+
+    suspend fun findComparable(
+        carId: Int,
+        baseChargeId: Int,
+        radiusMeters: Double = DEFAULT_RADIUS_METERS
+    ): ChargeComparison? {
+        val summaries = chargeSummaryDao.getAllForCar(carId)
+        val baseSummary = summaries.firstOrNull { it.chargeId == baseChargeId } ?: return null
+
+        val dcIds = aggregateDao.getDcChargeIds(carId).toSet()
+        if (baseChargeId !in dcIds) return null
+
+        val aggregates = aggregateDao.getChargeAggregatesForCar(carId).associateBy { it.chargeId }
+
+        fun toComparable(s: ChargeSummary, distanceMeters: Double): ComparableCharge {
+            val agg = aggregates[s.chargeId]
+            return ComparableCharge(
+                chargeId = s.chargeId,
+                startDate = s.startDate,
+                address = s.address,
+                brand = agg?.fastChargerBrand,
+                peakKw = agg?.maxChargerPower,
+                energyAdded = s.energyAdded,
+                durationMin = s.durationMin,
+                cost = s.cost,
+                startBattery = s.startBatteryLevel,
+                endBattery = s.endBatteryLevel,
+                outsideTempAvg = s.outsideTempAvg,
+                distanceMeters = distanceMeters,
+                isBase = s.chargeId == baseChargeId
+            )
+        }
+
+        val others = summaries
+            .asSequence()
+            .filter { it.chargeId != baseChargeId && it.chargeId in dcIds }
+            .map { it to haversineMeters(baseSummary.latitude, baseSummary.longitude, it.latitude, it.longitude) }
+            .filter { (_, distance) -> distance <= radiusMeters }
+            .map { (s, distance) -> toComparable(s, distance) }
+            .sortedByDescending { it.peakKw ?: -1 }
+            .toList()
+
+        if (others.isEmpty()) return null
+        return ChargeComparison(
+            base = toComparable(baseSummary, 0.0),
+            others = others,
+            radiusMeters = radiusMeters
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -1,0 +1,248 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
+import kotlin.math.roundToInt
+
+/** One session's charging curve in power-vs-SoC space. [points] are (SoC %, power kW). */
+data class OverlayCurve(
+    val label: String,
+    val color: Color,
+    val isBase: Boolean,
+    val points: List<Offset>
+)
+
+/**
+ * Overlays several charging sessions' power curves against state-of-charge. The base session is
+ * drawn bold with a soft fill; tap/drag shows a crosshair and each session's power at that SoC.
+ * Follows the project chart rules: 4 Y labels (¼/½/¾/end), 5 X labels (start/¼/½/¾/end), tap tooltip.
+ */
+@Composable
+fun PowerSocOverlayChart(
+    curves: List<OverlayCurve>,
+    modifier: Modifier = Modifier,
+    chartHeight: Dp = 190.dp
+) {
+    val valid = curves.filter { it.points.size >= 2 }
+    if (valid.isEmpty()) return
+
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val crosshairColor = MaterialTheme.colorScheme.onSurface
+
+    val socMin = valid.minOf { c -> c.points.minOf { it.x } }
+    val socMax = valid.maxOf { c -> c.points.maxOf { it.x } }
+    val socRange = (socMax - socMin).coerceAtLeast(1f)
+    val powerMaxRaw = valid.maxOf { c -> c.points.maxOf { it.y } }
+    val powerMax = (ceil(powerMaxRaw / 20f) * 20f).coerceAtLeast(20f)
+
+    val density = LocalDensity.current
+    val chartHeightPx = with(density) { chartHeight.toPx() }
+    val labelStripPx = with(density) { 18.dp.toPx() }
+    val topPad = with(density) { 6.dp.toPx() }
+
+    var selectedSoc by remember { mutableStateOf<Float?>(null) }
+
+    val labelPaint = remember(labelColor) {
+        android.graphics.Paint().apply {
+            color = labelColor.toArgb()
+            textSize = 26f
+            isAntiAlias = true
+        }
+    }
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(chartHeight + 18.dp)
+                .pointerInput(valid, socMin, socMax) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        down.consume()
+                        fun update(x: Float) {
+                            val frac = (x / size.width).coerceIn(0f, 1f)
+                            selectedSoc = socMin + frac * socRange
+                        }
+                        update(down.position.x)
+                        drag(down.id) { change ->
+                            change.consume()
+                            update(change.position.x)
+                        }
+                    }
+                }
+        ) {
+            val w = size.width
+            val plotH = chartHeightPx - topPad
+            fun xFor(soc: Float) = (soc - socMin) / socRange * w
+            fun yFor(power: Float) = topPad + (1f - power / powerMax) * plotH
+
+            // Horizontal gridlines + Y labels at 25/50/75/100% of the power range
+            for (i in 1..4) {
+                val v = powerMax * i / 4f
+                val y = yFor(v)
+                drawLine(gridColor, Offset(0f, y), Offset(w, y), strokeWidth = 1f)
+                drawContext.canvas.nativeCanvas.drawText("${v.roundToInt()}", 8f, y - 6f, labelPaint)
+            }
+
+            // X labels at 5 SoC positions
+            for (i in 0..4) {
+                val soc = socMin + socRange * i / 4f
+                val x = xFor(soc)
+                val txt = "${soc.roundToInt()}%"
+                val tw = labelPaint.measureText(txt)
+                val tx = when (i) {
+                    0 -> 0f
+                    4 -> (x - tw).coerceAtMost(w - tw)
+                    else -> x - tw / 2
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    txt, tx.coerceAtLeast(0f), chartHeightPx + labelStripPx - 2f, labelPaint
+                )
+            }
+
+            // Curves — others first so the base draws on top
+            valid.sortedBy { it.isBase }.forEach { c ->
+                val pts = c.points.sortedBy { it.x }
+                val path = Path()
+                pts.forEachIndexed { idx, p ->
+                    val px = xFor(p.x)
+                    val py = yFor(p.y)
+                    if (idx == 0) path.moveTo(px, py) else path.lineTo(px, py)
+                }
+                if (c.isBase) {
+                    val fill = Path().apply {
+                        addPath(path)
+                        lineTo(xFor(pts.last().x), yFor(0f))
+                        lineTo(xFor(pts.first().x), yFor(0f))
+                        close()
+                    }
+                    drawPath(
+                        fill,
+                        Brush.verticalGradient(listOf(c.color.copy(alpha = 0.25f), c.color.copy(alpha = 0f)))
+                    )
+                }
+                drawPath(
+                    path,
+                    c.color,
+                    style = Stroke(
+                        width = if (c.isBase) 7f else 4f,
+                        cap = StrokeCap.Round,
+                        join = StrokeJoin.Round
+                    )
+                )
+            }
+
+            // Crosshair + per-curve dots
+            selectedSoc?.let { soc ->
+                val cx = xFor(soc)
+                drawLine(
+                    crosshairColor.copy(alpha = 0.4f),
+                    Offset(cx, topPad),
+                    Offset(cx, chartHeightPx),
+                    strokeWidth = 1.5f
+                )
+                valid.forEach { c ->
+                    val power = interpolatePower(c.points, soc) ?: return@forEach
+                    drawCircle(c.color, radius = if (c.isBase) 7f else 5f, center = Offset(cx, yFor(power)))
+                }
+            }
+        }
+
+        // Tooltip — SoC and each session's power at the crosshair
+        selectedSoc?.let { soc ->
+            val rows = valid.mapNotNull { c -> interpolatePower(c.points, soc)?.let { c to it } }
+            if (rows.isNotEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 4.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Text(
+                        text = "${soc.roundToInt()}% SoC",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    rows.forEach { (curve, power) ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(
+                                modifier = Modifier
+                                    .size(8.dp)
+                                    .clip(CircleShape)
+                                    .background(curve.color)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "${power.roundToInt()} kW",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Linear interpolation of power at [soc] along a curve sorted by SoC; null when out of range. */
+private fun interpolatePower(points: List<Offset>, soc: Float): Float? {
+    val sorted = points.sortedBy { it.x }
+    if (sorted.isEmpty() || soc < sorted.first().x || soc > sorted.last().x) return null
+    for (i in 1 until sorted.size) {
+        val a = sorted[i - 1]
+        val b = sorted[i]
+        if (soc <= b.x) {
+            val span = (b.x - a.x)
+            if (span <= 0f) return a.y
+            val t = (soc - a.x) / span
+            return a.y + t * (b.y - a.y)
+        }
+    }
+    return sorted.last().y
+}

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -23,6 +23,7 @@ import com.matedroid.R
 import com.matedroid.ui.screens.battery.BatteryScreen
 import com.matedroid.ui.screens.charges.ChargeDetailScreen
 import com.matedroid.ui.screens.charges.ChargesScreen
+import com.matedroid.ui.screens.charges.CompareChargesScreen
 import com.matedroid.ui.screens.charges.CurrentChargeScreen
 import com.matedroid.ui.screens.dashboard.DashboardScreen
 import com.matedroid.ui.screens.demo.PalettePreviewScreen
@@ -66,6 +67,9 @@ sealed interface Screen {
 
     @Serializable
     data class ChargeDetail(val carId: Int, val chargeId: Int, val exteriorColor: String? = null) : Screen
+
+    @Serializable
+    data class CompareCharges(val carId: Int, val baseChargeId: Int, val exteriorColor: String? = null) : Screen
 
     @Serializable
     data class CurrentCharge(val carId: Int, val exteriorColor: String? = null) : Screen
@@ -262,6 +266,22 @@ fun NavGraph(
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToTripDetail = { tripStartDate ->
                     navController.navigate(Screen.TripDetail(route.carId, tripStartDate, route.exteriorColor))
+                },
+                onNavigateToCompare = { baseChargeId ->
+                    navController.navigate(Screen.CompareCharges(route.carId, baseChargeId, route.exteriorColor))
+                }
+            )
+        }
+
+        composable<Screen.CompareCharges> { backStackEntry ->
+            val route = backStackEntry.toRoute<Screen.CompareCharges>()
+            CompareChargesScreen(
+                carId = route.carId,
+                baseChargeId = route.baseChargeId,
+                exteriorColor = route.exteriorColor,
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToChargeDetail = { chargeId ->
+                    navController.navigate(Screen.ChargeDetail(route.carId, chargeId, route.exteriorColor))
                 }
             )
         }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeComparisonViewModel.kt
@@ -1,0 +1,70 @@
+package com.matedroid.ui.screens.charges
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.data.model.Currency
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.ChargeComparison
+import com.matedroid.domain.ChargeComparisonRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** How the comparison leaderboard is ranked. */
+enum class CompareSort { PEAK, DURATION, COST }
+
+data class ChargeComparisonUiState(
+    val isLoading: Boolean = true,
+    val comparison: ChargeComparison? = null,
+    val sort: CompareSort = CompareSort.PEAK,
+    val currencySymbol: String = "€",
+    val units: Units? = null
+)
+
+@HiltViewModel
+class ChargeComparisonViewModel @Inject constructor(
+    private val comparisonRepository: ChargeComparisonRepository,
+    private val repository: TeslamateRepository,
+    private val settingsDataStore: SettingsDataStore
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ChargeComparisonUiState())
+    val uiState: StateFlow<ChargeComparisonUiState> = _uiState.asStateFlow()
+
+    private var loaded = false
+
+    fun load(carId: Int, baseChargeId: Int) {
+        if (loaded) return
+        loaded = true
+
+        viewModelScope.launch {
+            val settings = settingsDataStore.settings.first()
+            val currency = Currency.findByCode(settings.currencyCode)
+            val units = when (val status = repository.getCarStatus(carId)) {
+                is ApiResult.Success -> status.data.units
+                is ApiResult.Error -> null
+            }
+            val comparison = comparisonRepository.findComparable(carId, baseChargeId)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    comparison = comparison,
+                    currencySymbol = currency.symbol,
+                    units = units
+                )
+            }
+        }
+    }
+
+    fun setSort(sort: CompareSort) {
+        _uiState.update { it.copy(sort = sort) }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeComparisonViewModel.kt
@@ -9,7 +9,9 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.ChargeComparison
 import com.matedroid.domain.ChargeComparisonRepository
+import com.matedroid.domain.ComparableCharge
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,12 +23,24 @@ import javax.inject.Inject
 /** How the comparison leaderboard is ranked. */
 enum class CompareSort { PEAK, DURATION, COST }
 
+/** One point of a charging curve: power (kW) at a given state of charge (%). */
+data class CurvePoint(val soc: Float, val power: Float)
+
+/** A session's charging curve in power-vs-SoC space, for the overlay chart. */
+data class SessionCurve(
+    val chargeId: Int,
+    val isBase: Boolean,
+    val points: List<CurvePoint>
+)
+
 data class ChargeComparisonUiState(
     val isLoading: Boolean = true,
     val comparison: ChargeComparison? = null,
     val sort: CompareSort = CompareSort.PEAK,
     val currencySymbol: String = "€",
-    val units: Units? = null
+    val units: Units? = null,
+    val curves: List<SessionCurve> = emptyList(),
+    val curvesLoading: Boolean = false
 )
 
 @HiltViewModel
@@ -40,10 +54,16 @@ class ChargeComparisonViewModel @Inject constructor(
     val uiState: StateFlow<ChargeComparisonUiState> = _uiState.asStateFlow()
 
     private var loaded = false
+    private var carId: Int? = null
+
+    /** Cache of fetched curves by charge id, so re-sorting the overlay doesn't refetch details. */
+    private val curveCache = mutableMapOf<Int, SessionCurve>()
+    private var curveFetchJob: Job? = null
 
     fun load(carId: Int, baseChargeId: Int) {
         if (loaded) return
         loaded = true
+        this.carId = carId
 
         viewModelScope.launch {
             val settings = settingsDataStore.settings.first()
@@ -61,10 +81,56 @@ class ChargeComparisonViewModel @Inject constructor(
                     units = units
                 )
             }
+            refreshCurves(carId)
         }
     }
 
     fun setSort(sort: CompareSort) {
         _uiState.update { it.copy(sort = sort) }
+        carId?.let { refreshCurves(it) }
+    }
+
+    /** Pick the base + the top others by the current sort, and overlay at most [MAX_CURVES] curves. */
+    private fun refreshCurves(carId: Int) {
+        val comparison = _uiState.value.comparison ?: return
+        val ordered = listOf(comparison.base) +
+            sortedOthers(comparison.others, _uiState.value.sort).take(MAX_CURVES - 1)
+
+        curveFetchJob?.cancel()
+        curveFetchJob = viewModelScope.launch {
+            _uiState.update { it.copy(curvesLoading = true) }
+            ordered.forEach { charge ->
+                if (!curveCache.containsKey(charge.chargeId)) {
+                    buildCurve(carId, charge.chargeId, charge.isBase)?.let { curveCache[charge.chargeId] = it }
+                }
+            }
+            val curves = ordered.mapNotNull { curveCache[it.chargeId] }
+            _uiState.update { it.copy(curves = curves, curvesLoading = false) }
+        }
+    }
+
+    private fun sortedOthers(others: List<ComparableCharge>, sort: CompareSort): List<ComparableCharge> =
+        when (sort) {
+            CompareSort.PEAK -> others.sortedByDescending { it.peakKw ?: -1 }
+            CompareSort.DURATION -> others.sortedBy { it.durationMin }
+            CompareSort.COST -> others.sortedBy { it.costPerKwh ?: Double.MAX_VALUE }
+        }
+
+    private suspend fun buildCurve(carId: Int, chargeId: Int, isBase: Boolean): SessionCurve? {
+        val detail = when (val result = repository.getChargeDetail(carId, chargeId)) {
+            is ApiResult.Success -> result.data
+            is ApiResult.Error -> return null
+        }
+        val points = detail.chargePoints.orEmpty().mapNotNull { point ->
+            val soc = point.batteryLevel?.toFloat()
+            val power = point.chargerPower?.toFloat()
+            if (soc != null && power != null && power >= 0f) CurvePoint(soc, power) else null
+        }
+        return if (points.size >= 2) SessionCurve(chargeId, isBase, points) else null
+    }
+
+    companion object {
+        /** Max curves overlaid at once (base + up to 4 others) — keeps a busy SuC readable. */
+        const val MAX_CURVES = 5
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Paid
 import androidx.compose.material.icons.filled.BatteryChargingFull
@@ -33,6 +35,7 @@ import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.EnergySavingsLeaf
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.Schedule
@@ -68,6 +71,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -78,6 +82,7 @@ import com.matedroid.R
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.ChargePoint
 import com.matedroid.data.api.models.Units
+import com.matedroid.domain.ChargeComparison
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
@@ -102,6 +107,7 @@ fun ChargeDetailScreen(
     exteriorColor: String? = null,
     onNavigateBack: () -> Unit,
     onNavigateToTripDetail: (tripStartDate: String) -> Unit = {},
+    onNavigateToCompare: (baseChargeId: Int) -> Unit = {},
     viewModel: ChargeDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -151,6 +157,8 @@ fun ChargeDetailScreen(
                     isDcCharge = uiState.isDcCharge,
                     exteriorColor = exteriorColor,
                     containingTrip = uiState.containingTrip,
+                    comparison = uiState.comparison,
+                    onCompareClick = { onNavigateToCompare(chargeId) },
                     onNavigateToTripDetail = onNavigateToTripDetail,
                     onRemoveFromTrip = viewModel::removeFromTrip,
                     onEditCost = if (teslamateBaseUrl.isNotBlank()) {
@@ -175,6 +183,8 @@ private fun ChargeDetailContent(
     isDcCharge: Boolean,
     exteriorColor: String?,
     containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
+    comparison: ChargeComparison?,
+    onCompareClick: () -> Unit,
     onNavigateToTripDetail: (String) -> Unit,
     onRemoveFromTrip: () -> Unit,
     onEditCost: (() -> Unit)? = null,
@@ -225,6 +235,11 @@ private fun ChargeDetailContent(
         // Accent stat tiles — the headline secondary figures
         stats?.let { s ->
             ChargeStatTiles(stats = s, units = units, palette = palette)
+        }
+
+        // Compare entry — appears for DC charges with comparable sessions nearby
+        comparison?.let { cmp ->
+            ChargeCompareCard(comparison = cmp, palette = palette, onClick = onCompareClick)
         }
 
         // Primary chart: power curve, accent-tinted by charge type (DC orange / AC green)
@@ -511,6 +526,61 @@ private fun ChargeStatTile(
             fontWeight = FontWeight.Bold,
             color = accent,
             maxLines = 1
+        )
+    }
+}
+
+/** Entry point into the charge-comparison screen, shown only for DC charges with nearby siblings. */
+@Composable
+private fun ChargeCompareCard(
+    comparison: ChargeComparison,
+    palette: CarColorPalette,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(palette.accent.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(palette.accent.copy(alpha = 0.20f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Insights,
+                contentDescription = null,
+                tint = palette.accent,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.compare_charges_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = pluralStringResource(
+                    R.plurals.compare_sessions_nearby,
+                    comparison.others.size,
+                    comparison.others.size
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -221,16 +222,6 @@ private fun ChargeDetailContent(
             onEditCost = onEditCost
         )
 
-        // Part-of-trip banner
-        if (containingTrip != null) {
-            val (_, trip) = containingTrip
-            com.matedroid.ui.components.PartOfTripCard(
-                tripRoute = trip.displayName(),
-                onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
-                onConfirmRemove = onRemoveFromTrip
-            )
-        }
-
         // Accent stat tiles — the headline secondary figures
         stats?.let { s ->
             ChargeStatTiles(stats = s, units = units, palette = palette)
@@ -276,13 +267,24 @@ private fun ChargeDetailContent(
             )
         }
 
+        // Part-of-trip banner — kept at the very end, below the details
+        if (containingTrip != null) {
+            val (_, trip) = containingTrip
+            com.matedroid.ui.components.PartOfTripCard(
+                tripRoute = trip.displayName(),
+                onNavigateToTrip = { onNavigateToTripDetail(trip.startDate) },
+                onConfirmRemove = onRemoveFromTrip
+            )
+        }
+
         Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
 /**
- * Compact hero: location, the two headline figures (energy added and peak power) in the car's
- * accent colour, a one-line summary, and the start timestamp. Replaces the old verbose header.
+ * Compact hero: location, the dominant figure (energy added) in the car's accent colour, a
+ * balanced row of labelled key figures (peak power, battery swing, duration), and a footer with
+ * the start time and the (editable) cost. Replaces the old verbose header.
  */
 @Composable
 private fun ChargeHeroSection(
@@ -297,8 +299,11 @@ private fun ChargeHeroSection(
     val unknownLocationLabel = stringResource(R.string.unknown_location)
     val unknownLabel = stringResource(R.string.unknown)
     val freeLabel = stringResource(R.string.charge_free)
+    val peakLabel = stringResource(R.string.peak)
+    val batteryLabel = stringResource(R.string.battery)
+    val durationLabel = stringResource(R.string.duration)
 
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
         // Location
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
@@ -316,12 +321,15 @@ private fun ChargeHeroSection(
             )
         }
 
-        // Headline figures: energy added [· peak power] + AC/DC badge
-        Row(verticalAlignment = Alignment.Bottom) {
-            detail.chargeEnergyAdded?.let { energy ->
+        // Dominant figure: energy added, with the AC/DC badge on the right
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.Bottom) {
                 Text(
-                    text = "%.1f".format(energy),
-                    style = MaterialTheme.typography.headlineSmall,
+                    text = "%.1f".format(detail.chargeEnergyAdded ?: 0.0),
+                    style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
                     color = palette.accent
                 )
@@ -329,41 +337,61 @@ private fun ChargeHeroSection(
                     text = " kWh",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 1.dp)
+                    modifier = Modifier.padding(start = 2.dp, bottom = 3.dp)
                 )
             }
-            if (stats != null && stats.powerMax > 0) {
-                Text(
-                    text = "  ·  ${stats.powerMax}",
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = palette.accent
-                )
-                Text(
-                    text = " kW",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 1.dp)
-                )
-            }
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.weight(1f))
             ChargeTypeBadge(isDcCharge = isDcCharge)
         }
 
-        // Summary line: SoC range · duration   |   cost (tappable to edit in TeslaMate)
+        // Balanced row of labelled key figures
+        if (stats != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (stats.powerMax > 0) {
+                    HeroStat(
+                        label = peakLabel,
+                        value = "${stats.powerMax} kW",
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                HeroStat(
+                    label = batteryLabel,
+                    value = "${stats.batteryStart}% → ${stats.batteryEnd}%",
+                    modifier = Modifier.weight(1f)
+                )
+                HeroStat(
+                    label = durationLabel,
+                    value = formatDurationCompact(stats.durationMin),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+        // Footer: start time (left) and cost (right, tappable to edit in TeslaMate)
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = if (stats != null)
-                    "${stats.batteryStart}% → ${stats.batteryEnd}%  ·  ${formatDurationCompact(stats.durationMin)}"
-                else "",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Schedule,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(5.dp))
+                Text(
+                    text = formatDateTime(detail.startDate, unknownLabel, is24Hour),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
 
             val cost = detail.cost ?: 0.0
             if (cost > 0 || onEditCost != null) {
@@ -395,26 +423,35 @@ private fun ChargeHeroSection(
                 }
             }
         }
-
-        // Start timestamp — quiet caption
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.Default.Schedule,
-                contentDescription = null,
-                modifier = Modifier.size(13.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                text = formatDateTime(detail.startDate, unknownLabel, is24Hour),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
     }
 }
 
-/** Two-up grid of accent tiles for the headline secondary figures. */
+/** A single labelled figure: small uppercase label over a bold value. Left-aligned in a column. */
+@Composable
+private fun HeroStat(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(
+            text = label.uppercase(java.util.Locale.getDefault()),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1
+        )
+    }
+}
+
+/** A single row of accent tiles for the secondary "quality" figures (avg power, efficiency, temp). */
 @Composable
 private fun ChargeStatTiles(
     stats: ChargeDetailStats,
@@ -423,33 +460,26 @@ private fun ChargeStatTiles(
 ) {
     val avgLabel = stringResource(R.string.average)
     val efficiencyLabel = stringResource(R.string.efficiency)
-    val batteryLabel = stringResource(R.string.battery)
     val temperatureLabel = stringResource(R.string.temperature)
 
     val tiles = buildList {
         if (stats.powerMax > 0) add(avgLabel to "${stats.powerAvg.roundToInt()} kW")
         add(efficiencyLabel to "${stats.efficiency.roundToInt()}%")
-        add(batteryLabel to "+${stats.batteryAdded}%")
         if (stats.tempMax > -100) add(temperatureLabel to UnitFormatter.formatTemperature(stats.tempAvg, units))
     }
     if (tiles.isEmpty()) return
 
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        tiles.chunked(2).forEach { rowTiles ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                rowTiles.forEach { (label, value) ->
-                    ChargeStatTile(
-                        label = label,
-                        value = value,
-                        accent = palette.accent,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                if (rowTiles.size < 2) Spacer(modifier = Modifier.weight(1f))
-            }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        tiles.forEach { (label, value) ->
+            ChargeStatTile(
+                label = label,
+                value = value,
+                accent = palette.accent,
+                modifier = Modifier.weight(1f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -3,9 +3,12 @@ package com.matedroid.ui.screens.charges
 import android.content.Intent
 import android.net.Uri
 import android.view.MotionEvent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,13 +32,13 @@ import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.EnergySavingsLeaf
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -51,12 +54,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -77,6 +82,8 @@ import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.screens.trips.displayName
+import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.ui.theme.CarColorPalettes
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
@@ -141,6 +148,7 @@ fun ChargeDetailScreen(
                     units = uiState.units,
                     currencySymbol = uiState.currencySymbol,
                     isDcCharge = uiState.isDcCharge,
+                    exteriorColor = exteriorColor,
                     containingTrip = uiState.containingTrip,
                     onNavigateToTripDetail = onNavigateToTripDetail,
                     onRemoveFromTrip = viewModel::removeFromTrip,
@@ -164,12 +172,14 @@ private fun ChargeDetailContent(
     units: Units?,
     currencySymbol: String,
     isDcCharge: Boolean,
+    exteriorColor: String?,
     containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
     onNavigateToTripDetail: (String) -> Unit,
     onRemoveFromTrip: () -> Unit,
     onEditCost: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    val palette = CarColorPalettes.forExteriorColor(exteriorColor, isSystemInDarkTheme())
     val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
     val scrollState = rememberScrollState()
     var sharedXFraction by remember { mutableStateOf<Float?>(null) }
@@ -177,6 +187,19 @@ private fun ChargeDetailContent(
     LaunchedEffect(scrollState) {
         snapshotFlow { scrollState.isScrollInProgress }
             .collect { isScrolling -> if (isScrolling) sharedXFraction = null }
+    }
+
+    // Chart time labels are shared by the primary power chart and the secondary charts.
+    val chargePoints = detail.chargePoints
+    val timeLabels = chargePoints?.takeIf { it.size > 2 }
+        ?.let { extractTimeLabels(it, is24Hour) } ?: emptyList()
+    val fractionToTimeLabel: (Float) -> String = label@{ fraction ->
+        val cp = chargePoints
+        if (cp == null || cp.size <= 2) return@label ""
+        val index = (fraction * cp.lastIndex).roundToInt().coerceIn(0, cp.lastIndex)
+        cp[index].date?.let { dateStr ->
+            parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
+        } ?: ""
     }
 
     Column(
@@ -187,8 +210,16 @@ private fun ChargeDetailContent(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Location header card
-        LocationHeaderCard(detail = detail, currencySymbol = currencySymbol, isDcCharge = isDcCharge, onEditCost = onEditCost)
+        // Hero: location, headline energy/power, key meta, AC/DC badge
+        ChargeHeroSection(
+            detail = detail,
+            stats = stats,
+            isDcCharge = isDcCharge,
+            currencySymbol = currencySymbol,
+            palette = palette,
+            is24Hour = is24Hour,
+            onEditCost = onEditCost
+        )
 
         // Part-of-trip banner
         if (containingTrip != null) {
@@ -200,389 +231,444 @@ private fun ChargeDetailContent(
             )
         }
 
-        // Map showing charge location
-        if (detail.latitude != null && detail.longitude != null) {
-            ChargeMapCard(latitude = detail.latitude, longitude = detail.longitude)
+        // Accent stat tiles — the headline secondary figures
+        stats?.let { s ->
+            ChargeStatTiles(stats = s, units = units, palette = palette)
         }
 
-        // Stats grid
+        // Primary chart: power curve, accent-tinted by charge type (DC orange / AC green)
+        val cp = chargePoints
+        if (cp != null && cp.size > 2 && cp.any { (it.chargerPower ?: 0) > 0 }) {
+            PowerChartCard(
+                chargePoints = cp,
+                timeLabels = timeLabels,
+                title = stringResource(R.string.power_profile),
+                color = if (isDcCharge) palette.dcColor else palette.acColor,
+                externalSelectedFraction = sharedXFraction,
+                onXSelected = { sharedXFraction = it },
+                fractionToTimeLabel = fractionToTimeLabel
+            )
+        }
+
+        // Map showing charge location
+        if (detail.latitude != null && detail.longitude != null) {
+            ChargeMapCard(
+                latitude = detail.latitude,
+                longitude = detail.longitude,
+                accent = palette.accent
+            )
+        }
+
+        // Everything else, tucked away behind a tap by default
         stats?.let { s ->
-            // Localized labels
-            val energyLabel = stringResource(R.string.energy)
-            val batteryLabel = stringResource(R.string.battery)
-            val powerLabel = stringResource(R.string.power)
-            val chargerLabel = stringResource(R.string.charger)
-            val temperatureLabel = stringResource(R.string.temperature)
-            val costLabel = stringResource(R.string.cost)
-            val addedLabel = stringResource(R.string.energy_added)
-            val usedLabel = stringResource(R.string.used)
-            val efficiencyLabel = stringResource(R.string.efficiency)
-            val startLabel = stringResource(R.string.start)
-            val endLabel = stringResource(R.string.end)
-            val durationLabel = stringResource(R.string.duration)
-            val maximumLabel = stringResource(R.string.maximum)
-            val minimumLabel = stringResource(R.string.minimum)
-            val averageLabel = stringResource(R.string.average)
-            val voltageMaxLabel = stringResource(R.string.voltage_max)
-            val voltageMinLabel = stringResource(R.string.voltage_min)
-            val voltageAvgLabel = stringResource(R.string.voltage_avg)
-            val currentMaxLabel = stringResource(R.string.current_max)
-            val currentMinLabel = stringResource(R.string.current_min)
-            val currentAvgLabel = stringResource(R.string.current_avg)
-            val totalLabel = stringResource(R.string.total)
-            val perKwhLabel = stringResource(R.string.per_kwh)
-            val freeLabel = stringResource(R.string.charge_free)
-
-            // Energy section
-            StatsSectionCard(
-                title = energyLabel,
-                icon = Icons.Default.EnergySavingsLeaf,
-                stats = listOf(
-                    StatItem(addedLabel, "%.2f kWh".format(s.energyAdded)),
-                    StatItem(usedLabel, "%.2f kWh".format(s.energyUsed)),
-                    StatItem(efficiencyLabel, "%.1f%%".format(s.efficiency))
-                )
+            ChargeMoreDetails(
+                stats = s,
+                units = units,
+                isDcCharge = isDcCharge,
+                currencySymbol = currencySymbol,
+                palette = palette,
+                chargePoints = chargePoints?.takeIf { it.size > 2 },
+                timeLabels = timeLabels,
+                sharedXFraction = sharedXFraction,
+                onXSelected = { sharedXFraction = it },
+                fractionToTimeLabel = fractionToTimeLabel,
+                onEditCost = onEditCost
             )
-
-            // Battery section
-            StatsSectionCard(
-                title = batteryLabel,
-                icon = Icons.Default.BatteryChargingFull,
-                stats = listOf(
-                    StatItem(startLabel, "${s.batteryStart}%"),
-                    StatItem(endLabel, "${s.batteryEnd}%"),
-                    StatItem(addedLabel, "+${s.batteryAdded}%"),
-                    StatItem(durationLabel, formatDurationCompact(s.durationMin))
-                )
-            )
-
-            // Power section
-            if (s.powerMax > 0) {
-                StatsSectionCard(
-                    title = powerLabel,
-                    icon = Icons.Default.Bolt,
-                    stats = listOf(
-                        StatItem(maximumLabel, "${s.powerMax} kW"),
-                        StatItem(minimumLabel, "${s.powerMin} kW"),
-                        StatItem(averageLabel, "%.1f kW".format(s.powerAvg))
-                    )
-                )
-            }
-
-            // Voltage & Current section
-            // Shown only for AC charges
-            if (!isDcCharge) {
-                StatsSectionCard(
-                    title = chargerLabel,
-                    icon = Icons.Default.ElectricalServices,
-                    stats = listOf(
-                        StatItem(voltageMaxLabel, "${s.voltageMax} V"),
-                        StatItem(voltageMinLabel, "${s.voltageMin} V"),
-                        StatItem(voltageAvgLabel, "%.0f V".format(s.voltageAvg)),
-                        StatItem(currentMaxLabel, "${s.currentMax} A"),
-                        StatItem(currentMinLabel, "${s.currentMin} A"),
-                        StatItem(currentAvgLabel, "%.1f A".format(s.currentAvg))
-                    )
-                )
-            }
-
-            // Temperature section
-            if (s.tempMax > -100) {
-                StatsSectionCard(
-                    title = temperatureLabel,
-                    icon = Icons.Default.DeviceThermostat,
-                    stats = listOf(
-                        StatItem(maximumLabel, UnitFormatter.formatTemperature(s.tempMax, units)),
-                        StatItem(minimumLabel, UnitFormatter.formatTemperature(s.tempMin, units)),
-                        StatItem(averageLabel, UnitFormatter.formatTemperature(s.tempAvg, units))
-                    )
-                )
-            }
-
-            // Cost section. Tappable (when a TeslaMate URL is configured) so the user can edit
-            // the cost in TeslaMate — including adding one to a free/uncosted charge, which is
-            // why the card still shows for cost == 0 as long as editing is possible.
-            val cost = s.cost ?: 0.0
-            if (cost > 0) {
-                StatsSectionCard(
-                    title = costLabel,
-                    icon = Icons.Default.Paid,
-                    stats = listOf(
-                        StatItem(totalLabel, "$currencySymbol%.2f".format(cost)),
-                        StatItem(perKwhLabel, "$currencySymbol%.3f".format(cost / s.energyAdded.coerceAtLeast(0.001)))
-                    ),
-                    onClick = onEditCost
-                )
-            } else if (onEditCost != null) {
-                StatsSectionCard(
-                    title = costLabel,
-                    icon = Icons.Default.Paid,
-                    stats = listOf(StatItem(totalLabel, freeLabel)),
-                    onClick = onEditCost
-                )
-            }
-
-            // Charts
-            val chargePoints = detail.chargePoints
-            if (!chargePoints.isNullOrEmpty() && chargePoints.size > 2) {
-                // Extract time range for labels
-                val timeLabels = extractTimeLabels(chargePoints, is24Hour)
-                val fractionToTimeLabel: (Float) -> String = { fraction ->
-                    val index = (fraction * chargePoints.lastIndex).roundToInt().coerceIn(0, chargePoints.lastIndex)
-                    chargePoints[index].date?.let { dateStr ->
-                        parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
-                    } ?: ""
-                }
-
-                // Localized chart titles
-                val powerProfileTitle = stringResource(R.string.power_profile)
-                val voltageProfileTitle = stringResource(R.string.voltage_profile)
-                val currentProfileTitle = stringResource(R.string.current_profile)
-                val batteryLevelTitle = stringResource(R.string.battery_level)
-
-                if (chargePoints.any { (it.chargerPower ?: 0) > 0 }) {
-                    PowerChartCard(
-                        chargePoints = chargePoints,
-                        timeLabels = timeLabels,
-                        title = powerProfileTitle,
-                        externalSelectedFraction = sharedXFraction,
-                        onXSelected = { sharedXFraction = it },
-                        fractionToTimeLabel = fractionToTimeLabel
-                    )
-                }
-                // Only show voltage and current charts for AC charges
-                if (!isDcCharge) {
-                    if (chargePoints.any { (it.chargerVoltage ?: 0) > 0 }) {
-                        VoltageChartCard(
-                            chargePoints = chargePoints,
-                            timeLabels = timeLabels,
-                            title = voltageProfileTitle,
-                            externalSelectedFraction = sharedXFraction,
-                            onXSelected = { sharedXFraction = it },
-                            fractionToTimeLabel = fractionToTimeLabel
-                        )
-                    }
-                    if (chargePoints.any { (it.chargerCurrent ?: 0) > 0 }) {
-                        CurrentChartCard(
-                            chargePoints = chargePoints,
-                            timeLabels = timeLabels,
-                            title = currentProfileTitle,
-                            externalSelectedFraction = sharedXFraction,
-                            onXSelected = { sharedXFraction = it },
-                            fractionToTimeLabel = fractionToTimeLabel
-                        )
-                    }
-                }
-                if (chargePoints.any { it.outsideTemp != null }) {
-                    TemperatureChartCard(
-                        chargePoints = chargePoints,
-                        units = units,
-                        timeLabels = timeLabels,
-                        title = temperatureLabel,
-                        externalSelectedFraction = sharedXFraction,
-                        onXSelected = { sharedXFraction = it },
-                        fractionToTimeLabel = fractionToTimeLabel
-                    )
-                }
-                if (chargePoints.any { it.batteryLevel != null }) {
-                    BatteryChartCard(
-                        chargePoints = chargePoints,
-                        timeLabels = timeLabels,
-                        title = batteryLevelTitle,
-                        externalSelectedFraction = sharedXFraction,
-                        onXSelected = { sharedXFraction = it },
-                        fractionToTimeLabel = fractionToTimeLabel
-                    )
-                }
-            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
+/**
+ * Compact hero: location, the two headline figures (energy added and peak power) in the car's
+ * accent colour, a one-line summary, and the start timestamp. Replaces the old verbose header.
+ */
 @Composable
-private fun LocationHeaderCard(
+private fun ChargeHeroSection(
     detail: ChargeDetail,
-    currencySymbol: String,
+    stats: ChargeDetailStats?,
     isDcCharge: Boolean,
+    currencySymbol: String,
+    palette: CarColorPalette,
+    is24Hour: Boolean,
     onEditCost: (() -> Unit)? = null
 ) {
-    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
-    val locationLabel = stringResource(R.string.location)
     val unknownLocationLabel = stringResource(R.string.unknown_location)
-    val startedLabel = stringResource(R.string.started)
-    val endedLabel = stringResource(R.string.ended)
-    val energyAddedLabel = stringResource(R.string.energy_added_header)
-    val costLabel = stringResource(R.string.cost)
     val unknownLabel = stringResource(R.string.unknown)
+    val freeLabel = stringResource(R.string.charge_free)
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            // Location
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.primary
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        // Location
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = palette.accent
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = detail.address ?: unknownLocationLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2
+            )
+        }
+
+        // Headline figures: energy added [· peak power] + AC/DC badge
+        Row(verticalAlignment = Alignment.Bottom) {
+            detail.chargeEnergyAdded?.let { energy ->
+                Text(
+                    text = "%.1f".format(energy),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = palette.accent
                 )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = locationLabel,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = detail.address ?: unknownLocationLabel,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
+                Text(
+                    text = " kWh",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 1.dp)
+                )
             }
+            if (stats != null && stats.powerMax > 0) {
+                Text(
+                    text = "  ·  ${stats.powerMax}",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = palette.accent
+                )
+                Text(
+                    text = " kW",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 1.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            ChargeTypeBadge(isDcCharge = isDcCharge)
+        }
 
-            HorizontalDivider(
-                modifier = Modifier.padding(start = 36.dp),
-                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f)
+        // Summary line: SoC range · duration   |   cost (tappable to edit in TeslaMate)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (stats != null)
+                    "${stats.batteryStart}% → ${stats.batteryEnd}%  ·  ${formatDurationCompact(stats.durationMin)}"
+                else "",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
             )
 
-            // Start time
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Schedule,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = startedLabel,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = formatDateTime(detail.startDate, unknownLabel, is24Hour),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-            }
-
-            // End time
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Schedule,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = endedLabel,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = formatDateTime(detail.endDate, unknownLabel, is24Hour),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                    detail.durationStr?.let { duration ->
-                        Text(
-                            text = stringResource(R.string.duration_label, duration),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
-                    }
-                }
-            }
-
-            // Energy added and cost summary
-            detail.chargeEnergyAdded?.let { energy ->
-                HorizontalDivider(
-                    modifier = Modifier.padding(start = 36.dp),
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f)
-                )
-
+            val cost = detail.cost ?: 0.0
+            if (cost > 0 || onEditCost != null) {
+                val costText = if (cost > 0) "$currencySymbol%.2f".format(cost) else freeLabel
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = if (onEditCost != null) {
+                        Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable(onClick = onEditCost)
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    } else Modifier
                 ) {
-                    // Energy Added (left side) with AC/DC badge
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = costText,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    if (onEditCost != null) {
+                        Spacer(modifier = Modifier.width(4.dp))
                         Icon(
-                            imageVector = Icons.Default.Power,
+                            imageVector = Icons.AutoMirrored.Filled.OpenInNew,
                             contentDescription = null,
-                            modifier = Modifier.size(24.dp),
-                            tint = Color(0xFF4CAF50)
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column {
-                            Text(
-                                text = energyAddedLabel,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                    }
+                }
+            }
+        }
+
+        // Start timestamp — quiet caption
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.Schedule,
+                contentDescription = null,
+                modifier = Modifier.size(13.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = formatDateTime(detail.startDate, unknownLabel, is24Hour),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/** Two-up grid of accent tiles for the headline secondary figures. */
+@Composable
+private fun ChargeStatTiles(
+    stats: ChargeDetailStats,
+    units: Units?,
+    palette: CarColorPalette
+) {
+    val avgLabel = stringResource(R.string.average)
+    val efficiencyLabel = stringResource(R.string.efficiency)
+    val batteryLabel = stringResource(R.string.battery)
+    val temperatureLabel = stringResource(R.string.temperature)
+
+    val tiles = buildList {
+        if (stats.powerMax > 0) add(avgLabel to "${stats.powerAvg.roundToInt()} kW")
+        add(efficiencyLabel to "${stats.efficiency.roundToInt()}%")
+        add(batteryLabel to "+${stats.batteryAdded}%")
+        if (stats.tempMax > -100) add(temperatureLabel to UnitFormatter.formatTemperature(stats.tempAvg, units))
+    }
+    if (tiles.isEmpty()) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        tiles.chunked(2).forEach { rowTiles ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                rowTiles.forEach { (label, value) ->
+                    ChargeStatTile(
+                        label = label,
+                        value = value,
+                        accent = palette.accent,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                if (rowTiles.size < 2) Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChargeStatTile(
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(accent.copy(alpha = 0.12f))
+            .padding(vertical = 12.dp, horizontal = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = label.uppercase(java.util.Locale.getDefault()),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1
+        )
+    }
+}
+
+/**
+ * Collapsible section holding the detailed stat cards and the secondary charts. Collapsed by
+ * default to keep the screen calm; the headline figures live in the hero and tiles above.
+ */
+@Composable
+private fun ChargeMoreDetails(
+    stats: ChargeDetailStats,
+    units: Units?,
+    isDcCharge: Boolean,
+    currencySymbol: String,
+    palette: CarColorPalette,
+    chargePoints: List<ChargePoint>?,
+    timeLabels: List<String>,
+    sharedXFraction: Float?,
+    onXSelected: (Float?) -> Unit,
+    fractionToTimeLabel: (Float) -> String,
+    onEditCost: (() -> Unit)? = null
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "moreDetailsChevron")
+    val temperatureLabel = stringResource(R.string.temperature)
+
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { expanded = !expanded }
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(if (expanded) R.string.hide_details else R.string.more_details),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = palette.accent
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = palette.accent,
+                modifier = Modifier
+                    .size(22.dp)
+                    .rotate(rotation)
+            )
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                // Energy section
+                StatsSectionCard(
+                    title = stringResource(R.string.energy),
+                    icon = Icons.Default.EnergySavingsLeaf,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.energy_added), "%.2f kWh".format(stats.energyAdded)),
+                        StatItem(stringResource(R.string.used), "%.2f kWh".format(stats.energyUsed)),
+                        StatItem(stringResource(R.string.efficiency), "%.1f%%".format(stats.efficiency))
+                    )
+                )
+
+                // Battery section
+                StatsSectionCard(
+                    title = stringResource(R.string.battery),
+                    icon = Icons.Default.BatteryChargingFull,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.start), "${stats.batteryStart}%"),
+                        StatItem(stringResource(R.string.end), "${stats.batteryEnd}%"),
+                        StatItem(stringResource(R.string.energy_added), "+${stats.batteryAdded}%"),
+                        StatItem(stringResource(R.string.duration), formatDurationCompact(stats.durationMin))
+                    )
+                )
+
+                // Power section
+                if (stats.powerMax > 0) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.power),
+                        icon = Icons.Default.Bolt,
+                        stats = listOf(
+                            StatItem(stringResource(R.string.maximum), "${stats.powerMax} kW"),
+                            StatItem(stringResource(R.string.minimum), "${stats.powerMin} kW"),
+                            StatItem(stringResource(R.string.average), "%.1f kW".format(stats.powerAvg))
+                        )
+                    )
+                }
+
+                // Voltage & current — AC only
+                if (!isDcCharge) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.charger),
+                        icon = Icons.Default.ElectricalServices,
+                        stats = listOf(
+                            StatItem(stringResource(R.string.voltage_max), "${stats.voltageMax} V"),
+                            StatItem(stringResource(R.string.voltage_min), "${stats.voltageMin} V"),
+                            StatItem(stringResource(R.string.voltage_avg), "%.0f V".format(stats.voltageAvg)),
+                            StatItem(stringResource(R.string.current_max), "${stats.currentMax} A"),
+                            StatItem(stringResource(R.string.current_min), "${stats.currentMin} A"),
+                            StatItem(stringResource(R.string.current_avg), "%.1f A".format(stats.currentAvg))
+                        )
+                    )
+                }
+
+                // Temperature section
+                if (stats.tempMax > -100) {
+                    StatsSectionCard(
+                        title = temperatureLabel,
+                        icon = Icons.Default.DeviceThermostat,
+                        stats = listOf(
+                            StatItem(stringResource(R.string.maximum), UnitFormatter.formatTemperature(stats.tempMax, units)),
+                            StatItem(stringResource(R.string.minimum), UnitFormatter.formatTemperature(stats.tempMin, units)),
+                            StatItem(stringResource(R.string.average), UnitFormatter.formatTemperature(stats.tempAvg, units))
+                        )
+                    )
+                }
+
+                // Cost section — tappable to edit in TeslaMate when configured.
+                val cost = stats.cost ?: 0.0
+                if (cost > 0) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.cost),
+                        icon = Icons.Default.Paid,
+                        stats = listOf(
+                            StatItem(stringResource(R.string.total), "$currencySymbol%.2f".format(cost)),
+                            StatItem(stringResource(R.string.per_kwh), "$currencySymbol%.3f".format(cost / stats.energyAdded.coerceAtLeast(0.001)))
+                        ),
+                        onClick = onEditCost
+                    )
+                } else if (onEditCost != null) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.cost),
+                        icon = Icons.Default.Paid,
+                        stats = listOf(StatItem(stringResource(R.string.total), stringResource(R.string.charge_free))),
+                        onClick = onEditCost
+                    )
+                }
+
+                // Secondary charts
+                if (chargePoints != null) {
+                    if (!isDcCharge) {
+                        if (chargePoints.any { (it.chargerVoltage ?: 0) > 0 }) {
+                            VoltageChartCard(
+                                chargePoints = chargePoints,
+                                timeLabels = timeLabels,
+                                title = stringResource(R.string.voltage_profile),
+                                externalSelectedFraction = sharedXFraction,
+                                onXSelected = onXSelected,
+                                fractionToTimeLabel = fractionToTimeLabel
                             )
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = "%.2f kWh".format(energy),
-                                    style = MaterialTheme.typography.titleLarge,
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color(0xFF4CAF50)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                ChargeTypeBadge(isDcCharge = isDcCharge)
-                            }
+                        }
+                        if (chargePoints.any { (it.chargerCurrent ?: 0) > 0 }) {
+                            CurrentChartCard(
+                                chargePoints = chargePoints,
+                                timeLabels = timeLabels,
+                                title = stringResource(R.string.current_profile),
+                                externalSelectedFraction = sharedXFraction,
+                                onXSelected = onXSelected,
+                                fractionToTimeLabel = fractionToTimeLabel
+                            )
                         }
                     }
-
-                    // Cost (right side) — tappable to open TeslaMate's cost editor when configured.
-                    detail.cost?.let { cost ->
-                        if (cost > 0) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = if (onEditCost != null) {
-                                    Modifier
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .clickable(onClick = onEditCost)
-                                        .padding(4.dp)
-                                } else Modifier
-                            ) {
-                                Column(horizontalAlignment = Alignment.End) {
-                                    Text(
-                                        text = costLabel,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                                    )
-                                    Text(
-                                        text = "$currencySymbol%.2f".format(cost),
-                                        style = MaterialTheme.typography.titleLarge,
-                                        fontWeight = FontWeight.Bold,
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                                    )
-                                }
-                                Spacer(modifier = Modifier.width(12.dp))
-                                Icon(
-                                    imageVector = if (onEditCost != null) Icons.AutoMirrored.Filled.OpenInNew else Icons.Default.Paid,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(if (onEditCost != null) 20.dp else 24.dp),
-                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                        }
+                    if (chargePoints.any { it.outsideTemp != null }) {
+                        TemperatureChartCard(
+                            chargePoints = chargePoints,
+                            units = units,
+                            timeLabels = timeLabels,
+                            title = temperatureLabel,
+                            externalSelectedFraction = sharedXFraction,
+                            onXSelected = onXSelected,
+                            fractionToTimeLabel = fractionToTimeLabel
+                        )
+                    }
+                    if (chargePoints.any { it.batteryLevel != null }) {
+                        BatteryChartCard(
+                            chargePoints = chargePoints,
+                            timeLabels = timeLabels,
+                            title = stringResource(R.string.battery_level),
+                            color = palette.accent,
+                            externalSelectedFraction = sharedXFraction,
+                            onXSelected = onXSelected,
+                            fractionToTimeLabel = fractionToTimeLabel
+                        )
                     }
                 }
             }
@@ -591,7 +677,7 @@ private fun LocationHeaderCard(
 }
 
 @Composable
-private fun ChargeMapCard(latitude: Double, longitude: Double) {
+private fun ChargeMapCard(latitude: Double, longitude: Double, accent: Color) {
     val context = LocalContext.current
     val locationTitle = stringResource(R.string.location)
     val chargeLocationMarker = stringResource(R.string.charge_location)
@@ -626,7 +712,7 @@ private fun ChargeMapCard(latitude: Double, longitude: Double) {
                     .height(200.dp)
                     .clip(RoundedCornerShape(8.dp))
             ) {
-                val primaryColor = MaterialTheme.colorScheme.primary.toArgb()
+                val primaryColor = accent.toArgb()
 
                 AndroidView(
                     factory = { ctx ->
@@ -791,6 +877,7 @@ private fun PowerChartCard(
     chargePoints: List<ChargePoint>,
     timeLabels: List<String>,
     title: String,
+    color: Color,
     externalSelectedFraction: Float? = null,
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
@@ -802,7 +889,7 @@ private fun PowerChartCard(
         title = title,
         icon = Icons.Default.Bolt,
         data = powers,
-        color = Color(0xFF4CAF50),
+        color = color,
         unit = "kW",
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
@@ -898,6 +985,7 @@ private fun BatteryChartCard(
     chargePoints: List<ChargePoint>,
     timeLabels: List<String>,
     title: String,
+    color: Color,
     externalSelectedFraction: Float? = null,
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
@@ -915,7 +1003,7 @@ private fun BatteryChartCard(
         title = title,
         icon = Icons.Default.BatteryChargingFull,
         data = batteryLevels,
-        color = MaterialTheme.colorScheme.primary,
+        color = color,
         unit = "%",
         fixedMinMax = Pair(yMin, yMax),
         timeLabels = timeLabels,

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
@@ -9,6 +9,8 @@ import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.ChargeComparison
+import com.matedroid.domain.ChargeComparisonRepository
 import com.matedroid.domain.LegRef
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
@@ -30,7 +32,8 @@ data class ChargeDetailUiState(
     val currencySymbol: String = "€",
     val isDcCharge: Boolean = false,
     val containingTrip: Pair<Long, Trip>? = null,
-    val teslamateBaseUrl: String = ""
+    val teslamateBaseUrl: String = "",
+    val comparison: ChargeComparison? = null
 )
 
 data class ChargeDetailStats(
@@ -60,7 +63,8 @@ data class ChargeDetailStats(
 class ChargeDetailViewModel @Inject constructor(
     private val repository: TeslamateRepository,
     private val settingsDataStore: SettingsDataStore,
-    private val tripRepository: TripRepository
+    private val tripRepository: TripRepository,
+    private val chargeComparisonRepository: ChargeComparisonRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChargeDetailUiState())
@@ -97,6 +101,11 @@ class ChargeDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val containing = tripRepository.findTripContaining(carId, SavedTripLeg.TYPE_CHARGE, chargeId)
             _uiState.update { it.copy(containingTrip = containing) }
+        }
+
+        viewModelScope.launch {
+            val comparison = chargeComparisonRepository.findComparable(carId, chargeId)
+            _uiState.update { it.copy(comparison = comparison) }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
@@ -4,19 +4,28 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -35,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -45,6 +55,8 @@ import com.matedroid.data.api.models.Units
 import com.matedroid.domain.ComparableCharge
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.PowerSocOverlayChart
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDurationCompact
@@ -106,6 +118,8 @@ fun CompareChargesScreen(
                 sort = uiState.sort,
                 currencySymbol = uiState.currencySymbol,
                 units = uiState.units,
+                curves = uiState.curves,
+                curvesLoading = uiState.curvesLoading,
                 palette = palette,
                 onSortChange = viewModel::setSort,
                 onChargeClick = onNavigateToChargeDetail,
@@ -121,6 +135,8 @@ private fun CompareContent(
     sort: CompareSort,
     currencySymbol: String,
     units: Units?,
+    curves: List<SessionCurve>,
+    curvesLoading: Boolean,
     palette: CarColorPalette,
     onSortChange: (CompareSort) -> Unit,
     onChargeClick: (Int) -> Unit,
@@ -164,6 +180,14 @@ private fun CompareContent(
             }
         }
 
+        // Power-vs-SoC overlay of the top sessions for the current sort
+        OverlayChartCard(
+            comparison = comparison,
+            curves = curves,
+            curvesLoading = curvesLoading,
+            palette = palette
+        )
+
         // Leaderboard
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             ranked.forEachIndexed { index, charge ->
@@ -193,6 +217,103 @@ private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: (
             selectedLabelColor = accent
         )
     )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun OverlayChartCard(
+    comparison: com.matedroid.domain.ChargeComparison,
+    curves: List<SessionCurve>,
+    curvesLoading: Boolean,
+    palette: CarColorPalette
+) {
+    val byId = remember(comparison) { comparison.all.associateBy { it.chargeId } }
+    val otherColors = listOf(
+        Color(0xFF5B8DD9), Color(0xFF4CAF50), Color(0xFF9B6BD9), Color(0xFF6D7A92)
+    )
+    val thisChargeLabel = stringResource(R.string.compare_this_charge)
+
+    var otherIndex = 0
+    val overlay = curves.map { sessionCurve ->
+        val meta = byId[sessionCurve.chargeId]
+        val color = if (sessionCurve.isBase) palette.accent else otherColors[otherIndex++ % otherColors.size]
+        val label = if (sessionCurve.isBase) {
+            thisChargeLabel
+        } else {
+            meta?.brand?.takeIf { it.isNotBlank() }
+                ?: meta?.startDate?.let { parseIsoDateTime(it)?.toLocalDate()?.formatMedium(Locale.getDefault()) }
+                ?: ""
+        }
+        OverlayCurve(
+            label = label,
+            color = color,
+            isBase = sessionCurve.isBase,
+            points = sessionCurve.points.map { Offset(it.soc, it.power) }
+        )
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Bolt,
+                    contentDescription = null,
+                    tint = palette.accent,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.compare_power_vs_soc),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            if (overlay.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(190.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (curvesLoading) CircularProgressIndicator(color = palette.accent)
+                }
+            } else {
+                PowerSocOverlayChart(curves = overlay)
+                Spacer(modifier = Modifier.height(10.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    overlay.forEach { LegendItem(it.color, it.label) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(5.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
@@ -1,0 +1,291 @@
+package com.matedroid.ui.screens.charges
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.matedroid.R
+import com.matedroid.data.api.models.Units
+import com.matedroid.domain.ComparableCharge
+import com.matedroid.domain.model.UnitFormatter
+import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.ui.theme.CarColorPalettes
+import com.matedroid.util.formatDurationCompact
+import com.matedroid.util.formatMedium
+import com.matedroid.util.parseIsoDateTime
+import java.util.Locale
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CompareChargesScreen(
+    carId: Int,
+    baseChargeId: Int,
+    exteriorColor: String? = null,
+    onNavigateBack: () -> Unit,
+    onNavigateToChargeDetail: (Int) -> Unit,
+    viewModel: ChargeComparisonViewModel = hiltViewModel()
+) {
+    LaunchedEffect(carId, baseChargeId) { viewModel.load(carId, baseChargeId) }
+    val uiState by viewModel.uiState.collectAsState()
+    val palette = CarColorPalettes.forExteriorColor(exteriorColor, isSystemInDarkTheme())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.compare_charges_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        val comparison = uiState.comparison
+        when {
+            uiState.isLoading -> MateDroidLoadingPlaceholder(modifier = Modifier.padding(padding))
+            comparison == null -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.compare_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            else -> CompareContent(
+                comparison = comparison,
+                sort = uiState.sort,
+                currencySymbol = uiState.currencySymbol,
+                units = uiState.units,
+                palette = palette,
+                onSortChange = viewModel::setSort,
+                onChargeClick = onNavigateToChargeDetail,
+                modifier = Modifier.padding(padding)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompareContent(
+    comparison: com.matedroid.domain.ChargeComparison,
+    sort: CompareSort,
+    currencySymbol: String,
+    units: Units?,
+    palette: CarColorPalette,
+    onSortChange: (CompareSort) -> Unit,
+    onChargeClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val ranked = remember(comparison, sort) {
+        when (sort) {
+            CompareSort.PEAK -> comparison.all.sortedByDescending { it.peakKw ?: -1 }
+            CompareSort.DURATION -> comparison.all.sortedBy { it.durationMin }
+            CompareSort.COST -> comparison.all.sortedBy { it.costPerKwh ?: Double.MAX_VALUE }
+        }
+    }
+    val radiusKm = (comparison.radiusMeters / 1000.0).roundToInt()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        // Scope
+        Text(
+            text = stringResource(R.string.compare_scope, comparison.totalCount, radiusKm),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Sort control
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = stringResource(R.string.ranked_by).uppercase(Locale.getDefault()),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                SortChip(stringResource(R.string.peak), sort == CompareSort.PEAK, palette.accent) { onSortChange(CompareSort.PEAK) }
+                SortChip(stringResource(R.string.duration), sort == CompareSort.DURATION, palette.accent) { onSortChange(CompareSort.DURATION) }
+                SortChip(stringResource(R.string.cost), sort == CompareSort.COST, palette.accent) { onSortChange(CompareSort.COST) }
+            }
+        }
+
+        // Leaderboard
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            ranked.forEachIndexed { index, charge ->
+                CompareRow(
+                    rank = index + 1,
+                    charge = charge,
+                    sort = sort,
+                    currencySymbol = currencySymbol,
+                    units = units,
+                    palette = palette,
+                    onClick = if (charge.isBase) null else { { onChargeClick(charge.chargeId) } }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = accent.copy(alpha = 0.16f),
+            selectedLabelColor = accent
+        )
+    )
+}
+
+@Composable
+private fun CompareRow(
+    rank: Int,
+    charge: ComparableCharge,
+    sort: CompareSort,
+    currencySymbol: String,
+    units: Units?,
+    palette: CarColorPalette,
+    onClick: (() -> Unit)?
+) {
+    val bg = if (charge.isBase) palette.accent.copy(alpha = 0.12f) else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val (value, unit) = valueFor(charge, sort, currencySymbol)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(bg)
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = rankBadge(rank),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(28.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = if (charge.isBase) stringResource(R.string.compare_this_charge)
+                else (charge.brand?.takeIf { it.isNotBlank() } ?: charge.address),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = if (charge.isBase) palette.accent else MaterialTheme.colorScheme.onSurface,
+                maxLines = 1
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                parseIsoDateTime(charge.startDate)?.toLocalDate()?.let {
+                    Pill(it.formatMedium(Locale.getDefault()))
+                }
+                Pill("${charge.startBattery} → ${charge.endBattery}%")
+                charge.outsideTempAvg?.let { Pill(UnitFormatter.formatTemperature(it, units)) }
+            }
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (charge.isBase) palette.accent else MaterialTheme.colorScheme.onSurface
+            )
+            if (unit.isNotEmpty()) {
+                Text(
+                    text = unit,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Pill(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 7.dp, vertical = 3.dp)
+    )
+}
+
+private fun rankBadge(rank: Int): String = when (rank) {
+    1 -> "🥇"
+    2 -> "🥈"
+    3 -> "🥉"
+    else -> "$rank"
+}
+
+private fun valueFor(charge: ComparableCharge, sort: CompareSort, currencySymbol: String): Pair<String, String> =
+    when (sort) {
+        CompareSort.PEAK -> (charge.peakKw?.let { "$it" } ?: "—") to "kW"
+        CompareSort.DURATION -> formatDurationCompact(charge.durationMin) to ""
+        CompareSort.COST -> (charge.costPerKwh?.let { "$currencySymbol${"%.3f".format(it)}" } ?: "—") to "/kWh"
+    }

--- a/app/src/main/java/com/matedroid/util/GeoUtil.kt
+++ b/app/src/main/java/com/matedroid/util/GeoUtil.kt
@@ -1,0 +1,20 @@
+package com.matedroid.util
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Great-circle distance between two WGS84 coordinates, in metres (haversine formula).
+ * Accurate enough for the short distances we use it for (grouping charges by location).
+ */
+fun haversineMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+    val earthRadiusM = 6_371_000.0
+    val dLat = Math.toRadians(lat2 - lat1)
+    val dLon = Math.toRadians(lon2 - lon1)
+    val a = sin(dLat / 2) * sin(dLat / 2) +
+        cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+        sin(dLon / 2) * sin(dLon / 2)
+    return earthRadiusM * 2 * atan2(sqrt(a), sqrt(1 - a))
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1236,4 +1236,13 @@
     <string name="more_details">Més detalls</string>
     <string name="hide_details">Amaga els detalls</string>
     <string name="peak">Pic</string>
+    <string name="compare_charges_title">Compara càrregues ràpides</string>
+    <string name="ranked_by">Ordena per</string>
+    <string name="compare_this_charge">Aquesta càrrega</string>
+    <string name="compare_empty">No hi ha càrregues ràpides comparables a prop</string>
+    <string name="compare_scope">%1$d càrregues · en %2$d km</string>
+    <plurals name="compare_sessions_nearby">
+        <item quantity="one">%d càrrega comparable a prop</item>
+        <item quantity="other">%d càrregues comparables a prop</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1235,4 +1235,5 @@
     <string name="chart_week_label">S%1$d</string>
     <string name="more_details">Més detalls</string>
     <string name="hide_details">Amaga els detalls</string>
+    <string name="peak">Pic</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1233,4 +1233,6 @@
     <string name="duration_months">%1$dmes</string>
     <string name="duration_months_weeks">%1$dmes %2$dset</string>
     <string name="chart_week_label">S%1$d</string>
+    <string name="more_details">Més detalls</string>
+    <string name="hide_details">Amaga els detalls</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1240,6 +1240,7 @@
     <string name="ranked_by">Ordena per</string>
     <string name="compare_this_charge">Aquesta càrrega</string>
     <string name="compare_empty">No hi ha càrregues ràpides comparables a prop</string>
+    <string name="compare_power_vs_soc">Potència vs SoC</string>
     <string name="compare_scope">%1$d càrregues · en %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d càrrega comparable a prop</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1350,4 +1350,5 @@
     <string name="chart_week_label">KW%1$d</string>
     <string name="more_details">Mehr Details</string>
     <string name="hide_details">Details ausblenden</string>
+    <string name="peak">Spitze</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1351,4 +1351,13 @@
     <string name="more_details">Mehr Details</string>
     <string name="hide_details">Details ausblenden</string>
     <string name="peak">Spitze</string>
+    <string name="compare_charges_title">Schnellladungen vergleichen</string>
+    <string name="ranked_by">Sortiert nach</string>
+    <string name="compare_this_charge">Diese Ladung</string>
+    <string name="compare_empty">Keine vergleichbaren Schnellladungen in der Nähe</string>
+    <string name="compare_scope">%1$d Ladungen · im Umkreis von %2$d km</string>
+    <plurals name="compare_sessions_nearby">
+        <item quantity="one">%d vergleichbare Ladung in der Nähe</item>
+        <item quantity="other">%d vergleichbare Ladungen in der Nähe</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1348,4 +1348,6 @@
     <string name="duration_months_weeks">%1$dMon %2$dWo</string>
     <!-- Compact week-of-year label for chart X axes, e.g. "KW23" (Kalenderwoche) -->
     <string name="chart_week_label">KW%1$d</string>
+    <string name="more_details">Mehr Details</string>
+    <string name="hide_details">Details ausblenden</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1355,6 +1355,7 @@
     <string name="ranked_by">Sortiert nach</string>
     <string name="compare_this_charge">Diese Ladung</string>
     <string name="compare_empty">Keine vergleichbaren Schnellladungen in der Nähe</string>
+    <string name="compare_power_vs_soc">Leistung vs. SoC</string>
     <string name="compare_scope">%1$d Ladungen · im Umkreis von %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d vergleichbare Ladung in der Nähe</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1233,4 +1233,6 @@
     <string name="duration_months">%1$dmes</string>
     <string name="duration_months_weeks">%1$dmes %2$dsem</string>
     <string name="chart_week_label">S%1$d</string>
+    <string name="more_details">Más detalles</string>
+    <string name="hide_details">Ocultar detalles</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1240,6 +1240,7 @@
     <string name="ranked_by">Ordenar por</string>
     <string name="compare_this_charge">Esta carga</string>
     <string name="compare_empty">No hay cargas rápidas comparables cerca</string>
+    <string name="compare_power_vs_soc">Potencia vs SoC</string>
     <string name="compare_scope">%1$d cargas · en %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d carga comparable cerca</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1235,4 +1235,5 @@
     <string name="chart_week_label">S%1$d</string>
     <string name="more_details">Más detalles</string>
     <string name="hide_details">Ocultar detalles</string>
+    <string name="peak">Pico</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1236,4 +1236,13 @@
     <string name="more_details">Más detalles</string>
     <string name="hide_details">Ocultar detalles</string>
     <string name="peak">Pico</string>
+    <string name="compare_charges_title">Comparar cargas rápidas</string>
+    <string name="ranked_by">Ordenar por</string>
+    <string name="compare_this_charge">Esta carga</string>
+    <string name="compare_empty">No hay cargas rápidas comparables cerca</string>
+    <string name="compare_scope">%1$d cargas · en %2$d km</string>
+    <plurals name="compare_sessions_nearby">
+        <item quantity="one">%d carga comparable cerca</item>
+        <item quantity="other">%d cargas comparables cerca</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1235,4 +1235,5 @@
     <string name="chart_week_label">S%1$d</string>
     <string name="more_details">Più dettagli</string>
     <string name="hide_details">Nascondi dettagli</string>
+    <string name="peak">Picco</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1236,4 +1236,13 @@
     <string name="more_details">Più dettagli</string>
     <string name="hide_details">Nascondi dettagli</string>
     <string name="peak">Picco</string>
+    <string name="compare_charges_title">Confronta ricariche rapide</string>
+    <string name="ranked_by">Ordina per</string>
+    <string name="compare_this_charge">Questa ricarica</string>
+    <string name="compare_empty">Nessuna ricarica rapida confrontabile nelle vicinanze</string>
+    <string name="compare_scope">%1$d ricariche · entro %2$d km</string>
+    <plurals name="compare_sessions_nearby">
+        <item quantity="one">%d ricarica confrontabile nelle vicinanze</item>
+        <item quantity="other">%d ricariche confrontabili nelle vicinanze</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1233,4 +1233,6 @@
     <string name="duration_months">%1$dmesi</string>
     <string name="duration_months_weeks">%1$dmesi %2$dsett</string>
     <string name="chart_week_label">S%1$d</string>
+    <string name="more_details">Più dettagli</string>
+    <string name="hide_details">Nascondi dettagli</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1240,6 +1240,7 @@
     <string name="ranked_by">Ordina per</string>
     <string name="compare_this_charge">Questa ricarica</string>
     <string name="compare_empty">Nessuna ricarica rapida confrontabile nelle vicinanze</string>
+    <string name="compare_power_vs_soc">Potenza vs SoC</string>
     <string name="compare_scope">%1$d ricariche · entro %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d ricarica confrontabile nelle vicinanze</item>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1260,4 +1260,5 @@
     <string name="chart_week_label">第%1$d周</string>
     <string name="more_details">更多详情</string>
     <string name="hide_details">隐藏详情</string>
+    <string name="peak">峰值</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1258,4 +1258,6 @@
     <string name="duration_months">%1$d个月</string>
     <string name="duration_months_weeks">%1$d个月%2$d周</string>
     <string name="chart_week_label">第%1$d周</string>
+    <string name="more_details">更多详情</string>
+    <string name="hide_details">隐藏详情</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1261,4 +1261,12 @@
     <string name="more_details">更多详情</string>
     <string name="hide_details">隐藏详情</string>
     <string name="peak">峰值</string>
+    <string name="compare_charges_title">比较快充</string>
+    <string name="ranked_by">排序方式</string>
+    <string name="compare_this_charge">本次充电</string>
+    <string name="compare_empty">附近没有可比的快充</string>
+    <string name="compare_scope">%1$d 次充电 · %2$d 公里内</string>
+    <plurals name="compare_sessions_nearby">
+        <item quantity="other">附近 %d 次可比充电</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1265,6 +1265,7 @@
     <string name="ranked_by">排序方式</string>
     <string name="compare_this_charge">本次充电</string>
     <string name="compare_empty">附近没有可比的快充</string>
+    <string name="compare_power_vs_soc">功率 vs 电量</string>
     <string name="compare_scope">%1$d 次充电 · %2$d 公里内</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="other">附近 %d 次可比充电</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1360,4 +1360,16 @@
     <string name="hide_details">Hide details</string>
     <!-- Charge detail hero: label for the maximum/peak charging power figure -->
     <string name="peak">Peak</string>
+    <!-- Charge comparison feature -->
+    <string name="compare_charges_title">Compare fast charges</string>
+    <string name="ranked_by">Ranked by</string>
+    <string name="compare_this_charge">This charge</string>
+    <string name="compare_empty">No comparable DC charges nearby</string>
+    <!-- %1$d = number of charges, %2$d = radius in km -->
+    <string name="compare_scope">%1$d charges · within %2$d km</string>
+    <!-- %d = number of comparable charges near this one -->
+    <plurals name="compare_sessions_nearby">
+        <item quantity="one">%d comparable charge nearby</item>
+        <item quantity="other">%d comparable charges nearby</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1358,4 +1358,6 @@
     <!-- Charge detail: toggle that expands/collapses the secondary stats and charts -->
     <string name="more_details">More details</string>
     <string name="hide_details">Hide details</string>
+    <!-- Charge detail hero: label for the maximum/peak charging power figure -->
+    <string name="peak">Peak</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1355,4 +1355,7 @@
     <string name="duration_months_weeks">%1$dmo %2$dw</string>
     <!-- Compact week-of-year label for chart X axes, e.g. "W23" -->
     <string name="chart_week_label">W%1$d</string>
+    <!-- Charge detail: toggle that expands/collapses the secondary stats and charts -->
+    <string name="more_details">More details</string>
+    <string name="hide_details">Hide details</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1365,6 +1365,8 @@
     <string name="ranked_by">Ranked by</string>
     <string name="compare_this_charge">This charge</string>
     <string name="compare_empty">No comparable DC charges nearby</string>
+    <!-- Chart title: charging power against state of charge -->
+    <string name="compare_power_vs_soc">Power vs SoC</string>
     <!-- %1$d = number of charges, %2$d = radius in km -->
     <string name="compare_scope">%1$d charges · within %2$d km</string>
     <!-- %d = number of comparable charges near this one -->


### PR DESCRIPTION
## Summary

Two pieces of work on the charge experience.

### 1. Charge detail screen redesign
- Compact **hero**: location, energy added + peak power in the car's accent colour, AC/DC badge, a balanced labelled-column row (peak · battery swing · duration), and a footer with start time + editable cost.
- A single row of **accent stat tiles** (avg power · efficiency · temperature).
- The **power curve** is the primary chart, tinted by charge type (DC → orange, AC → green).
- All detailed stat sections and the secondary charts (battery, temperature, voltage/current) move behind a **"More details"** toggle, collapsed by default.
- Part-of-trip banner moved to the very end of the screen.

### 2. Compare DC charges (highlight feature)
- A **"Compare fast charges"** entry card on the detail screen, shown only for DC charges with comparable sessions nearby.
- A **Compare screen** with:
  - a **power-vs-SoC overlay chart** — your session bold, up to 4 others overlaid (the top by the selected dimension, so busy Superchargers stay readable), tap/drag crosshair + per-session tooltip;
  - a re-sortable **leaderboard** (peak / duration / cost) with charger, date, SoC swing and temp per row, your charge highlighted.
- Matching is **DC-only, within 2 km** (haversine), assembled entirely from the local cache (summaries + detail aggregates); curves are fetched lazily and cached.

## Notes
- New strings localised in all 6 locales (incl. a plural for the count).
- Shared line-chart component untouched, so drives are unaffected.
- `lintDebug` green; validated on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)