### PR TITLE
Drive detail redesign + same-route drive comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Compare similar charges and drives** — the charge and drive detail screens now show a "Compare" card. For a DC charge it overlays the power-vs-SoC curves of other fast-charging sessions in the same area with a re-sortable leaderboard (peak / time / price); for a drive it overlays the speed-vs-distance curves of other runs of the same route, ranked by efficiency.
 - **Edit a charge's cost from its detail screen** — the Cost section now shows an external-link icon and the whole card opens TeslaMate's cost editor (previously possible only from the charges list). It appears even for free/uncosted charges so you can add a cost.
 - **Tap a drive or charge in the trip timeline to open its detail** — selecting a segment now shows a chevron on its info row; tapping it jumps straight to that drive's or charge's detail screen.
 
 ### Changed
 - **Redesigned the charge detail screen** — a compact hero (energy added and peak power in the car's accent colour) with quick stat tiles and the power curve up front, while the detailed stats and the battery, temperature and AC charts now live behind a "More details" toggle.
+- **Redesigned the drive detail screen** to match — a compact hero (distance in the accent colour, an efficiency tile, and labelled avg-speed / battery / duration figures) with the speed profile up front, while the detailed stats and the power, battery and elevation charts move behind a "More details" toggle.
 - **The Trips list now shows the year on each trip's date chip**, not just day and month.
 - **"Short" drives are now those under 1 km** (was 0.1 km), so brief repositioning hops stop cluttering the lists and trip timelines when "Show short drives / charges" is off. Charges are unchanged (0.1 kWh or less).
 - **The trip timeline gives brief legs an honest sliver** instead of a fixed minimum block, so a quick 1 km hop no longer looks nearly as wide as a long highway leg.

--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -22,6 +22,9 @@ interface AggregateDao {
     @Query("SELECT * FROM drive_detail_aggregates WHERE driveId = :driveId")
     suspend fun getDriveAggregate(driveId: Int): DriveDetailAggregate?
 
+    @Query("SELECT * FROM drive_detail_aggregates WHERE carId = :carId")
+    suspend fun getDriveAggregatesForCar(carId: Int): List<DriveDetailAggregate>
+
     @Query("DELETE FROM drive_detail_aggregates WHERE carId = :carId")
     suspend fun deleteDriveAggregatesForCar(carId: Int)
 

--- a/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
@@ -23,6 +23,9 @@ interface DriveSummaryDao {
     @Query("SELECT * FROM drives_summary WHERE carId = :carId ORDER BY startDate DESC")
     fun observeAll(carId: Int): Flow<List<DriveSummary>>
 
+    @Query("SELECT * FROM drives_summary WHERE carId = :carId ORDER BY startDate ASC")
+    suspend fun getAllForCar(carId: Int): List<DriveSummary>
+
     @Query("SELECT MAX(driveId) FROM drives_summary WHERE carId = :carId")
     suspend fun getMaxDriveId(carId: Int): Int?
 

--- a/app/src/main/java/com/matedroid/domain/DriveComparisonRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/DriveComparisonRepository.kt
@@ -22,6 +22,14 @@ data class ComparableDrive(
     val isBase: Boolean
 )
 
+/** Reference figures averaged across every drive in the comparison set. */
+data class DriveAverage(
+    val efficiency: Double?,
+    val durationMin: Int,
+    val speedAvg: Int,
+    val count: Int
+)
+
 /** A base drive plus the other drives along the same route. */
 data class DriveComparison(
     val base: ComparableDrive,
@@ -30,6 +38,20 @@ data class DriveComparison(
 ) {
     val all: List<ComparableDrive> get() = others + base
     val totalCount: Int get() = others.size + 1
+
+    /** The "average drive" on this route, used as a reference in the leaderboard. */
+    val average: DriveAverage
+        get() {
+            val list = all
+            if (list.isEmpty()) return DriveAverage(null, 0, 0, 0)
+            val efficiencies = list.mapNotNull { it.efficiency }
+            return DriveAverage(
+                efficiency = if (efficiencies.isNotEmpty()) efficiencies.average() else null,
+                durationMin = list.sumOf { it.durationMin } / list.size,
+                speedAvg = list.sumOf { it.speedAvg } / list.size,
+                count = list.size
+            )
+        }
 }
 
 /**

--- a/app/src/main/java/com/matedroid/domain/DriveComparisonRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/DriveComparisonRepository.kt
@@ -1,0 +1,105 @@
+package com.matedroid.domain
+
+import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.local.dao.DriveSummaryDao
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.util.haversineMeters
+import kotlin.math.abs
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** One drive in a comparison set, assembled from cached summary data. */
+data class ComparableDrive(
+    val driveId: Int,
+    val startDate: String,
+    val startAddress: String,
+    val endAddress: String,
+    val efficiency: Double?,
+    val distance: Double,
+    val durationMin: Int,
+    val speedAvg: Int,
+    val outsideTempAvg: Double?,
+    val isBase: Boolean
+)
+
+/** A base drive plus the other drives along the same route. */
+data class DriveComparison(
+    val base: ComparableDrive,
+    val others: List<ComparableDrive>,
+    val endpointRadiusMeters: Double
+) {
+    val all: List<ComparableDrive> get() = others + base
+    val totalCount: Int get() = others.size + 1
+}
+
+/**
+ * Finds comparable drives along the same route as a given drive: same start and same end (within a
+ * radius), and a similar total distance (so a detour to the same endpoints isn't counted as the same
+ * route). Uses only the local cache — drive summaries for the metrics, drive aggregates for the
+ * start/end coordinates. Returns null when the route's endpoints aren't known or nothing matches.
+ */
+@Singleton
+class DriveComparisonRepository @Inject constructor(
+    private val driveSummaryDao: DriveSummaryDao,
+    private val aggregateDao: AggregateDao
+) {
+    companion object {
+        const val DEFAULT_ENDPOINT_RADIUS_METERS = 250.0
+        /** A candidate's distance must be within ±25% of the base to count as the same route. */
+        const val DISTANCE_TOLERANCE = 0.25
+    }
+
+    suspend fun findComparable(
+        carId: Int,
+        baseDriveId: Int,
+        endpointRadiusMeters: Double = DEFAULT_ENDPOINT_RADIUS_METERS
+    ): DriveComparison? {
+        val summaries = driveSummaryDao.getAllForCar(carId)
+        val baseSummary = summaries.firstOrNull { it.driveId == baseDriveId } ?: return null
+
+        val aggregates = aggregateDao.getDriveAggregatesForCar(carId).associateBy { it.driveId }
+        val baseAgg = aggregates[baseDriveId] ?: return null
+        val baseStartLat = baseAgg.startLatitude ?: return null
+        val baseStartLon = baseAgg.startLongitude ?: return null
+        val baseEndLat = baseAgg.endLatitude ?: return null
+        val baseEndLon = baseAgg.endLongitude ?: return null
+        val baseDistance = baseSummary.distance
+
+        fun toComparable(s: DriveSummary): ComparableDrive = ComparableDrive(
+            driveId = s.driveId,
+            startDate = s.startDate,
+            startAddress = s.startAddress,
+            endAddress = s.endAddress,
+            efficiency = s.efficiency,
+            distance = s.distance,
+            durationMin = s.durationMin,
+            speedAvg = s.speedAvg,
+            outsideTempAvg = s.outsideTempAvg,
+            isBase = s.driveId == baseDriveId
+        )
+
+        val others = summaries
+            .filter { s ->
+                if (s.driveId == baseDriveId) return@filter false
+                val agg = aggregates[s.driveId] ?: return@filter false
+                val sLat = agg.startLatitude ?: return@filter false
+                val sLon = agg.startLongitude ?: return@filter false
+                val eLat = agg.endLatitude ?: return@filter false
+                val eLon = agg.endLongitude ?: return@filter false
+                val startClose = haversineMeters(baseStartLat, baseStartLon, sLat, sLon) <= endpointRadiusMeters
+                val endClose = haversineMeters(baseEndLat, baseEndLon, eLat, eLon) <= endpointRadiusMeters
+                val distanceOk = baseDistance <= 0.0 ||
+                    abs(s.distance - baseDistance) / baseDistance <= DISTANCE_TOLERANCE
+                startClose && endClose && distanceOk
+            }
+            .map { toComparable(it) }
+            .sortedBy { it.efficiency ?: Double.MAX_VALUE }
+
+        if (others.isEmpty()) return null
+        return DriveComparison(
+            base = toComparable(baseSummary),
+            others = others,
+            endpointRadiusMeters = endpointRadiusMeters
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -44,12 +45,13 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
-/** One session's charging curve in power-vs-SoC space. [points] are (SoC %, power kW). */
+/** One session's curve. [points] are (x, y). [dashed] draws it as a thin dashed reference line. */
 data class OverlayCurve(
     val label: String,
     val color: Color,
     val isBase: Boolean,
-    val points: List<Offset>
+    val points: List<Offset>,
+    val dashed: Boolean = false
 )
 
 /**
@@ -169,9 +171,10 @@ fun PowerSocOverlayChart(
                     path,
                     c.color,
                     style = Stroke(
-                        width = if (c.isBase) 7f else 4f,
+                        width = if (c.isBase) 7f else if (c.dashed) 3f else 4f,
                         cap = StrokeCap.Round,
-                        join = StrokeJoin.Round
+                        join = StrokeJoin.Round,
+                        pathEffect = if (c.dashed) PathEffect.dashPathEffect(floatArrayOf(12f, 10f)) else null
                     )
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -66,7 +67,8 @@ fun PowerSocOverlayChart(
     chartHeight: Dp = 190.dp,
     xUnit: String = "%",
     xCaption: String = " SoC",
-    valueUnit: String = "kW"
+    valueUnit: String = "kW",
+    dismissKey: Any? = null
 ) {
     val valid = curves.filter { it.points.size >= 2 }
     if (valid.isEmpty()) return
@@ -87,6 +89,9 @@ fun PowerSocOverlayChart(
     val topPad = with(density) { 6.dp.toPx() }
 
     var selectedSoc by remember { mutableStateOf<Float?>(null) }
+
+    // Parent bumps dismissKey (on an outside tap or a scroll) to clear the tooltip.
+    LaunchedEffect(dismissKey) { selectedSoc = null }
 
     val labelPaint = remember(labelColor) {
         android.graphics.Paint().apply {

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -61,7 +61,10 @@ data class OverlayCurve(
 fun PowerSocOverlayChart(
     curves: List<OverlayCurve>,
     modifier: Modifier = Modifier,
-    chartHeight: Dp = 190.dp
+    chartHeight: Dp = 190.dp,
+    xUnit: String = "%",
+    xCaption: String = " SoC",
+    valueUnit: String = "kW"
 ) {
     val valid = curves.filter { it.points.size >= 2 }
     if (valid.isEmpty()) return
@@ -129,7 +132,7 @@ fun PowerSocOverlayChart(
             for (i in 0..4) {
                 val soc = socMin + socRange * i / 4f
                 val x = xFor(soc)
-                val txt = "${soc.roundToInt()}%"
+                val txt = "${soc.roundToInt()}$xUnit"
                 val tw = labelPaint.measureText(txt)
                 val tx = when (i) {
                     0 -> 0f
@@ -203,7 +206,7 @@ fun PowerSocOverlayChart(
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     Text(
-                        text = "${soc.roundToInt()}% SoC",
+                        text = "${soc.roundToInt()}$xUnit$xCaption",
                         style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface
@@ -218,7 +221,7 @@ fun PowerSocOverlayChart(
                             )
                             Spacer(modifier = Modifier.width(6.dp))
                             Text(
-                                text = "${power.roundToInt()} kW",
+                                text = "${power.roundToInt()} $valueUnit",
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -27,6 +27,7 @@ import com.matedroid.ui.screens.charges.CompareChargesScreen
 import com.matedroid.ui.screens.charges.CurrentChargeScreen
 import com.matedroid.ui.screens.dashboard.DashboardScreen
 import com.matedroid.ui.screens.demo.PalettePreviewScreen
+import com.matedroid.ui.screens.drives.CompareDrivesScreen
 import com.matedroid.ui.screens.drives.DriveDetailScreen
 import com.matedroid.ui.screens.drives.DrivesScreen
 import com.matedroid.ui.screens.mileage.MileageScreen
@@ -79,6 +80,9 @@ sealed interface Screen {
 
     @Serializable
     data class DriveDetail(val carId: Int, val driveId: Int, val exteriorColor: String? = null) : Screen
+
+    @Serializable
+    data class CompareDrives(val carId: Int, val baseDriveId: Int, val exteriorColor: String? = null) : Screen
 
     @Serializable
     data class Battery(val carId: Int, val efficiency: Float = 0f, val exteriorColor: String? = null) : Screen
@@ -316,6 +320,22 @@ fun NavGraph(
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToTripDetail = { tripStartDate ->
                     navController.navigate(Screen.TripDetail(route.carId, tripStartDate, route.exteriorColor))
+                },
+                onNavigateToCompare = { baseDriveId ->
+                    navController.navigate(Screen.CompareDrives(route.carId, baseDriveId, route.exteriorColor))
+                }
+            )
+        }
+
+        composable<Screen.CompareDrives> { backStackEntry ->
+            val route = backStackEntry.toRoute<Screen.CompareDrives>()
+            CompareDrivesScreen(
+                carId = route.carId,
+                baseDriveId = route.baseDriveId,
+                exteriorColor = route.exteriorColor,
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToDriveDetail = { driveId ->
+                    navController.navigate(Screen.DriveDetail(route.carId, driveId, route.exteriorColor))
                 }
             )
         }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.charges
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -40,10 +41,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -151,10 +156,19 @@ private fun CompareContent(
     }
     val radiusKm = (comparison.radiusMeters / 1000.0).roundToInt()
 
+    // Bumped on an outside tap or a scroll to dismiss the chart tooltip.
+    var dismissKey by remember { mutableStateOf(0) }
+    val scrollState = rememberScrollState()
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.isScrollInProgress }
+            .collect { if (it) dismissKey++ }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
+            .pointerInput(Unit) { detectTapGestures { dismissKey++ } }
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
@@ -185,7 +199,8 @@ private fun CompareContent(
             comparison = comparison,
             curves = curves,
             curvesLoading = curvesLoading,
-            palette = palette
+            palette = palette,
+            dismissKey = dismissKey
         )
 
         // Leaderboard
@@ -225,7 +240,8 @@ private fun OverlayChartCard(
     comparison: com.matedroid.domain.ChargeComparison,
     curves: List<SessionCurve>,
     curvesLoading: Boolean,
-    palette: CarColorPalette
+    palette: CarColorPalette,
+    dismissKey: Any?
 ) {
     val byId = remember(comparison) { comparison.all.associateBy { it.chargeId } }
     val otherColors = listOf(
@@ -285,7 +301,7 @@ private fun OverlayChartCard(
                     if (curvesLoading) CircularProgressIndicator(color = palette.accent)
                 }
             } else {
-                PowerSocOverlayChart(curves = overlay)
+                PowerSocOverlayChart(curves = overlay, dismissKey = dismissKey)
                 Spacer(modifier = Modifier.height(10.dp))
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -204,6 +204,7 @@ private fun CompareContent(
             val keep = sortedSetOf<Int>()
             listOf(0, 1, 2).forEach { if (it in ranked.indices) keep.add(it) }
             for (d in -1..1) (baseIndex + d).let { if (it in ranked.indices) keep.add(it) }
+            if (ranked.isNotEmpty()) keep.add(ranked.lastIndex) // always show the worst run
             keep.toList()
         }
 
@@ -231,13 +232,6 @@ private fun CompareContent(
                 title = stringResource(R.string.compare_average),
                 caption = pluralStringResource(R.plurals.compare_drives_nearby, comparison.average.count, comparison.average.count),
                 value = averageValue(comparison.average, sort, units),
-                palette = palette
-            )
-            ReferenceRow(
-                leading = "↑",
-                title = "P100",
-                caption = null,
-                value = p100Value(comparison.all, sort, units),
                 palette = palette
             )
         }
@@ -314,13 +308,6 @@ private fun averageValue(average: DriveAverage, sort: DriveCompareSort, units: U
         DriveCompareSort.EFFICIENCY -> average.efficiency?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
         DriveCompareSort.DURATION -> formatDurationCompact(average.durationMin)
         DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
-    }
-
-private fun p100Value(all: List<ComparableDrive>, sort: DriveCompareSort, units: Units?): String =
-    when (sort) {
-        DriveCompareSort.EFFICIENCY -> all.mapNotNull { it.efficiency }.maxOrNull()?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
-        DriveCompareSort.DURATION -> all.maxOfOrNull { it.durationMin }?.let { formatDurationCompact(it) } ?: "—"
-        DriveCompareSort.SPEED -> all.maxOfOrNull { it.speedAvg }?.let { UnitFormatter.formatSpeed(it.toDouble(), units) } ?: "—"
     }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -127,6 +127,7 @@ fun CompareDrivesScreen(
                 units = uiState.units,
                 curves = uiState.curves,
                 curvesLoading = uiState.curvesLoading,
+                averageCurve = uiState.averageCurve,
                 palette = palette,
                 onSortChange = viewModel::setSort,
                 onDriveClick = onNavigateToDriveDetail,
@@ -143,6 +144,7 @@ private fun CompareContent(
     units: Units?,
     curves: List<DriveSessionCurve>,
     curvesLoading: Boolean,
+    averageCurve: List<DriveCurvePoint>,
     palette: CarColorPalette,
     onSortChange: (DriveCompareSort) -> Unit,
     onDriveClick: (Int) -> Unit,
@@ -187,6 +189,7 @@ private fun CompareContent(
             comparison = comparison,
             curves = curves,
             curvesLoading = curvesLoading,
+            averageCurve = averageCurve,
             units = units,
             palette = palette
         )
@@ -223,7 +226,20 @@ private fun CompareContent(
             val tailGap = ranked.lastIndex - prev
             if (tailGap > 0) GapRow(tailGap) { showAll = true }
 
-            AverageRow(average = comparison.average, sort = sort, units = units, palette = palette)
+            ReferenceRow(
+                leading = "Ø",
+                title = stringResource(R.string.compare_average),
+                caption = pluralStringResource(R.plurals.compare_drives_nearby, comparison.average.count, comparison.average.count),
+                value = averageValue(comparison.average, sort, units),
+                palette = palette
+            )
+            ReferenceRow(
+                leading = "↑",
+                title = "P100",
+                caption = null,
+                value = p100Value(comparison.all, sort, units),
+                palette = palette
+            )
         }
     }
 }
@@ -248,18 +264,15 @@ private fun GapRow(hiddenCount: Int, onClick: () -> Unit) {
     }
 }
 
+/** A reference row (Average, P100, …) styled with an accent outline. */
 @Composable
-private fun AverageRow(
-    average: DriveAverage,
-    sort: DriveCompareSort,
-    units: Units?,
+private fun ReferenceRow(
+    leading: String,
+    title: String,
+    caption: String?,
+    value: String,
     palette: CarColorPalette
 ) {
-    val value = when (sort) {
-        DriveCompareSort.EFFICIENCY -> average.efficiency?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
-        DriveCompareSort.DURATION -> formatDurationCompact(average.durationMin)
-        DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
-    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -269,7 +282,7 @@ private fun AverageRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = "Ø",
+            text = leading,
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = palette.accent,
@@ -278,13 +291,13 @@ private fun AverageRow(
         Spacer(modifier = Modifier.width(8.dp))
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
-                text = stringResource(R.string.compare_average),
+                text = title,
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.Bold,
                 color = palette.accent,
                 maxLines = 1
             )
-            Pill(pluralStringResource(R.plurals.compare_drives_nearby, average.count, average.count))
+            if (caption != null) Pill(caption)
         }
         Spacer(modifier = Modifier.width(8.dp))
         Text(
@@ -295,6 +308,20 @@ private fun AverageRow(
         )
     }
 }
+
+private fun averageValue(average: DriveAverage, sort: DriveCompareSort, units: Units?): String =
+    when (sort) {
+        DriveCompareSort.EFFICIENCY -> average.efficiency?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
+        DriveCompareSort.DURATION -> formatDurationCompact(average.durationMin)
+        DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
+    }
+
+private fun p100Value(all: List<ComparableDrive>, sort: DriveCompareSort, units: Units?): String =
+    when (sort) {
+        DriveCompareSort.EFFICIENCY -> all.mapNotNull { it.efficiency }.maxOrNull()?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
+        DriveCompareSort.DURATION -> all.maxOfOrNull { it.durationMin }?.let { formatDurationCompact(it) } ?: "—"
+        DriveCompareSort.SPEED -> all.maxOfOrNull { it.speedAvg }?.let { UnitFormatter.formatSpeed(it.toDouble(), units) } ?: "—"
+    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -316,6 +343,7 @@ private fun OverlayChartCard(
     comparison: com.matedroid.domain.DriveComparison,
     curves: List<DriveSessionCurve>,
     curvesLoading: Boolean,
+    averageCurve: List<DriveCurvePoint>,
     units: Units?,
     palette: CarColorPalette
 ) {
@@ -343,6 +371,16 @@ private fun OverlayChartCard(
             points = sessionCurve.points.map { Offset(it.distance, it.speed) }
         )
     }
+    val averageOverlay = averageCurve.takeIf { it.isNotEmpty() }?.let { avg ->
+        OverlayCurve(
+            label = stringResource(R.string.compare_average),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            isBase = false,
+            dashed = true,
+            points = avg.map { Offset(it.distance, it.speed) }
+        )
+    }
+    val allOverlay = overlay + listOfNotNull(averageOverlay)
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -378,7 +416,7 @@ private fun OverlayChartCard(
                 }
             } else {
                 PowerSocOverlayChart(
-                    curves = overlay,
+                    curves = allOverlay,
                     xUnit = " $distanceUnit",
                     xCaption = "",
                     valueUnit = speedUnit
@@ -388,7 +426,7 @@ private fun OverlayChartCard(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
-                    overlay.forEach { LegendItem(it.color, it.label) }
+                    allOverlay.forEach { LegendItem(it.color, it.label) }
                 }
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -190,6 +192,7 @@ private fun CompareContent(
             curves = curves,
             curvesLoading = curvesLoading,
             averageCurve = averageCurve,
+            sort = sort,
             units = units,
             palette = palette
         )
@@ -324,14 +327,69 @@ private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: (
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun OverlayChartCard(
     comparison: com.matedroid.domain.DriveComparison,
     curves: List<DriveSessionCurve>,
     curvesLoading: Boolean,
     averageCurve: List<DriveCurvePoint>,
+    sort: DriveCompareSort,
     units: Units?,
+    palette: CarColorPalette
+) {
+    val isDuration = sort == DriveCompareSort.DURATION
+    val isConsumption = sort == DriveCompareSort.EFFICIENCY
+    val title = when {
+        isDuration -> stringResource(R.string.duration)
+        isConsumption -> stringResource(R.string.compare_consumption_vs_distance)
+        else -> stringResource(R.string.compare_speed_vs_distance)
+    }
+    val icon = when {
+        isDuration -> Icons.Default.Schedule
+        isConsumption -> Icons.Default.Bolt
+        else -> Icons.Default.Speed
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 12.dp)
+            ) {
+                Icon(imageVector = icon, contentDescription = null, tint = palette.accent, modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+
+            if (isDuration) {
+                DurationBars(comparison = comparison, palette = palette)
+            } else {
+                LineOverlay(
+                    comparison = comparison,
+                    curves = curves,
+                    curvesLoading = curvesLoading,
+                    averageCurve = averageCurve,
+                    valueUnit = if (isConsumption) "kWh" else UnitFormatter.getSpeedUnit(units),
+                    distanceUnit = if (units?.isImperial == true) "mi" else "km",
+                    palette = palette
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun LineOverlay(
+    comparison: com.matedroid.domain.DriveComparison,
+    curves: List<DriveSessionCurve>,
+    curvesLoading: Boolean,
+    averageCurve: List<DriveCurvePoint>,
+    valueUnit: String,
+    distanceUnit: String,
     palette: CarColorPalette
 ) {
     val byId = remember(comparison) { comparison.all.associateBy { it.driveId } }
@@ -339,8 +397,6 @@ private fun OverlayChartCard(
         Color(0xFF5B8DD9), Color(0xFF4CAF50), Color(0xFF9B6BD9), Color(0xFF6D7A92)
     )
     val thisDriveLabel = stringResource(R.string.compare_this_drive)
-    val distanceUnit = if (units?.isImperial == true) "mi" else "km"
-    val speedUnit = UnitFormatter.getSpeedUnit(units)
 
     var otherIndex = 0
     val overlay = curves.map { sessionCurve ->
@@ -355,7 +411,7 @@ private fun OverlayChartCard(
             label = label,
             color = color,
             isBase = sessionCurve.isBase,
-            points = sessionCurve.points.map { Offset(it.distance, it.speed) }
+            points = sessionCurve.points.map { Offset(it.distance, it.value) }
         )
     }
     val averageOverlay = averageCurve.takeIf { it.isNotEmpty() }?.let { avg ->
@@ -363,57 +419,110 @@ private fun OverlayChartCard(
             label = stringResource(R.string.compare_average),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             isBase = false,
-            dashed = true,
-            points = avg.map { Offset(it.distance, it.speed) }
+            points = avg.map { Offset(it.distance, it.value) },
+            dashed = true
         )
     }
     val allOverlay = overlay + listOfNotNull(averageOverlay)
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 12.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Speed,
-                    contentDescription = null,
-                    tint = palette.accent,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(R.string.compare_speed_vs_distance),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-            }
+    if (overlay.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(190.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            if (curvesLoading) CircularProgressIndicator(color = palette.accent)
+        }
+    } else {
+        PowerSocOverlayChart(
+            curves = allOverlay,
+            xUnit = " $distanceUnit",
+            xCaption = "",
+            valueUnit = valueUnit
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            allOverlay.forEach { LegendItem(it.color, it.label) }
+        }
+    }
+}
 
-            if (overlay.isEmpty()) {
+/** Horizontal bars for the Duration dimension: top 3, the current run, average and worst, fastest first. */
+@Composable
+private fun DurationBars(
+    comparison: com.matedroid.domain.DriveComparison,
+    palette: CarColorPalette
+) {
+    val thisDriveLabel = stringResource(R.string.compare_this_drive)
+    val averageLabel = stringResource(R.string.compare_average)
+
+    data class Entry(val label: String, val durationMin: Int, val isBase: Boolean, val isAverage: Boolean)
+
+    val sortedAsc = comparison.all.sortedBy { it.durationMin }
+    val kept = LinkedHashMap<Int, ComparableDrive>()
+    sortedAsc.take(3).forEach { kept[it.driveId] = it }
+    kept[comparison.base.driveId] = comparison.base
+    sortedAsc.lastOrNull()?.let { kept[it.driveId] = it }
+
+    val entries = kept.values.map { drive ->
+        Entry(
+            label = if (drive.isBase) thisDriveLabel
+            else parseIsoDateTime(drive.startDate)?.toLocalDate()?.formatMedium(Locale.getDefault()) ?: drive.startAddress,
+            durationMin = drive.durationMin,
+            isBase = drive.isBase,
+            isAverage = false
+        )
+    }.toMutableList()
+    entries.add(Entry(averageLabel, comparison.average.durationMin, isBase = false, isAverage = true))
+
+    val ordered = entries.sortedBy { it.durationMin }
+    val maxDuration = (ordered.maxOfOrNull { it.durationMin } ?: 1).coerceAtLeast(1)
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        ordered.forEach { entry ->
+            val barColor = when {
+                entry.isBase -> palette.accent
+                entry.isAverage -> palette.accent.copy(alpha = 0.4f)
+                else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            }
+            val labelColor = if (entry.isBase || entry.isAverage) palette.accent else MaterialTheme.colorScheme.onSurface
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = entry.label,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = if (entry.isBase || entry.isAverage) FontWeight.Bold else FontWeight.Normal,
+                        color = labelColor,
+                        maxLines = 1
+                    )
+                    Text(
+                        text = formatDurationCompact(entry.durationMin),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = labelColor
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(190.dp),
-                    contentAlignment = Alignment.Center
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
                 ) {
-                    if (curvesLoading) CircularProgressIndicator(color = palette.accent)
-                }
-            } else {
-                PowerSocOverlayChart(
-                    curves = allOverlay,
-                    xUnit = " $distanceUnit",
-                    xCaption = "",
-                    valueUnit = speedUnit
-                )
-                Spacer(modifier = Modifier.height(10.dp))
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    allOverlay.forEach { LegendItem(it.color, it.label) }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(entry.durationMin.toFloat() / maxDuration)
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(barColor)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -1,0 +1,400 @@
+package com.matedroid.ui.screens.drives
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.matedroid.R
+import com.matedroid.data.api.models.Units
+import com.matedroid.domain.ComparableDrive
+import com.matedroid.domain.model.UnitFormatter
+import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.PowerSocOverlayChart
+import com.matedroid.ui.theme.CarColorPalette
+import com.matedroid.ui.theme.CarColorPalettes
+import com.matedroid.util.formatDurationCompact
+import com.matedroid.util.formatMedium
+import com.matedroid.util.parseIsoDateTime
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CompareDrivesScreen(
+    carId: Int,
+    baseDriveId: Int,
+    exteriorColor: String? = null,
+    onNavigateBack: () -> Unit,
+    onNavigateToDriveDetail: (Int) -> Unit,
+    viewModel: DriveComparisonViewModel = hiltViewModel()
+) {
+    LaunchedEffect(carId, baseDriveId) { viewModel.load(carId, baseDriveId) }
+    val uiState by viewModel.uiState.collectAsState()
+    val palette = CarColorPalettes.forExteriorColor(exteriorColor, isSystemInDarkTheme())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.compare_drives_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        val comparison = uiState.comparison
+        when {
+            uiState.isLoading -> MateDroidLoadingPlaceholder(
+                color = palette.accent,
+                modifier = Modifier.padding(padding)
+            )
+            comparison == null -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.compare_drives_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            else -> CompareContent(
+                comparison = comparison,
+                sort = uiState.sort,
+                units = uiState.units,
+                curves = uiState.curves,
+                curvesLoading = uiState.curvesLoading,
+                palette = palette,
+                onSortChange = viewModel::setSort,
+                onDriveClick = onNavigateToDriveDetail,
+                modifier = Modifier.padding(padding)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompareContent(
+    comparison: com.matedroid.domain.DriveComparison,
+    sort: DriveCompareSort,
+    units: Units?,
+    curves: List<DriveSessionCurve>,
+    curvesLoading: Boolean,
+    palette: CarColorPalette,
+    onSortChange: (DriveCompareSort) -> Unit,
+    onDriveClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val ranked = remember(comparison, sort) {
+        when (sort) {
+            DriveCompareSort.EFFICIENCY -> comparison.all.sortedBy { it.efficiency ?: Double.MAX_VALUE }
+            DriveCompareSort.DURATION -> comparison.all.sortedBy { it.durationMin }
+            DriveCompareSort.SPEED -> comparison.all.sortedByDescending { it.speedAvg }
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.compare_drives_scope, comparison.totalCount),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = stringResource(R.string.ranked_by).uppercase(Locale.getDefault()),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                SortChip(stringResource(R.string.efficiency), sort == DriveCompareSort.EFFICIENCY, palette.accent) { onSortChange(DriveCompareSort.EFFICIENCY) }
+                SortChip(stringResource(R.string.duration), sort == DriveCompareSort.DURATION, palette.accent) { onSortChange(DriveCompareSort.DURATION) }
+                SortChip(stringResource(R.string.speed), sort == DriveCompareSort.SPEED, palette.accent) { onSortChange(DriveCompareSort.SPEED) }
+            }
+        }
+
+        OverlayChartCard(
+            comparison = comparison,
+            curves = curves,
+            curvesLoading = curvesLoading,
+            units = units,
+            palette = palette
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            ranked.forEachIndexed { index, drive ->
+                CompareRow(
+                    rank = index + 1,
+                    drive = drive,
+                    sort = sort,
+                    units = units,
+                    palette = palette,
+                    onClick = if (drive.isBase) null else { { onDriveClick(drive.driveId) } }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = accent.copy(alpha = 0.16f),
+            selectedLabelColor = accent
+        )
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun OverlayChartCard(
+    comparison: com.matedroid.domain.DriveComparison,
+    curves: List<DriveSessionCurve>,
+    curvesLoading: Boolean,
+    units: Units?,
+    palette: CarColorPalette
+) {
+    val byId = remember(comparison) { comparison.all.associateBy { it.driveId } }
+    val otherColors = listOf(
+        Color(0xFF5B8DD9), Color(0xFF4CAF50), Color(0xFF9B6BD9), Color(0xFF6D7A92)
+    )
+    val thisDriveLabel = stringResource(R.string.compare_this_drive)
+    val distanceUnit = if (units?.isImperial == true) "mi" else "km"
+    val speedUnit = UnitFormatter.getSpeedUnit(units)
+
+    var otherIndex = 0
+    val overlay = curves.map { sessionCurve ->
+        val meta = byId[sessionCurve.driveId]
+        val color = if (sessionCurve.isBase) palette.accent else otherColors[otherIndex++ % otherColors.size]
+        val label = if (sessionCurve.isBase) {
+            thisDriveLabel
+        } else {
+            meta?.startDate?.let { parseIsoDateTime(it)?.toLocalDate()?.formatMedium(Locale.getDefault()) } ?: ""
+        }
+        OverlayCurve(
+            label = label,
+            color = color,
+            isBase = sessionCurve.isBase,
+            points = sessionCurve.points.map { Offset(it.distance, it.speed) }
+        )
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Speed,
+                    contentDescription = null,
+                    tint = palette.accent,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.compare_speed_vs_distance),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            if (overlay.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(190.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (curvesLoading) CircularProgressIndicator(color = palette.accent)
+                }
+            } else {
+                PowerSocOverlayChart(
+                    curves = overlay,
+                    xUnit = " $distanceUnit",
+                    xCaption = "",
+                    valueUnit = speedUnit
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    overlay.forEach { LegendItem(it.color, it.label) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(5.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun CompareRow(
+    rank: Int,
+    drive: ComparableDrive,
+    sort: DriveCompareSort,
+    units: Units?,
+    palette: CarColorPalette,
+    onClick: (() -> Unit)?
+) {
+    val bg = if (drive.isBase) palette.accent.copy(alpha = 0.12f) else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+    val value = valueFor(drive, sort, units)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(bg)
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = rankBadge(rank),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(28.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = if (drive.isBase) stringResource(R.string.compare_this_drive)
+                else (parseIsoDateTime(drive.startDate)?.toLocalDate()?.formatMedium(Locale.getDefault()) ?: drive.startAddress),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = if (drive.isBase) palette.accent else MaterialTheme.colorScheme.onSurface,
+                maxLines = 1
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Pill(UnitFormatter.formatSpeed(drive.speedAvg.toDouble(), units))
+                drive.outsideTempAvg?.let { Pill(UnitFormatter.formatTemperature(it, units)) }
+            }
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = if (drive.isBase) palette.accent else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun Pill(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 7.dp, vertical = 3.dp)
+    )
+}
+
+private fun rankBadge(rank: Int): String = when (rank) {
+    1 -> "🥇"
+    2 -> "🥈"
+    3 -> "🥉"
+    else -> "$rank"
+}
+
+private fun valueFor(drive: ComparableDrive, sort: DriveCompareSort, units: Units?): String =
+    when (sort) {
+        DriveCompareSort.EFFICIENCY -> drive.efficiency?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
+        DriveCompareSort.DURATION -> formatDurationCompact(drive.durationMin)
+        DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(drive.speedAvg.toDouble(), units)
+    }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -1,6 +1,7 @@
 package com.matedroid.ui.screens.drives
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -40,12 +41,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -53,6 +58,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.ComparableDrive
+import com.matedroid.domain.DriveAverage
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.OverlayCurve
@@ -185,18 +191,108 @@ private fun CompareContent(
             palette = palette
         )
 
+        // Curate the leaderboard: top 3 of this dimension + the current run with its neighbours,
+        // the rest collapsed behind a tappable "+N more", and an averaged reference row.
+        var showAll by rememberSaveable { mutableStateOf(false) }
+        val baseIndex = ranked.indexOfFirst { it.isBase }.coerceAtLeast(0)
+        val keptIndices = if (showAll) {
+            ranked.indices.toList()
+        } else {
+            val keep = sortedSetOf<Int>()
+            listOf(0, 1, 2).forEach { if (it in ranked.indices) keep.add(it) }
+            for (d in -1..1) (baseIndex + d).let { if (it in ranked.indices) keep.add(it) }
+            keep.toList()
+        }
+
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            ranked.forEachIndexed { index, drive ->
+            var prev = -1
+            keptIndices.forEach { idx ->
+                val gap = idx - prev - 1
+                if (gap > 0) GapRow(gap) { showAll = true }
+                val drive = ranked[idx]
                 CompareRow(
-                    rank = index + 1,
+                    rank = idx + 1,
                     drive = drive,
                     sort = sort,
                     units = units,
                     palette = palette,
                     onClick = if (drive.isBase) null else { { onDriveClick(drive.driveId) } }
                 )
+                prev = idx
             }
+            val tailGap = ranked.lastIndex - prev
+            if (tailGap > 0) GapRow(tailGap) { showAll = true }
+
+            AverageRow(average = comparison.average, sort = sort, units = units, palette = palette)
         }
+    }
+}
+
+@Composable
+private fun GapRow(hiddenCount: Int, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 6.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "⋯  " + pluralStringResource(R.plurals.compare_more, hiddenCount, hiddenCount),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun AverageRow(
+    average: DriveAverage,
+    sort: DriveCompareSort,
+    units: Units?,
+    palette: CarColorPalette
+) {
+    val value = when (sort) {
+        DriveCompareSort.EFFICIENCY -> average.efficiency?.let { UnitFormatter.formatEfficiency(it, units) } ?: "—"
+        DriveCompareSort.DURATION -> formatDurationCompact(average.durationMin)
+        DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .border(1.dp, palette.accent.copy(alpha = 0.35f), RoundedCornerShape(14.dp))
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Ø",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = palette.accent,
+            modifier = Modifier.width(28.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = stringResource(R.string.compare_average),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = palette.accent,
+                maxLines = 1
+            )
+            Pill(pluralStringResource(R.plurals.compare_drives_nearby, average.count, average.count))
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = palette.accent
+        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -3,6 +3,7 @@ package com.matedroid.ui.screens.drives
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,16 +42,19 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -160,10 +164,19 @@ private fun CompareContent(
         }
     }
 
+    // Bumped on an outside tap or a scroll to dismiss the chart tooltip.
+    var dismissKey by remember { mutableStateOf(0) }
+    val scrollState = rememberScrollState()
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.isScrollInProgress }
+            .collect { if (it) dismissKey++ }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
+            .pointerInput(Unit) { detectTapGestures { dismissKey++ } }
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
@@ -181,9 +194,9 @@ private fun CompareContent(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                SortChip(stringResource(R.string.speed), sort == DriveCompareSort.SPEED, palette.accent) { onSortChange(DriveCompareSort.SPEED) }
                 SortChip(stringResource(R.string.efficiency), sort == DriveCompareSort.EFFICIENCY, palette.accent) { onSortChange(DriveCompareSort.EFFICIENCY) }
                 SortChip(stringResource(R.string.duration), sort == DriveCompareSort.DURATION, palette.accent) { onSortChange(DriveCompareSort.DURATION) }
-                SortChip(stringResource(R.string.speed), sort == DriveCompareSort.SPEED, palette.accent) { onSortChange(DriveCompareSort.SPEED) }
             }
         }
 
@@ -194,7 +207,8 @@ private fun CompareContent(
             averageCurve = averageCurve,
             sort = sort,
             units = units,
-            palette = palette
+            palette = palette,
+            dismissKey = dismissKey
         )
 
         // Curate the leaderboard: top 3 of this dimension + the current run with its neighbours,
@@ -335,7 +349,8 @@ private fun OverlayChartCard(
     averageCurve: List<DriveCurvePoint>,
     sort: DriveCompareSort,
     units: Units?,
-    palette: CarColorPalette
+    palette: CarColorPalette,
+    dismissKey: Any?
 ) {
     val isDuration = sort == DriveCompareSort.DURATION
     val isConsumption = sort == DriveCompareSort.EFFICIENCY
@@ -364,18 +379,24 @@ private fun OverlayChartCard(
                 Text(text = title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             }
 
-            if (isDuration) {
-                DurationBars(comparison = comparison, palette = palette)
-            } else {
-                LineOverlay(
-                    comparison = comparison,
-                    curves = curves,
-                    curvesLoading = curvesLoading,
-                    averageCurve = averageCurve,
-                    valueUnit = if (isConsumption) "kWh" else UnitFormatter.getSpeedUnit(units),
-                    distanceUnit = if (units?.isImperial == true) "mi" else "km",
-                    palette = palette
-                )
+            // Fixed body height so switching dimension (line + legend vs bars) never jumps.
+            Box(modifier = Modifier.fillMaxWidth().height(CHART_BODY_HEIGHT)) {
+                if (isDuration) {
+                    DurationBars(comparison = comparison, palette = palette)
+                } else {
+                    LineOverlay(
+                        comparison = comparison,
+                        curves = curves,
+                        curvesLoading = curvesLoading,
+                        averageCurve = averageCurve,
+                        valueUnit = if (isConsumption) {
+                            if (units?.isImperial == true) "Wh/mi" else "Wh/km"
+                        } else UnitFormatter.getSpeedUnit(units),
+                        distanceUnit = if (units?.isImperial == true) "mi" else "km",
+                        palette = palette,
+                        dismissKey = dismissKey
+                    )
+                }
             }
         }
     }
@@ -390,7 +411,8 @@ private fun LineOverlay(
     averageCurve: List<DriveCurvePoint>,
     valueUnit: String,
     distanceUnit: String,
-    palette: CarColorPalette
+    palette: CarColorPalette,
+    dismissKey: Any?
 ) {
     val byId = remember(comparison) { comparison.all.associateBy { it.driveId } }
     val otherColors = listOf(
@@ -427,19 +449,19 @@ private fun LineOverlay(
 
     if (overlay.isEmpty()) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(190.dp),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             if (curvesLoading) CircularProgressIndicator(color = palette.accent)
         }
     } else {
+        Column {
         PowerSocOverlayChart(
             curves = allOverlay,
             xUnit = " $distanceUnit",
             xCaption = "",
-            valueUnit = valueUnit
+            valueUnit = valueUnit,
+            dismissKey = dismissKey
         )
         Spacer(modifier = Modifier.height(10.dp))
         FlowRow(
@@ -448,8 +470,12 @@ private fun LineOverlay(
         ) {
             allOverlay.forEach { LegendItem(it.color, it.label) }
         }
+        }
     }
 }
+
+/** Fixed height for the comparison chart body, so line+legend and the duration bars match. */
+private val CHART_BODY_HEIGHT = 268.dp
 
 /** Horizontal bars for the Duration dimension: top 3, the current run, average and worst, fastest first. */
 @Composable
@@ -482,7 +508,10 @@ private fun DurationBars(
     val ordered = entries.sortedBy { it.durationMin }
     val maxDuration = (ordered.maxOfOrNull { it.durationMin } ?: 1).coerceAtLeast(1)
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.SpaceEvenly
+    ) {
         ordered.forEach { entry ->
             val barColor = when {
                 entry.isBase -> palette.accent

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
@@ -37,7 +37,8 @@ data class DriveComparisonUiState(
     val sort: DriveCompareSort = DriveCompareSort.EFFICIENCY,
     val units: Units? = null,
     val curves: List<DriveSessionCurve> = emptyList(),
-    val curvesLoading: Boolean = false
+    val curvesLoading: Boolean = false,
+    val averageCurve: List<DriveCurvePoint> = emptyList()
 )
 
 @HiltViewModel
@@ -67,6 +68,7 @@ class DriveComparisonViewModel @Inject constructor(
             val comparison = comparisonRepository.findComparable(carId, baseDriveId)
             _uiState.update { it.copy(isLoading = false, comparison = comparison, units = units) }
             refreshCurves(carId)
+            computeAverageCurve(carId)
         }
     }
 
@@ -133,7 +135,71 @@ class DriveComparisonViewModel @Inject constructor(
         return if (points.size >= 2) DriveSessionCurve(driveId, isBase, points) else null
     }
 
+    /**
+     * Builds a dashed "average" speed-vs-distance curve from a sample of the route's runs:
+     * resamples each run onto a shared distance grid and averages the speed at each step.
+     */
+    private fun computeAverageCurve(carId: Int) {
+        val comparison = _uiState.value.comparison ?: return
+        val imperial = _uiState.value.units?.isImperial == true
+
+        viewModelScope.launch {
+            val sampleIds = sampleDriveIds(comparison.all.map { it.driveId })
+            val sampled = sampleIds.mapNotNull { id ->
+                curveCache[id]?.points
+                    ?: buildCurve(carId, id, isBase = false, imperial = imperial)?.also { curveCache[id] = it }?.points
+            }.filter { it.size >= 2 }
+
+            val average = averageCurves(sampled)
+            if (average.isNotEmpty()) {
+                _uiState.update { it.copy(averageCurve = average) }
+            }
+        }
+    }
+
+    /** Pick up to [AVERAGE_SAMPLE] drive ids spread evenly across the set, to bound detail fetches. */
+    private fun sampleDriveIds(ids: List<Int>): List<Int> {
+        if (ids.size <= AVERAGE_SAMPLE) return ids
+        return (0 until AVERAGE_SAMPLE)
+            .map { ids[it * (ids.size - 1) / (AVERAGE_SAMPLE - 1)] }
+            .distinct()
+    }
+
+    private fun averageCurves(curves: List<List<DriveCurvePoint>>): List<DriveCurvePoint> {
+        if (curves.isEmpty()) return emptyList()
+        val maxDistance = curves.maxOf { it.lastOrNull()?.distance ?: 0f }
+        if (maxDistance <= 0f) return emptyList()
+
+        val buckets = 40
+        val result = ArrayList<DriveCurvePoint>(buckets + 1)
+        for (b in 0..buckets) {
+            val distance = maxDistance * b / buckets
+            val speeds = curves.mapNotNull { interpolateSpeed(it, distance) }
+            if (speeds.isNotEmpty()) {
+                result.add(DriveCurvePoint(distance, speeds.average().toFloat()))
+            }
+        }
+        return result
+    }
+
+    private fun interpolateSpeed(points: List<DriveCurvePoint>, distance: Float): Float? {
+        if (points.isEmpty() || distance < points.first().distance || distance > points.last().distance) return null
+        for (i in 1 until points.size) {
+            val a = points[i - 1]
+            val b = points[i]
+            if (distance <= b.distance) {
+                val span = b.distance - a.distance
+                if (span <= 0f) return a.speed
+                val t = (distance - a.distance) / span
+                return a.speed + t * (b.speed - a.speed)
+            }
+        }
+        return points.last().speed
+    }
+
     companion object {
         const val MAX_CURVES = 5
+        /** How many runs to sample when computing the average curve (bounds detail fetches). */
+        const val AVERAGE_SAMPLE = 10
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
@@ -11,6 +11,9 @@ import com.matedroid.domain.DriveComparisonRepository
 import com.matedroid.util.haversineMeters
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,7 +41,7 @@ private data class DriveCurveData(val driveId: Int, val isBase: Boolean, val sam
 data class DriveComparisonUiState(
     val isLoading: Boolean = true,
     val comparison: DriveComparison? = null,
-    val sort: DriveCompareSort = DriveCompareSort.EFFICIENCY,
+    val sort: DriveCompareSort = DriveCompareSort.SPEED,
     val units: Units? = null,
     val curves: List<DriveSessionCurve> = emptyList(),
     val curvesLoading: Boolean = false,
@@ -100,35 +103,57 @@ class DriveComparisonViewModel @Inject constructor(
         curveFetchJob = viewModelScope.launch {
             _uiState.update { it.copy(curvesLoading = true) }
 
-            (ordered.map { it.driveId } + sampleIds).distinct().forEach { id ->
-                if (!curveDataCache.containsKey(id)) {
-                    buildCurveData(carId, id, id == comparison.base.driveId, imperial)?.let { curveDataCache[id] = it }
-                }
+            // Fetch any missing drive details concurrently (network calls overlap).
+            suspend fun ensureFetched(ids: List<Int>) = coroutineScope {
+                ids.distinct()
+                    .filter { !curveDataCache.containsKey(it) }
+                    .map { id -> async { id to buildCurveData(carId, id, id == comparison.base.driveId, imperial) } }
+                    .awaitAll()
+                    .forEach { (id, data) -> if (data != null) curveDataCache[id] = data }
             }
 
+            // Phase 1: the overlaid curves — show them as soon as they're ready.
+            ensureFetched(ordered.map { it.driveId })
             val curves = ordered.mapNotNull { drive ->
                 curveDataCache[drive.driveId]?.let { data ->
-                    DriveSessionCurve(
-                        driveId = drive.driveId,
-                        isBase = drive.isBase,
-                        points = data.samples.map { DriveCurvePoint(it.distance, metricValue(it, sort)) }
-                    )
+                    DriveSessionCurve(drive.driveId, drive.isBase, metricPoints(data.samples, sort))
                 }
             }
-            val sampleCurves = sampleIds
-                .mapNotNull { id -> curveDataCache[id]?.samples?.map { DriveCurvePoint(it.distance, metricValue(it, sort)) } }
-                .filter { it.size >= 2 }
-            val average = averageCurves(sampleCurves)
+            _uiState.update { it.copy(curves = curves, curvesLoading = false) }
 
-            _uiState.update { it.copy(curves = curves, averageCurve = average, curvesLoading = false) }
+            // Phase 2: the dashed average from a wider sample — fills in afterwards.
+            ensureFetched(sampleIds)
+            val sampleCurves = sampleIds
+                .mapNotNull { id -> curveDataCache[id]?.samples?.let { metricPoints(it, sort) } }
+                .filter { it.size >= 2 }
+            _uiState.update { it.copy(averageCurve = averageCurves(sampleCurves)) }
         }
     }
 
-    private fun metricValue(sample: DriveCurveSample, sort: DriveCompareSort): Float =
-        when (sort) {
-            DriveCompareSort.EFFICIENCY -> sample.energyKwh
-            else -> sample.speed
+    /**
+     * Per-point series for the chart. Speed is plotted directly; consumption is the instantaneous
+     * Wh/(km|mi) over a short trailing-distance window (ΔkWh / Δdistance × 1000) — smooth and bounded,
+     * unlike raw power/speed which blows up at low speed.
+     */
+    private fun metricPoints(samples: List<DriveCurveSample>, sort: DriveCompareSort): List<DriveCurvePoint> {
+        if (sort != DriveCompareSort.EFFICIENCY) {
+            return samples.map { DriveCurvePoint(it.distance, it.speed) }
         }
+        val maxDistance = samples.lastOrNull()?.distance ?: 0f
+        if (maxDistance <= 0f) return emptyList()
+        val window = (maxDistance / 25f).coerceAtLeast(0.2f) // ~25 segments along the route
+        val points = ArrayList<DriveCurvePoint>(samples.size)
+        var lo = 0
+        for (i in samples.indices) {
+            while (lo < i && samples[i].distance - samples[lo].distance > window) lo++
+            val dDist = samples[i].distance - samples[lo].distance
+            if (dDist > 0f) {
+                val dEnergy = samples[i].energyKwh - samples[lo].energyKwh
+                points.add(DriveCurvePoint(samples[i].distance, (dEnergy / dDist) * 1000f))
+            }
+        }
+        return points
+    }
 
     private fun sortedOthers(others: List<ComparableDrive>, sort: DriveCompareSort): List<ComparableDrive> =
         when (sort) {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
@@ -1,0 +1,139 @@
+package com.matedroid.ui.screens.drives
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.ComparableDrive
+import com.matedroid.domain.DriveComparison
+import com.matedroid.domain.DriveComparisonRepository
+import com.matedroid.util.haversineMeters
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** How the comparison leaderboard is ranked. */
+enum class DriveCompareSort { EFFICIENCY, DURATION, SPEED }
+
+/** One point of a drive curve: speed at a given distance along the route, in display units. */
+data class DriveCurvePoint(val distance: Float, val speed: Float)
+
+/** A drive's speed-vs-distance curve, for the overlay chart. */
+data class DriveSessionCurve(
+    val driveId: Int,
+    val isBase: Boolean,
+    val points: List<DriveCurvePoint>
+)
+
+data class DriveComparisonUiState(
+    val isLoading: Boolean = true,
+    val comparison: DriveComparison? = null,
+    val sort: DriveCompareSort = DriveCompareSort.EFFICIENCY,
+    val units: Units? = null,
+    val curves: List<DriveSessionCurve> = emptyList(),
+    val curvesLoading: Boolean = false
+)
+
+@HiltViewModel
+class DriveComparisonViewModel @Inject constructor(
+    private val comparisonRepository: DriveComparisonRepository,
+    private val repository: TeslamateRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DriveComparisonUiState())
+    val uiState: StateFlow<DriveComparisonUiState> = _uiState.asStateFlow()
+
+    private var loaded = false
+    private var carId: Int? = null
+    private val curveCache = mutableMapOf<Int, DriveSessionCurve>()
+    private var curveFetchJob: Job? = null
+
+    fun load(carId: Int, baseDriveId: Int) {
+        if (loaded) return
+        loaded = true
+        this.carId = carId
+
+        viewModelScope.launch {
+            val units = when (val status = repository.getCarStatus(carId)) {
+                is ApiResult.Success -> status.data.units
+                is ApiResult.Error -> null
+            }
+            val comparison = comparisonRepository.findComparable(carId, baseDriveId)
+            _uiState.update { it.copy(isLoading = false, comparison = comparison, units = units) }
+            refreshCurves(carId)
+        }
+    }
+
+    fun setSort(sort: DriveCompareSort) {
+        _uiState.update { it.copy(sort = sort) }
+        carId?.let { refreshCurves(it) }
+    }
+
+    private fun refreshCurves(carId: Int) {
+        val comparison = _uiState.value.comparison ?: return
+        val ordered = listOf(comparison.base) +
+            sortedOthers(comparison.others, _uiState.value.sort).take(MAX_CURVES - 1)
+        val imperial = _uiState.value.units?.isImperial == true
+
+        curveFetchJob?.cancel()
+        curveFetchJob = viewModelScope.launch {
+            _uiState.update { it.copy(curvesLoading = true) }
+            ordered.forEach { drive ->
+                if (!curveCache.containsKey(drive.driveId)) {
+                    buildCurve(carId, drive.driveId, drive.isBase, imperial)?.let { curveCache[drive.driveId] = it }
+                }
+            }
+            val curves = ordered.mapNotNull { curveCache[it.driveId] }
+            _uiState.update { it.copy(curves = curves, curvesLoading = false) }
+        }
+    }
+
+    private fun sortedOthers(others: List<ComparableDrive>, sort: DriveCompareSort): List<ComparableDrive> =
+        when (sort) {
+            DriveCompareSort.EFFICIENCY -> others.sortedBy { it.efficiency ?: Double.MAX_VALUE }
+            DriveCompareSort.DURATION -> others.sortedBy { it.durationMin }
+            DriveCompareSort.SPEED -> others.sortedByDescending { it.speedAvg }
+        }
+
+    private suspend fun buildCurve(carId: Int, driveId: Int, isBase: Boolean, imperial: Boolean): DriveSessionCurve? {
+        val detail = when (val result = repository.getDriveDetail(carId, driveId)) {
+            is ApiResult.Success -> result.data
+            is ApiResult.Error -> return null
+        }
+        val positions = detail.positions ?: return null
+        val toDisplay = if (imperial) 0.621371f else 1f // km→mi and km/h→mph share the factor
+
+        var cumulativeMeters = 0.0
+        var prevLat: Double? = null
+        var prevLon: Double? = null
+        val points = ArrayList<DriveCurvePoint>(positions.size)
+        positions.forEach { position ->
+            val lat = position.latitude
+            val lon = position.longitude
+            if (lat != null && lon != null) {
+                val pLat = prevLat
+                val pLon = prevLon
+                if (pLat != null && pLon != null) {
+                    cumulativeMeters += haversineMeters(pLat, pLon, lat, lon)
+                }
+                prevLat = lat
+                prevLon = lon
+                position.speed?.let { speed ->
+                    val distanceDisplay = (cumulativeMeters / 1000.0).toFloat() * toDisplay
+                    points.add(DriveCurvePoint(distanceDisplay, speed.toFloat() * toDisplay))
+                }
+            }
+        }
+        return if (points.size >= 2) DriveSessionCurve(driveId, isBase, points) else null
+    }
+
+    companion object {
+        const val MAX_CURVES = 5
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
@@ -18,18 +18,22 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/** How the comparison leaderboard is ranked. */
+/** How the comparison leaderboard is ranked (and, for line charts, which metric is plotted). */
 enum class DriveCompareSort { EFFICIENCY, DURATION, SPEED }
 
-/** One point of a drive curve: speed at a given distance along the route, in display units. */
-data class DriveCurvePoint(val distance: Float, val speed: Float)
+/** A resampled point of a drive's overlay line: the metric [value] at a [distance] along the route. */
+data class DriveCurvePoint(val distance: Float, val value: Float)
 
-/** A drive's speed-vs-distance curve, for the overlay chart. */
+/** A drive's overlay line in the currently-selected metric. */
 data class DriveSessionCurve(
     val driveId: Int,
     val isBase: Boolean,
     val points: List<DriveCurvePoint>
 )
+
+/** Raw per-point data for a drive, kept metric-independent so switching metric needs no refetch. */
+private data class DriveCurveSample(val distance: Float, val speed: Float, val energyKwh: Float)
+private data class DriveCurveData(val driveId: Int, val isBase: Boolean, val samples: List<DriveCurveSample>)
 
 data class DriveComparisonUiState(
     val isLoading: Boolean = true,
@@ -52,7 +56,7 @@ class DriveComparisonViewModel @Inject constructor(
 
     private var loaded = false
     private var carId: Int? = null
-    private val curveCache = mutableMapOf<Int, DriveSessionCurve>()
+    private val curveDataCache = mutableMapOf<Int, DriveCurveData>()
     private var curveFetchJob: Job? = null
 
     fun load(carId: Int, baseDriveId: Int) {
@@ -67,34 +71,64 @@ class DriveComparisonViewModel @Inject constructor(
             }
             val comparison = comparisonRepository.findComparable(carId, baseDriveId)
             _uiState.update { it.copy(isLoading = false, comparison = comparison, units = units) }
-            refreshCurves(carId)
-            computeAverageCurve(carId)
+            refresh(carId)
         }
     }
 
     fun setSort(sort: DriveCompareSort) {
         _uiState.update { it.copy(sort = sort) }
-        carId?.let { refreshCurves(it) }
+        carId?.let { refresh(it) }
     }
 
-    private fun refreshCurves(carId: Int) {
+    /** Rebuild the line overlay (curves + average) for the active metric. Duration uses bars, no curves. */
+    private fun refresh(carId: Int) {
         val comparison = _uiState.value.comparison ?: return
-        val ordered = listOf(comparison.base) +
-            sortedOthers(comparison.others, _uiState.value.sort).take(MAX_CURVES - 1)
+        val sort = _uiState.value.sort
+
+        // Duration is shown as bars from the leaderboard values — no per-point curves needed.
+        if (sort == DriveCompareSort.DURATION) {
+            curveFetchJob?.cancel()
+            _uiState.update { it.copy(curves = emptyList(), averageCurve = emptyList(), curvesLoading = false) }
+            return
+        }
+
         val imperial = _uiState.value.units?.isImperial == true
+        val ordered = listOf(comparison.base) + sortedOthers(comparison.others, sort).take(MAX_CURVES - 1)
+        val sampleIds = sampleDriveIds(comparison.all.map { it.driveId })
 
         curveFetchJob?.cancel()
         curveFetchJob = viewModelScope.launch {
             _uiState.update { it.copy(curvesLoading = true) }
-            ordered.forEach { drive ->
-                if (!curveCache.containsKey(drive.driveId)) {
-                    buildCurve(carId, drive.driveId, drive.isBase, imperial)?.let { curveCache[drive.driveId] = it }
+
+            (ordered.map { it.driveId } + sampleIds).distinct().forEach { id ->
+                if (!curveDataCache.containsKey(id)) {
+                    buildCurveData(carId, id, id == comparison.base.driveId, imperial)?.let { curveDataCache[id] = it }
                 }
             }
-            val curves = ordered.mapNotNull { curveCache[it.driveId] }
-            _uiState.update { it.copy(curves = curves, curvesLoading = false) }
+
+            val curves = ordered.mapNotNull { drive ->
+                curveDataCache[drive.driveId]?.let { data ->
+                    DriveSessionCurve(
+                        driveId = drive.driveId,
+                        isBase = drive.isBase,
+                        points = data.samples.map { DriveCurvePoint(it.distance, metricValue(it, sort)) }
+                    )
+                }
+            }
+            val sampleCurves = sampleIds
+                .mapNotNull { id -> curveDataCache[id]?.samples?.map { DriveCurvePoint(it.distance, metricValue(it, sort)) } }
+                .filter { it.size >= 2 }
+            val average = averageCurves(sampleCurves)
+
+            _uiState.update { it.copy(curves = curves, averageCurve = average, curvesLoading = false) }
         }
     }
+
+    private fun metricValue(sample: DriveCurveSample, sort: DriveCompareSort): Float =
+        when (sort) {
+            DriveCompareSort.EFFICIENCY -> sample.energyKwh
+            else -> sample.speed
+        }
 
     private fun sortedOthers(others: List<ComparableDrive>, sort: DriveCompareSort): List<ComparableDrive> =
         when (sort) {
@@ -103,61 +137,48 @@ class DriveComparisonViewModel @Inject constructor(
             DriveCompareSort.SPEED -> others.sortedByDescending { it.speedAvg }
         }
 
-    private suspend fun buildCurve(carId: Int, driveId: Int, isBase: Boolean, imperial: Boolean): DriveSessionCurve? {
+    /**
+     * Fetch a drive and derive its per-point samples: display distance, display speed, and cumulative
+     * energy used (kWh). Energy is integrated as power × (segment distance / speed), so no timestamps.
+     */
+    private suspend fun buildCurveData(carId: Int, driveId: Int, isBase: Boolean, imperial: Boolean): DriveCurveData? {
         val detail = when (val result = repository.getDriveDetail(carId, driveId)) {
             is ApiResult.Success -> result.data
             is ApiResult.Error -> return null
         }
         val positions = detail.positions ?: return null
-        val toDisplay = if (imperial) 0.621371f else 1f // km→mi and km/h→mph share the factor
+        val toDisplay = if (imperial) 0.621371f else 1f
 
-        var cumulativeMeters = 0.0
+        var cumDistanceDisplay = 0f
+        var cumEnergyKwh = 0.0
         var prevLat: Double? = null
         var prevLon: Double? = null
-        val points = ArrayList<DriveCurvePoint>(positions.size)
+        val samples = ArrayList<DriveCurveSample>(positions.size)
         positions.forEach { position ->
             val lat = position.latitude
             val lon = position.longitude
+            val speed = position.speed
             if (lat != null && lon != null) {
                 val pLat = prevLat
                 val pLon = prevLon
                 if (pLat != null && pLon != null) {
-                    cumulativeMeters += haversineMeters(pLat, pLon, lat, lon)
+                    val segKm = haversineMeters(pLat, pLon, lat, lon) / 1000.0
+                    cumDistanceDisplay += (segKm * toDisplay).toFloat()
+                    val power = position.power
+                    if (speed != null && speed > 0 && power != null) {
+                        cumEnergyKwh += power.toDouble() * (segKm / speed.toDouble()) // kW × h
+                    }
                 }
                 prevLat = lat
                 prevLon = lon
-                position.speed?.let { speed ->
-                    val distanceDisplay = (cumulativeMeters / 1000.0).toFloat() * toDisplay
-                    points.add(DriveCurvePoint(distanceDisplay, speed.toFloat() * toDisplay))
+                if (speed != null) {
+                    samples.add(DriveCurveSample(cumDistanceDisplay, speed.toFloat() * toDisplay, cumEnergyKwh.toFloat()))
                 }
             }
         }
-        return if (points.size >= 2) DriveSessionCurve(driveId, isBase, points) else null
+        return if (samples.size >= 2) DriveCurveData(driveId, isBase, samples) else null
     }
 
-    /**
-     * Builds a dashed "average" speed-vs-distance curve from a sample of the route's runs:
-     * resamples each run onto a shared distance grid and averages the speed at each step.
-     */
-    private fun computeAverageCurve(carId: Int) {
-        val comparison = _uiState.value.comparison ?: return
-        val imperial = _uiState.value.units?.isImperial == true
-
-        viewModelScope.launch {
-            val sampleIds = sampleDriveIds(comparison.all.map { it.driveId })
-            val sampled = sampleIds.mapNotNull { id ->
-                curveCache[id]?.points
-                    ?: buildCurve(carId, id, isBase = false, imperial = imperial)?.also { curveCache[id] = it }?.points
-            }.filter { it.size >= 2 }
-
-            val average = averageCurves(sampled)
-            if (average.isNotEmpty()) {
-                _uiState.update { it.copy(averageCurve = average) }
-            }
-        }
-    }
-
-    /** Pick up to [AVERAGE_SAMPLE] drive ids spread evenly across the set, to bound detail fetches. */
     private fun sampleDriveIds(ids: List<Int>): List<Int> {
         if (ids.size <= AVERAGE_SAMPLE) return ids
         return (0 until AVERAGE_SAMPLE)
@@ -174,32 +195,29 @@ class DriveComparisonViewModel @Inject constructor(
         val result = ArrayList<DriveCurvePoint>(buckets + 1)
         for (b in 0..buckets) {
             val distance = maxDistance * b / buckets
-            val speeds = curves.mapNotNull { interpolateSpeed(it, distance) }
-            if (speeds.isNotEmpty()) {
-                result.add(DriveCurvePoint(distance, speeds.average().toFloat()))
-            }
+            val values = curves.mapNotNull { interpolate(it, distance) }
+            if (values.isNotEmpty()) result.add(DriveCurvePoint(distance, values.average().toFloat()))
         }
         return result
     }
 
-    private fun interpolateSpeed(points: List<DriveCurvePoint>, distance: Float): Float? {
+    private fun interpolate(points: List<DriveCurvePoint>, distance: Float): Float? {
         if (points.isEmpty() || distance < points.first().distance || distance > points.last().distance) return null
         for (i in 1 until points.size) {
             val a = points[i - 1]
             val b = points[i]
             if (distance <= b.distance) {
                 val span = b.distance - a.distance
-                if (span <= 0f) return a.speed
+                if (span <= 0f) return a.value
                 val t = (distance - a.distance) / span
-                return a.speed + t * (b.speed - a.speed)
+                return a.value + t * (b.value - a.value)
             }
         }
-        return points.last().speed
+        return points.last().value
     }
 
     companion object {
         const val MAX_CURVES = 5
-        /** How many runs to sample when computing the average curve (bounds detail fetches). */
         const val AVERAGE_SAMPLE = 10
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -21,14 +21,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.Landscape
 import androidx.compose.material.icons.filled.LocationOn
 import com.matedroid.ui.icons.CustomIcons
@@ -67,6 +70,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -78,6 +82,7 @@ import com.matedroid.data.api.models.DriveDetail
 import com.matedroid.data.api.models.DrivePosition
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.WeatherPoint
+import com.matedroid.domain.DriveComparison
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
@@ -102,6 +107,7 @@ fun DriveDetailScreen(
     exteriorColor: String? = null,
     onNavigateBack: () -> Unit,
     onNavigateToTripDetail: (tripStartDate: String) -> Unit = {},
+    onNavigateToCompare: (baseDriveId: Int) -> Unit = {},
     viewModel: DriveDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -154,6 +160,8 @@ fun DriveDetailScreen(
                     weatherPoints = uiState.weatherPoints,
                     isLoadingWeather = uiState.isLoadingWeather,
                     containingTrip = uiState.containingTrip,
+                    comparison = uiState.comparison,
+                    onCompareClick = { onNavigateToCompare(driveId) },
                     onNavigateToTripDetail = onNavigateToTripDetail,
                     onRemoveFromTrip = viewModel::removeFromTrip,
                     modifier = Modifier.padding(padding)
@@ -172,6 +180,8 @@ private fun DriveDetailContent(
     weatherPoints: List<WeatherPoint>,
     isLoadingWeather: Boolean,
     containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
+    comparison: DriveComparison?,
+    onCompareClick: () -> Unit,
     onNavigateToTripDetail: (String) -> Unit,
     onRemoveFromTrip: () -> Unit,
     modifier: Modifier = Modifier
@@ -214,6 +224,11 @@ private fun DriveDetailContent(
 
         // Accent stat tiles — efficiency and its main confounders
         stats?.let { s -> DriveStatTiles(stats = s, units = units, palette = palette) }
+
+        // Compare entry — appears for drives with comparable sessions on the same route
+        comparison?.let { cmp ->
+            DriveCompareCard(comparison = cmp, palette = palette, onClick = onCompareClick)
+        }
 
         // Primary chart: speed profile, accent-tinted
         if (hasCharts && positions!!.any { it.speed != null }) {
@@ -472,6 +487,61 @@ private fun DriveStatTile(
             fontWeight = FontWeight.Bold,
             color = accent,
             maxLines = 1
+        )
+    }
+}
+
+/** Entry point into the drive-comparison screen, shown only for drives with comparable siblings. */
+@Composable
+private fun DriveCompareCard(
+    comparison: DriveComparison,
+    palette: CarColorPalette,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(palette.accent.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(palette.accent.copy(alpha = 0.20f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Insights,
+                contentDescription = null,
+                tint = palette.accent,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.compare_drives_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = pluralStringResource(
+                    R.plurals.compare_drives_nearby,
+                    comparison.others.size,
+                    comparison.others.size
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import android.graphics.Paint
 import android.net.Uri
 import android.view.MotionEvent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -25,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.DeviceThermostat
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Landscape
 import androidx.compose.material.icons.filled.LocationOn
 import com.matedroid.ui.icons.CustomIcons
@@ -51,11 +55,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -76,6 +82,7 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.screens.trips.displayName
+import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.BoundingBox
@@ -143,7 +150,7 @@ fun DriveDetailScreen(
                     detail = detail,
                     stats = uiState.stats,
                     units = uiState.units,
-                    routeColor = palette.accent,
+                    palette = palette,
                     weatherPoints = uiState.weatherPoints,
                     isLoadingWeather = uiState.isLoadingWeather,
                     containingTrip = uiState.containingTrip,
@@ -161,7 +168,7 @@ private fun DriveDetailContent(
     detail: DriveDetail,
     stats: DriveDetailStats?,
     units: Units?,
-    routeColor: Color,
+    palette: CarColorPalette,
     weatherPoints: List<WeatherPoint>,
     isLoadingWeather: Boolean,
     containingTrip: Pair<Long, com.matedroid.domain.model.Trip>?,
@@ -178,6 +185,22 @@ private fun DriveDetailContent(
             .collect { isScrolling -> if (isScrolling) sharedXFraction = null }
     }
 
+    val positions = detail.positions
+    val hasCharts = positions != null && positions.size > 2
+    val timeLabels = remember(positions) {
+        if (hasCharts) extractTimeLabels(positions!!, is24Hour) else emptyList()
+    }
+    val fractionToTimeLabel: (Float) -> String = remember(positions) {
+        label@{ fraction: Float ->
+            val pos = positions
+            if (pos == null || pos.size <= 2) return@label ""
+            val index = (fraction * pos.lastIndex).roundToInt().coerceIn(0, pos.lastIndex)
+            pos[index].date?.let { dateStr ->
+                parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
+            } ?: ""
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -186,10 +209,55 @@ private fun DriveDetailContent(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Route header card
-        RouteHeaderCard(detail = detail)
+        // Hero: route, dominant distance, key figures, footer
+        DriveHeroSection(detail = detail, stats = stats, units = units, palette = palette, is24Hour = is24Hour)
 
-        // Part-of-trip banner: link to the containing saved trip + detach action
+        // Accent stat tiles — efficiency and its main confounders
+        stats?.let { s -> DriveStatTiles(stats = s, units = units, palette = palette) }
+
+        // Primary chart: speed profile, accent-tinted
+        if (hasCharts && positions!!.any { it.speed != null }) {
+            SpeedChartCard(
+                positions = positions,
+                units = units,
+                color = palette.accent,
+                timeLabels = timeLabels,
+                externalSelectedFraction = sharedXFraction,
+                onXSelected = { sharedXFraction = it },
+                fractionToTimeLabel = fractionToTimeLabel
+            )
+        }
+
+        // Route map
+        if (!detail.positions.isNullOrEmpty()) {
+            DriveMapCard(positions = detail.positions, routeColor = palette.accent)
+        }
+
+        // Weather along the way
+        if (isLoadingWeather || weatherPoints.isNotEmpty()) {
+            WeatherAlongTheWayCard(
+                weatherPoints = weatherPoints,
+                units = units,
+                isLoading = isLoadingWeather
+            )
+        }
+
+        // Everything else behind a tap
+        stats?.let { s ->
+            DriveMoreDetails(
+                detail = detail,
+                stats = s,
+                units = units,
+                palette = palette,
+                positions = if (hasCharts) positions else null,
+                timeLabels = timeLabels,
+                sharedXFraction = sharedXFraction,
+                onXSelected = { sharedXFraction = it },
+                fractionToTimeLabel = fractionToTimeLabel
+            )
+        }
+
+        // Part-of-trip banner — kept at the very end
         if (containingTrip != null) {
             val (_, trip) = containingTrip
             com.matedroid.ui.components.PartOfTripCard(
@@ -199,265 +267,345 @@ private fun DriveDetailContent(
             )
         }
 
-        // Map showing the route
-        if (!detail.positions.isNullOrEmpty()) {
-            DriveMapCard(positions = detail.positions, routeColor = routeColor)
-        }
-
-        // Stats grid
-        stats?.let { s ->
-            // Speed section
-            StatsSectionCard(
-                title = stringResource(R.string.speed),
-                icon = Icons.Default.Speed,
-                stats = listOf(
-                    StatItem(stringResource(R.string.maximum), UnitFormatter.formatSpeed(s.speedMax.toDouble(), units)),
-                    StatItem(stringResource(R.string.average), UnitFormatter.formatSpeed(s.speedAvg, units)),
-                    StatItem(stringResource(R.string.avg_distance), UnitFormatter.formatSpeed(s.avgSpeedFromDistance, units))
-                )
-            )
-
-            // Distance & Duration section
-            StatsSectionCard(
-                title = stringResource(R.string.trip),
-                icon = CustomIcons.SteeringWheel,
-                stats = listOf(
-                    StatItem(stringResource(R.string.distance), UnitFormatter.formatDistance(s.distance, units)),
-                    StatItem(stringResource(R.string.duration), formatDurationCompact(s.durationMin)),
-                    StatItem(stringResource(R.string.efficiency), UnitFormatter.formatEfficiency(s.efficiency, units))
-                )
-            )
-
-            // Battery section
-            StatsSectionCard(
-                title = stringResource(R.string.battery),
-                icon = Icons.Default.BatteryChargingFull,
-                stats = listOf(
-                    StatItem(stringResource(R.string.start), "${s.batteryStart}%"),
-                    StatItem(stringResource(R.string.end), "${s.batteryEnd}%"),
-                    StatItem(stringResource(R.string.used), "${s.batteryUsed}%"),
-                    StatItem(stringResource(R.string.energy), "%.2f kWh".format(s.energyUsed))
-                )
-            )
-
-            // Power section
-            StatsSectionCard(
-                title = stringResource(R.string.power),
-                icon = Icons.Default.Bolt,
-                stats = listOf(
-                    StatItem(stringResource(R.string.max_accel), "${s.powerMax} kW"),
-                    StatItem(stringResource(R.string.min_regen), "${s.powerMin} kW"),
-                    StatItem(stringResource(R.string.average), "%.1f kW".format(s.powerAvg))
-                )
-            )
-
-            // Elevation section
-            if (s.elevationMax > 0 || s.elevationMin > 0) {
-                StatsSectionCard(
-                    title = stringResource(R.string.elevation),
-                    icon = Icons.Default.Landscape,
-                    stats = listOf(
-                        StatItem(stringResource(R.string.maximum), "%,d m".format(s.elevationMax)),
-                        StatItem(stringResource(R.string.minimum), "%,d m".format(s.elevationMin)),
-                        StatItem(stringResource(R.string.gain), "+%,d m".format(s.elevationGain)),
-                        StatItem(stringResource(R.string.loss), "-%,d m".format(s.elevationLoss))
-                    )
-                )
-            }
-
-            // Temperature section
-            if (s.outsideTempAvg != null || s.insideTempAvg != null) {
-                StatsSectionCard(
-                    title = stringResource(R.string.temperature),
-                    icon = Icons.Default.DeviceThermostat,
-                    stats = listOfNotNull(
-                        s.outsideTempAvg?.let { StatItem(stringResource(R.string.outside), UnitFormatter.formatTemperature(it, units)) },
-                        s.insideTempAvg?.let { StatItem(stringResource(R.string.inside), UnitFormatter.formatTemperature(it, units)) }
-                    )
-                )
-            }
-
-            // Charts
-            if (!detail.positions.isNullOrEmpty() && detail.positions.size > 2) {
-                val positions = detail.positions
-                // Remember expensive computations so they don't re-run on every
-                // recomposition during tooltip swipe interactions
-                val timeLabels = remember(positions) { extractTimeLabels(positions, is24Hour) }
-                val fractionToTimeLabel: (Float) -> String = remember(positions) {
-                    { fraction: Float ->
-                        val index = (fraction * positions.lastIndex).roundToInt().coerceIn(0, positions.lastIndex)
-                        positions[index].date?.let { dateStr ->
-                            parseIsoDateTime(dateStr)?.formatTime(java.util.Locale.getDefault(), is24Hour) ?: ""
-                        } ?: ""
-                    }
-                }
-
-                SpeedChartCard(
-                    positions = detail.positions,
-                    units = units,
-                    timeLabels = timeLabels,
-                    externalSelectedFraction = sharedXFraction,
-                    onXSelected = { sharedXFraction = it },
-                    fractionToTimeLabel = fractionToTimeLabel
-                )
-                PowerChartCard(
-                    positions = detail.positions,
-                    timeLabels = timeLabels,
-                    externalSelectedFraction = sharedXFraction,
-                    onXSelected = { sharedXFraction = it },
-                    fractionToTimeLabel = fractionToTimeLabel
-                )
-                BatteryChartCard(
-                    positions = detail.positions,
-                    timeLabels = timeLabels,
-                    externalSelectedFraction = sharedXFraction,
-                    onXSelected = { sharedXFraction = it },
-                    fractionToTimeLabel = fractionToTimeLabel
-                )
-                if (detail.positions.any { it.elevation != null && it.elevation != 0 }) {
-                    ElevationChartCard(
-                        positions = detail.positions,
-                        timeLabels = timeLabels,
-                        externalSelectedFraction = sharedXFraction,
-                        onXSelected = { sharedXFraction = it },
-                        fractionToTimeLabel = fractionToTimeLabel
-                    )
-                }
-            }
-        }
-
-        // Weather along the way - shown when loading or has data
-        if (isLoadingWeather || weatherPoints.isNotEmpty()) {
-            WeatherAlongTheWayCard(
-                weatherPoints = weatherPoints,
-                units = units,
-                isLoading = isLoadingWeather
-            )
-        }
-
         Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
+/**
+ * Compact hero: route (from → to), the dominant figure (distance) in the car's accent colour, a
+ * balanced row of labelled key figures (avg speed, battery swing, duration), and a footer with the
+ * start time and energy used. Replaces the old verbose header.
+ */
 @Composable
-private fun RouteHeaderCard(detail: DriveDetail) {
-    val is24Hour = android.text.format.DateFormat.is24HourFormat(LocalContext.current)
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            // Start location
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = stringResource(R.string.from),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = detail.startAddress ?: stringResource(R.string.unknown_location),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-            }
+private fun DriveHeroSection(
+    detail: DriveDetail,
+    stats: DriveDetailStats?,
+    units: Units?,
+    palette: CarColorPalette,
+    is24Hour: Boolean
+) {
+    val unknownLocation = stringResource(R.string.unknown_location)
+    val avgLabel = stringResource(R.string.average)
+    val batteryLabel = stringResource(R.string.battery)
+    val durationLabel = stringResource(R.string.duration)
+    val energyLabel = stringResource(R.string.energy)
 
-            HorizontalDivider(
-                modifier = Modifier.padding(start = 36.dp),
-                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f)
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Route
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RouteLine(
+                color = palette.accent,
+                label = stringResource(R.string.from),
+                value = detail.startAddress ?: unknownLocation
+            )
+            RouteLine(
+                color = MaterialTheme.colorScheme.tertiary,
+                label = stringResource(R.string.to),
+                value = detail.endAddress ?: unknownLocation
+            )
+        }
+
+        // Dominant figure: distance
+        stats?.let { s ->
+            Text(
+                text = UnitFormatter.formatDistance(s.distance, units),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = palette.accent
             )
 
-            // End location
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.tertiary
+            // Balanced row of labelled key figures
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                HeroStat(
+                    label = avgLabel,
+                    value = UnitFormatter.formatSpeed(s.speedAvg, units),
+                    modifier = Modifier.weight(1f)
                 )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = stringResource(R.string.to),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = detail.endAddress ?: stringResource(R.string.unknown_location),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
+                HeroStat(
+                    label = batteryLabel,
+                    value = "${s.batteryStart}% → ${s.batteryEnd}%",
+                    modifier = Modifier.weight(1f)
+                )
+                HeroStat(
+                    label = durationLabel,
+                    value = formatDurationCompact(s.durationMin),
+                    modifier = Modifier.weight(1f)
+                )
             }
 
-            HorizontalDivider(
-                modifier = Modifier.padding(start = 36.dp),
-                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f)
-            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-            // Start time
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Schedule,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = stringResource(R.string.started),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+            // Footer: start time and energy used
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Schedule,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    Spacer(modifier = Modifier.width(5.dp))
                     Text(
                         text = formatDateTime(detail.startDate, is24Hour),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-            }
-
-            // End time
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Schedule,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                Text(
+                    text = "$energyLabel · %.1f kWh".format(s.energyUsed),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
-                    Text(
-                        text = stringResource(R.string.ended),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RouteLine(color: Color, label: String, value: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = Icons.Default.LocationOn,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = color
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = "$label  ",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1
+        )
+    }
+}
+
+/** A single labelled figure: small uppercase label over a bold value. */
+@Composable
+private fun HeroStat(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(
+            text = label.uppercase(java.util.Locale.getDefault()),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1
+        )
+    }
+}
+
+/** A row of accent tiles for efficiency and its main confounders (temperature, elevation gain). */
+@Composable
+private fun DriveStatTiles(
+    stats: DriveDetailStats,
+    units: Units?,
+    palette: CarColorPalette
+) {
+    val efficiencyLabel = stringResource(R.string.efficiency)
+    val temperatureLabel = stringResource(R.string.temperature)
+    val gainLabel = stringResource(R.string.gain)
+
+    val tiles = buildList {
+        add(efficiencyLabel to UnitFormatter.formatEfficiency(stats.efficiency, units))
+        stats.outsideTempAvg?.let { add(temperatureLabel to UnitFormatter.formatTemperature(it, units)) }
+        if (stats.elevationGain > 0) add(gainLabel to "+%,d m".format(stats.elevationGain))
+    }
+    if (tiles.isEmpty()) return
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        tiles.forEach { (label, value) ->
+            DriveStatTile(label = label, value = value, accent = palette.accent, modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun DriveStatTile(
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(accent.copy(alpha = 0.12f))
+            .padding(vertical = 12.dp, horizontal = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = label.uppercase(java.util.Locale.getDefault()),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1
+        )
+    }
+}
+
+/** Collapsible section holding the detailed stat cards and the secondary charts. */
+@Composable
+private fun DriveMoreDetails(
+    detail: DriveDetail,
+    stats: DriveDetailStats,
+    units: Units?,
+    palette: CarColorPalette,
+    positions: List<DrivePosition>?,
+    timeLabels: List<String>,
+    sharedXFraction: Float?,
+    onXSelected: (Float?) -> Unit,
+    fractionToTimeLabel: (Float) -> String
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "driveMoreDetailsChevron")
+
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { expanded = !expanded }
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(if (expanded) R.string.hide_details else R.string.more_details),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = palette.accent
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = palette.accent,
+                modifier = Modifier
+                    .size(22.dp)
+                    .rotate(rotation)
+            )
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                StatsSectionCard(
+                    title = stringResource(R.string.speed),
+                    icon = Icons.Default.Speed,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.maximum), UnitFormatter.formatSpeed(stats.speedMax.toDouble(), units)),
+                        StatItem(stringResource(R.string.average), UnitFormatter.formatSpeed(stats.speedAvg, units)),
+                        StatItem(stringResource(R.string.avg_distance), UnitFormatter.formatSpeed(stats.avgSpeedFromDistance, units))
                     )
-                    Text(
-                        text = formatDateTime(detail.endDate, is24Hour),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                StatsSectionCard(
+                    title = stringResource(R.string.trip),
+                    icon = CustomIcons.SteeringWheel,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.distance), UnitFormatter.formatDistance(stats.distance, units)),
+                        StatItem(stringResource(R.string.duration), formatDurationCompact(stats.durationMin)),
+                        StatItem(stringResource(R.string.efficiency), UnitFormatter.formatEfficiency(stats.efficiency, units))
                     )
-                    detail.durationStr?.let { duration ->
-                        Text(
-                            text = stringResource(R.string.duration_label, duration),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                )
+                StatsSectionCard(
+                    title = stringResource(R.string.battery),
+                    icon = Icons.Default.BatteryChargingFull,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.start), "${stats.batteryStart}%"),
+                        StatItem(stringResource(R.string.end), "${stats.batteryEnd}%"),
+                        StatItem(stringResource(R.string.used), "${stats.batteryUsed}%"),
+                        StatItem(stringResource(R.string.energy), "%.2f kWh".format(stats.energyUsed))
+                    )
+                )
+                StatsSectionCard(
+                    title = stringResource(R.string.power),
+                    icon = Icons.Default.Bolt,
+                    stats = listOf(
+                        StatItem(stringResource(R.string.max_accel), "${stats.powerMax} kW"),
+                        StatItem(stringResource(R.string.min_regen), "${stats.powerMin} kW"),
+                        StatItem(stringResource(R.string.average), "%.1f kW".format(stats.powerAvg))
+                    )
+                )
+                if (stats.elevationMax > 0 || stats.elevationMin > 0) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.elevation),
+                        icon = Icons.Default.Landscape,
+                        stats = listOf(
+                            StatItem(stringResource(R.string.maximum), "%,d m".format(stats.elevationMax)),
+                            StatItem(stringResource(R.string.minimum), "%,d m".format(stats.elevationMin)),
+                            StatItem(stringResource(R.string.gain), "+%,d m".format(stats.elevationGain)),
+                            StatItem(stringResource(R.string.loss), "-%,d m".format(stats.elevationLoss))
+                        )
+                    )
+                }
+                if (stats.outsideTempAvg != null || stats.insideTempAvg != null) {
+                    StatsSectionCard(
+                        title = stringResource(R.string.temperature),
+                        icon = Icons.Default.DeviceThermostat,
+                        stats = listOfNotNull(
+                            stats.outsideTempAvg?.let { StatItem(stringResource(R.string.outside), UnitFormatter.formatTemperature(it, units)) },
+                            stats.insideTempAvg?.let { StatItem(stringResource(R.string.inside), UnitFormatter.formatTemperature(it, units)) }
+                        )
+                    )
+                }
+
+                // Secondary charts
+                if (positions != null) {
+                    PowerChartCard(
+                        positions = positions,
+                        timeLabels = timeLabels,
+                        externalSelectedFraction = sharedXFraction,
+                        onXSelected = onXSelected,
+                        fractionToTimeLabel = fractionToTimeLabel
+                    )
+                    BatteryChartCard(
+                        positions = positions,
+                        timeLabels = timeLabels,
+                        externalSelectedFraction = sharedXFraction,
+                        onXSelected = onXSelected,
+                        fractionToTimeLabel = fractionToTimeLabel
+                    )
+                    if (positions.any { it.elevation != null && it.elevation != 0 }) {
+                        ElevationChartCard(
+                            positions = positions,
+                            timeLabels = timeLabels,
+                            externalSelectedFraction = sharedXFraction,
+                            onXSelected = onXSelected,
+                            fractionToTimeLabel = fractionToTimeLabel
                         )
                     }
                 }
@@ -520,9 +668,6 @@ private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
                         MapView(ctx).apply {
                             setTileSource(TileSourceFactory.MAPNIK)
                             setMultiTouchControls(true)
-                            // Tell the parent vertical scroll to stop intercepting
-                            // touches so single-finger drag pans the map instead
-                            // of scrolling the page.
                             setOnTouchListener { v, event ->
                                 when (event.actionMasked) {
                                     MotionEvent.ACTION_DOWN,
@@ -536,7 +681,6 @@ private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
                                 false
                             }
 
-                            // Create polyline for the route
                             val geoPoints = validPositions.map { pos ->
                                 GeoPoint(pos.latitude!!, pos.longitude!!)
                             }
@@ -550,14 +694,12 @@ private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
                             }
                             overlays.add(polyline)
 
-                            // Calculate bounding box with padding
                             if (geoPoints.isNotEmpty()) {
                                 val north = geoPoints.maxOf { it.latitude }
                                 val south = geoPoints.minOf { it.latitude }
                                 val east = geoPoints.maxOf { it.longitude }
                                 val west = geoPoints.minOf { it.longitude }
 
-                                // Add some padding
                                 val latPadding = (north - south) * 0.15
                                 val lonPadding = (east - west) * 0.15
 
@@ -590,15 +732,13 @@ private fun StatsSectionCard(
     icon: ImageVector,
     stats: List<StatItem>
 ) {
-    // Get the current screen settings
     val configuration = LocalConfiguration.current
     val screenWidth = configuration.screenWidthDp
 
-    // Define how many columns we want according to the available screen width
     val columnCount = when {
-        screenWidth > 600 -> 4 // Big screen or landscape orientation
-        screenWidth > 340 -> 3 // Standard screen
-        else -> 2              // Small screen
+        screenWidth > 600 -> 4
+        screenWidth > 340 -> 3
+        else -> 2
     }
 
     Card(
@@ -628,7 +768,6 @@ private fun StatsSectionCard(
                 )
             }
 
-            // Divide the list of statistics according to the calculated number of columns
             val chunked = stats.chunked(columnCount)
             chunked.forEachIndexed { index, row ->
                 Row(
@@ -643,8 +782,6 @@ private fun StatsSectionCard(
                         )
                     }
 
-                    // Fill the leftover space if the last row is not complete.
-                    // This prevents a single item from stretching too much
                     val emptySlots = columnCount - row.size
                     if (emptySlots > 0) {
                         repeat(emptySlots) {
@@ -684,6 +821,7 @@ private fun StatItemView(
 private fun SpeedChartCard(
     positions: List<DrivePosition>,
     units: Units?,
+    color: Color,
     timeLabels: List<String>,
     externalSelectedFraction: Float? = null,
     onXSelected: ((Float?) -> Unit)? = null,
@@ -701,7 +839,7 @@ private fun SpeedChartCard(
         title = stringResource(R.string.speed_profile),
         icon = Icons.Default.Speed,
         data = speeds,
-        color = MaterialTheme.colorScheme.primary,
+        color = color,
         unit = UnitFormatter.getSpeedUnit(units),
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
@@ -782,7 +920,7 @@ private fun ElevationChartCard(
         title = stringResource(R.string.elevation_profile),
         icon = Icons.Default.Landscape,
         data = elevations,
-        color = Color(0xFF8B4513), // Brown color for terrain
+        color = Color(0xFF8B4513),
         unit = "m",
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
@@ -853,7 +991,6 @@ private fun ChartCard(
 /**
  * Extract 5 time labels from drive positions for X axis display.
  * Returns list of 5 time strings at 0%, 25%, 50%, 75%, and 100% positions.
- * Following the chart guidelines: start, 1st quarter, half, 3rd quarter, end.
  */
 private fun extractTimeLabels(positions: List<DrivePosition>, is24Hour: Boolean? = null): List<String> {
     if (positions.isEmpty()) return listOf("", "", "", "", "")
@@ -865,7 +1002,6 @@ private fun extractTimeLabels(positions: List<DrivePosition>, is24Hour: Boolean?
 
     if (times.isEmpty()) return listOf("", "", "", "", "")
 
-    // 5 positions: start (0%), 1st quarter (25%), half (50%), 3rd quarter (75%), end (100%)
     val indices = listOf(0, times.size / 4, times.size / 2, times.size * 3 / 4, times.size - 1)
     return indices.map { idx ->
         times.getOrNull(idx.coerceIn(0, times.size - 1))?.formatTime(locale, is24Hour) ?: ""

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
@@ -9,6 +9,8 @@ import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.data.repository.WeatherPoint
 import com.matedroid.data.repository.WeatherRepository
+import com.matedroid.domain.DriveComparison
+import com.matedroid.domain.DriveComparisonRepository
 import com.matedroid.domain.LegRef
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
@@ -28,7 +30,8 @@ data class DriveDetailUiState(
     val stats: DriveDetailStats? = null,
     val weatherPoints: List<WeatherPoint> = emptyList(),
     val isLoadingWeather: Boolean = false,
-    val containingTrip: Pair<Long, Trip>? = null
+    val containingTrip: Pair<Long, Trip>? = null,
+    val comparison: DriveComparison? = null
 )
 
 data class DriveDetailStats(
@@ -58,7 +61,8 @@ data class DriveDetailStats(
 class DriveDetailViewModel @Inject constructor(
     private val repository: TeslamateRepository,
     private val weatherRepository: WeatherRepository,
-    private val tripRepository: TripRepository
+    private val tripRepository: TripRepository,
+    private val driveComparisonRepository: DriveComparisonRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DriveDetailUiState())
@@ -78,6 +82,11 @@ class DriveDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val containing = tripRepository.findTripContaining(carId, SavedTripLeg.TYPE_DRIVE, driveId)
             _uiState.update { it.copy(containingTrip = containing) }
+        }
+
+        viewModelScope.launch {
+            val comparison = driveComparisonRepository.findComparable(carId, driveId)
+            _uiState.update { it.copy(comparison = comparison) }
         }
 
         viewModelScope.launch {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1241,6 +1241,15 @@
     <string name="compare_this_charge">Aquesta càrrega</string>
     <string name="compare_empty">No hi ha càrregues ràpides comparables a prop</string>
     <string name="compare_power_vs_soc">Potència vs SoC</string>
+    <string name="compare_drives_title">Compara trajectes</string>
+    <string name="compare_this_drive">Aquest trajecte</string>
+    <string name="compare_drives_scope">%1$d trajectes · mateixa ruta</string>
+    <string name="compare_drives_empty">No hi ha trajectes comparables en aquesta ruta</string>
+    <string name="compare_speed_vs_distance">Velocitat vs distància</string>
+    <plurals name="compare_drives_nearby">
+        <item quantity="one">%d trajecte comparable</item>
+        <item quantity="other">%d trajectes comparables</item>
+    </plurals>
     <string name="compare_scope">%1$d càrregues · en %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d càrrega comparable a prop</item>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1246,6 +1246,7 @@
     <string name="compare_drives_scope">%1$d trajectes · mateixa ruta</string>
     <string name="compare_drives_empty">No hi ha trajectes comparables en aquesta ruta</string>
     <string name="compare_speed_vs_distance">Velocitat vs distància</string>
+    <string name="compare_consumption_vs_distance">Consum vs distància</string>
     <string name="compare_average">Mitjana</string>
     <plurals name="compare_more">
         <item quantity="one">+%d més</item>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1246,6 +1246,11 @@
     <string name="compare_drives_scope">%1$d trajectes · mateixa ruta</string>
     <string name="compare_drives_empty">No hi ha trajectes comparables en aquesta ruta</string>
     <string name="compare_speed_vs_distance">Velocitat vs distància</string>
+    <string name="compare_average">Mitjana</string>
+    <plurals name="compare_more">
+        <item quantity="one">+%d més</item>
+        <item quantity="other">+%d més</item>
+    </plurals>
     <plurals name="compare_drives_nearby">
         <item quantity="one">%d trajecte comparable</item>
         <item quantity="other">%d trajectes comparables</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1361,6 +1361,7 @@
     <string name="compare_drives_scope">%1$d Fahrten · gleiche Strecke</string>
     <string name="compare_drives_empty">Keine vergleichbaren Fahrten auf dieser Strecke</string>
     <string name="compare_speed_vs_distance">Geschwindigkeit vs. Distanz</string>
+    <string name="compare_consumption_vs_distance">Verbrauch vs. Distanz</string>
     <string name="compare_average">Durchschnitt</string>
     <plurals name="compare_more">
         <item quantity="one">+%d weitere</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1356,6 +1356,15 @@
     <string name="compare_this_charge">Diese Ladung</string>
     <string name="compare_empty">Keine vergleichbaren Schnellladungen in der Nähe</string>
     <string name="compare_power_vs_soc">Leistung vs. SoC</string>
+    <string name="compare_drives_title">Fahrten vergleichen</string>
+    <string name="compare_this_drive">Diese Fahrt</string>
+    <string name="compare_drives_scope">%1$d Fahrten · gleiche Strecke</string>
+    <string name="compare_drives_empty">Keine vergleichbaren Fahrten auf dieser Strecke</string>
+    <string name="compare_speed_vs_distance">Geschwindigkeit vs. Distanz</string>
+    <plurals name="compare_drives_nearby">
+        <item quantity="one">%d vergleichbare Fahrt</item>
+        <item quantity="other">%d vergleichbare Fahrten</item>
+    </plurals>
     <string name="compare_scope">%1$d Ladungen · im Umkreis von %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d vergleichbare Ladung in der Nähe</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1361,6 +1361,11 @@
     <string name="compare_drives_scope">%1$d Fahrten · gleiche Strecke</string>
     <string name="compare_drives_empty">Keine vergleichbaren Fahrten auf dieser Strecke</string>
     <string name="compare_speed_vs_distance">Geschwindigkeit vs. Distanz</string>
+    <string name="compare_average">Durchschnitt</string>
+    <plurals name="compare_more">
+        <item quantity="one">+%d weitere</item>
+        <item quantity="other">+%d weitere</item>
+    </plurals>
     <plurals name="compare_drives_nearby">
         <item quantity="one">%d vergleichbare Fahrt</item>
         <item quantity="other">%d vergleichbare Fahrten</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1246,6 +1246,7 @@
     <string name="compare_drives_scope">%1$d trayectos · misma ruta</string>
     <string name="compare_drives_empty">No hay trayectos comparables en esta ruta</string>
     <string name="compare_speed_vs_distance">Velocidad vs distancia</string>
+    <string name="compare_consumption_vs_distance">Consumo vs distancia</string>
     <string name="compare_average">Media</string>
     <plurals name="compare_more">
         <item quantity="one">+%d más</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1241,6 +1241,15 @@
     <string name="compare_this_charge">Esta carga</string>
     <string name="compare_empty">No hay cargas rápidas comparables cerca</string>
     <string name="compare_power_vs_soc">Potencia vs SoC</string>
+    <string name="compare_drives_title">Comparar trayectos</string>
+    <string name="compare_this_drive">Este trayecto</string>
+    <string name="compare_drives_scope">%1$d trayectos · misma ruta</string>
+    <string name="compare_drives_empty">No hay trayectos comparables en esta ruta</string>
+    <string name="compare_speed_vs_distance">Velocidad vs distancia</string>
+    <plurals name="compare_drives_nearby">
+        <item quantity="one">%d trayecto comparable</item>
+        <item quantity="other">%d trayectos comparables</item>
+    </plurals>
     <string name="compare_scope">%1$d cargas · en %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d carga comparable cerca</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1246,6 +1246,11 @@
     <string name="compare_drives_scope">%1$d trayectos · misma ruta</string>
     <string name="compare_drives_empty">No hay trayectos comparables en esta ruta</string>
     <string name="compare_speed_vs_distance">Velocidad vs distancia</string>
+    <string name="compare_average">Media</string>
+    <plurals name="compare_more">
+        <item quantity="one">+%d más</item>
+        <item quantity="other">+%d más</item>
+    </plurals>
     <plurals name="compare_drives_nearby">
         <item quantity="one">%d trayecto comparable</item>
         <item quantity="other">%d trayectos comparables</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1246,6 +1246,11 @@
     <string name="compare_drives_scope">%1$d tragitti · stesso percorso</string>
     <string name="compare_drives_empty">Nessun tragitto confrontabile su questo percorso</string>
     <string name="compare_speed_vs_distance">Velocità vs distanza</string>
+    <string name="compare_average">Media</string>
+    <plurals name="compare_more">
+        <item quantity="one">+%d altro</item>
+        <item quantity="other">+%d altri</item>
+    </plurals>
     <plurals name="compare_drives_nearby">
         <item quantity="one">%d tragitto confrontabile</item>
         <item quantity="other">%d tragitti confrontabili</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1241,6 +1241,15 @@
     <string name="compare_this_charge">Questa ricarica</string>
     <string name="compare_empty">Nessuna ricarica rapida confrontabile nelle vicinanze</string>
     <string name="compare_power_vs_soc">Potenza vs SoC</string>
+    <string name="compare_drives_title">Confronta i tragitti</string>
+    <string name="compare_this_drive">Questo tragitto</string>
+    <string name="compare_drives_scope">%1$d tragitti · stesso percorso</string>
+    <string name="compare_drives_empty">Nessun tragitto confrontabile su questo percorso</string>
+    <string name="compare_speed_vs_distance">Velocità vs distanza</string>
+    <plurals name="compare_drives_nearby">
+        <item quantity="one">%d tragitto confrontabile</item>
+        <item quantity="other">%d tragitti confrontabili</item>
+    </plurals>
     <string name="compare_scope">%1$d ricariche · entro %2$d km</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="one">%d ricarica confrontabile nelle vicinanze</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1246,6 +1246,7 @@
     <string name="compare_drives_scope">%1$d tragitti · stesso percorso</string>
     <string name="compare_drives_empty">Nessun tragitto confrontabile su questo percorso</string>
     <string name="compare_speed_vs_distance">Velocità vs distanza</string>
+    <string name="compare_consumption_vs_distance">Consumo vs distanza</string>
     <string name="compare_average">Media</string>
     <plurals name="compare_more">
         <item quantity="one">+%d altro</item>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1271,6 +1271,7 @@
     <string name="compare_drives_scope">%1$d 段行程 · 相同路线</string>
     <string name="compare_drives_empty">此路线没有可比的行程</string>
     <string name="compare_speed_vs_distance">速度 vs 距离</string>
+    <string name="compare_consumption_vs_distance">消耗 vs 距离</string>
     <string name="compare_average">平均</string>
     <plurals name="compare_more">
         <item quantity="other">其余 %d 个</item>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1271,6 +1271,10 @@
     <string name="compare_drives_scope">%1$d 段行程 · 相同路线</string>
     <string name="compare_drives_empty">此路线没有可比的行程</string>
     <string name="compare_speed_vs_distance">速度 vs 距离</string>
+    <string name="compare_average">平均</string>
+    <plurals name="compare_more">
+        <item quantity="other">其余 %d 个</item>
+    </plurals>
     <plurals name="compare_drives_nearby">
         <item quantity="other">%d 段可比行程</item>
     </plurals>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1266,6 +1266,14 @@
     <string name="compare_this_charge">本次充电</string>
     <string name="compare_empty">附近没有可比的快充</string>
     <string name="compare_power_vs_soc">功率 vs 电量</string>
+    <string name="compare_drives_title">比较行程</string>
+    <string name="compare_this_drive">本次行程</string>
+    <string name="compare_drives_scope">%1$d 段行程 · 相同路线</string>
+    <string name="compare_drives_empty">此路线没有可比的行程</string>
+    <string name="compare_speed_vs_distance">速度 vs 距离</string>
+    <plurals name="compare_drives_nearby">
+        <item quantity="other">%d 段可比行程</item>
+    </plurals>
     <string name="compare_scope">%1$d 次充电 · %2$d 公里内</string>
     <plurals name="compare_sessions_nearby">
         <item quantity="other">附近 %d 次可比充电</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1374,6 +1374,13 @@
     <string name="compare_drives_scope">%1$d drives · same route</string>
     <string name="compare_drives_empty">No comparable drives on this route</string>
     <string name="compare_speed_vs_distance">Speed vs distance</string>
+    <!-- Leaderboard: the averaged reference row -->
+    <string name="compare_average">Average</string>
+    <!-- Leaderboard: tappable row to reveal the hidden drives. %d = how many are hidden -->
+    <plurals name="compare_more">
+        <item quantity="one">+%d more</item>
+        <item quantity="other">+%d more</item>
+    </plurals>
     <!-- %d = number of comparable drives on this route -->
     <plurals name="compare_drives_nearby">
         <item quantity="one">%d comparable drive</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1374,6 +1374,7 @@
     <string name="compare_drives_scope">%1$d drives · same route</string>
     <string name="compare_drives_empty">No comparable drives on this route</string>
     <string name="compare_speed_vs_distance">Speed vs distance</string>
+    <string name="compare_consumption_vs_distance">Consumption vs distance</string>
     <!-- Leaderboard: the averaged reference row -->
     <string name="compare_average">Average</string>
     <!-- Leaderboard: tappable row to reveal the hidden drives. %d = how many are hidden -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1367,6 +1367,18 @@
     <string name="compare_empty">No comparable DC charges nearby</string>
     <!-- Chart title: charging power against state of charge -->
     <string name="compare_power_vs_soc">Power vs SoC</string>
+    <!-- Drive comparison feature -->
+    <string name="compare_drives_title">Compare drives</string>
+    <string name="compare_this_drive">This drive</string>
+    <!-- %1$d = number of drives -->
+    <string name="compare_drives_scope">%1$d drives · same route</string>
+    <string name="compare_drives_empty">No comparable drives on this route</string>
+    <string name="compare_speed_vs_distance">Speed vs distance</string>
+    <!-- %d = number of comparable drives on this route -->
+    <plurals name="compare_drives_nearby">
+        <item quantity="one">%d comparable drive</item>
+        <item quantity="other">%d comparable drives</item>
+    </plurals>
     <!-- %1$d = number of charges, %2$d = radius in km -->
     <string name="compare_scope">%1$d charges · within %2$d km</string>
     <!-- %d = number of comparable charges near this one -->


### PR DESCRIPTION
Mirrors the charge work (#319) for drives. **Stacked on `feat/charge-detail-redesign`** — review/merge #319 first; GitHub will retarget this to `main` once it merges.

### 1. Drive detail screen redesign
- Compact **hero**: route (from → to), distance in the car's accent colour, labelled avg-speed / battery-swing / duration columns, and a start-time + energy-used footer.
- A row of **accent tiles** (efficiency + its main confounders: temperature and elevation gain).
- The **speed profile** is the primary chart; the route map and weather-along-the-way stay visible.
- Detailed stat sections (speed, trip, battery, power, elevation, temperature) and the secondary charts move behind a **"More details"** toggle. Part-of-trip banner moved to the end.

### 2. Compare drives (same route)
- A **"Compare drives"** entry card on the drive detail screen, shown only when there are comparable runs.
- A **Compare screen** with:
  - a **speed-vs-distance overlay chart** — your run bold, up to 4 others (top by the selected dimension), tap/drag crosshair + per-run tooltip;
  - a re-sortable **leaderboard** (efficiency / duration / speed) with date, avg speed and temp per row, your run highlighted.
- Matching = **same start + same end** (within ~250 m) and a similar total distance (±25%), from the local cache (summaries + aggregates). Curves fetched lazily and cached.

## Notes
- The overlay chart component is generalised with configurable axis units; the charge power-vs-SoC behaviour is the default, so #319 is unaffected.
- New strings localised in all 6 locales (incl. a plural). `compileDebugKotlin` green; lint running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)