### PR TITLE
fix: infer DC/AC by power for unsynced charges (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Time spent driving and charging now headline the trip timeline** as bold accent stat tiles, with the overall total as a quiet caption beneath.
 
 ### Fixed
+- **Recent DC charges no longer show as AC in the charges list** — until a charge's details are synced, its type is now inferred from average power instead of defaulting to AC, so a fast charge isn't mislabeled while it waits to be processed (#313).
 - **Drives and charges in a merged-and-renamed trip now show the trip's current name** on their detail screen, instead of the original auto-generated "city → city" name.
 - **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), short legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeStatsCalculator.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeStatsCalculator.kt
@@ -77,4 +77,34 @@ object ChargeStatsCalculator {
         val modePhases = phases.filter { it > 0 }.groupingBy { it }.eachCount().maxByOrNull { it.value }?.key
         return modePhases == null
     }
+
+    /**
+     * Average charging power (kW) above which an as-yet-unanalyzed charge is assumed to be DC.
+     * AC tops out around 11 kW (22 kW on three phases); DC fast charging sustains far more, so a
+     * threshold in between cleanly separates the two for the list heuristic.
+     */
+    const val DC_AVG_POWER_THRESHOLD_KW = 20.0
+
+    /**
+     * Best-effort DC/AC classification for the charges list.
+     *
+     * When the charge's detail has already been processed into an aggregate, return the exact
+     * stored result. Otherwise (the detail hasn't been synced yet) fall back to an average-power
+     * heuristic — energy added over duration — so recent DC charges aren't mislabeled as AC while
+     * waiting for the background sync. The value self-corrects to exact once the charge is processed.
+     */
+    fun isDcCharge(
+        chargeId: Int,
+        energyAddedKwh: Double?,
+        durationMin: Int?,
+        dcChargeIds: Set<Int>,
+        processedChargeIds: Set<Int>
+    ): Boolean {
+        if (chargeId in processedChargeIds) return chargeId in dcChargeIds
+        val minutes = durationMin ?: return false
+        val energy = energyAddedKwh ?: return false
+        if (minutes <= 0) return false
+        val avgPowerKw = energy / (minutes / 60.0)
+        return avgPowerKw > DC_AVG_POWER_THRESHOLD_KW
+    }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -146,6 +146,7 @@ fun ChargesScreen(
                 ChargesContent(
                     charges = uiState.charges,
                     dcChargeIds = uiState.dcChargeIds,
+                    processedChargeIds = uiState.processedChargeIds,
                     chartData = uiState.chartData,
                     chartGranularity = uiState.chartGranularity,
                     summary = uiState.summary,
@@ -184,6 +185,7 @@ fun ChargesScreen(
 private fun ChargesContent(
     charges: List<ChargeData>,
     dcChargeIds: Set<Int>,
+    processedChargeIds: Set<Int>,
     chartData: List<ChargeChartData>,
     chartGranularity: ChartGranularity,
     summary: ChargesSummary,
@@ -328,9 +330,15 @@ private fun ChargesContent(
             items(charges, key = { it.chargeId }) { charge ->
                 ChargeItem(
                     charge = charge,
-                    // Show DC badge if in dcChargeIds, AC otherwise
-                    // Will be correct once sync has processed charge details
-                    isDcCharge = charge.chargeId in dcChargeIds,
+                    // Exact for processed charges; for not-yet-synced ones, fall back to an
+                    // average-power heuristic so recent DC charges aren't shown as AC (issue #313).
+                    isDcCharge = ChargeStatsCalculator.isDcCharge(
+                        chargeId = charge.chargeId,
+                        energyAddedKwh = charge.chargeEnergyAdded,
+                        durationMin = charge.durationMin,
+                        dcChargeIds = dcChargeIds,
+                        processedChargeIds = processedChargeIds
+                    ),
                     currencySymbol = currencySymbol,
                     palette = palette,
                     onEditCost = if (teslamateBaseUrl.isNotBlank()) {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -380,18 +380,29 @@ class ChargesViewModel @Inject constructor(
             allCharges.filter { it.isSignificant() }
         }
 
+        // DC/AC classification matching the list badge: exact for processed charges, average-power
+        // heuristic for not-yet-synced ones (issue #313).
+        val processedChargeIds = state.processedChargeIds
+        fun isDc(charge: ChargeData) = ChargeStatsCalculator.isDcCharge(
+            chargeId = charge.chargeId,
+            energyAddedKwh = charge.chargeEnergyAdded,
+            durationMin = charge.durationMin,
+            dcChargeIds = dcChargeIds,
+            processedChargeIds = processedChargeIds
+        )
+
         // Apply charge type filter (AC/DC) for list display
         val displayCharges = when (chargeTypeFilter) {
             ChargeTypeFilter.ALL -> filteredCharges
-            ChargeTypeFilter.DC -> filteredCharges.filter { it.chargeId in dcChargeIds }
-            ChargeTypeFilter.AC -> filteredCharges.filter { it.chargeId !in dcChargeIds }
+            ChargeTypeFilter.DC -> filteredCharges.filter { isDc(it) }
+            ChargeTypeFilter.AC -> filteredCharges.filter { !isDc(it) }
         }
 
         // Apply charge type filter to all charges for summary/charts (include short charges)
         val chargesForStats = when (chargeTypeFilter) {
             ChargeTypeFilter.ALL -> allCharges
-            ChargeTypeFilter.DC -> allCharges.filter { it.chargeId in dcChargeIds }
-            ChargeTypeFilter.AC -> allCharges.filter { it.chargeId !in dcChargeIds }
+            ChargeTypeFilter.DC -> allCharges.filter { isDc(it) }
+            ChargeTypeFilter.AC -> allCharges.filter { !isDc(it) }
         }
 
         // Extract unique locations from the complete set


### PR DESCRIPTION
## Summary
Some DC charges were shown as AC in the charges list, while the detail screen correctly showed DC.

Fixes #313

## Root Cause
The charges list rendered the AC/DC badge from a cached `dcChargeIds` set as a strict binary: in the set → DC, otherwise → AC. That set only contains charges the background detail-sync has already processed into aggregates. The most recent charges are usually not processed yet, so they fell into the "otherwise" bucket and showed **AC**. The detail screen computes DC/AC live from the charge points (`detectDcCharge`), so it always showed the correct **DC** — hence "AC in the list, DC once inside". The list/aggregate and detail paths use the same phases rule, so it was never a logic bug; "not yet analyzed" was simply being mislabeled as AC. (The AC/DC filter had the same flaw.)

## Solution
Add a shared classifier `ChargeStatsCalculator.isDcCharge(...)`:
- **Processed charge** → exact result from the aggregate (unchanged behaviour).
- **Unprocessed charge** → average-power heuristic (`energyAdded / duration`); above ~20 kW is treated as DC. AC tops out around 11–22 kW, DC fast charging sustains far more, so the threshold separates them cleanly.

The value self-corrects to the exact result once the charge is processed. Both the list badge and the AC/DC filter now use this classifier, so they agree. `processedChargeIds` was already loaded into the ViewModel state; it's now threaded to the list.

## Test Plan
- [x] `./gradlew compileDebugKotlin testDebugUnitTest` passes
- [x] `./gradlew lintDebug` (run before merge)
- [ ] Manual: a recent DC fast charge that hasn't synced yet shows the DC badge in the list; once processed it stays DC; AC charges still show AC

Generated with [Claude Code](https://claude.com/claude-code)