### PR TITLE
fix: make the empty-Trips dashboard hint describe detection accurately (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Time spent driving and charging now headline the trip timeline** as bold accent stat tiles, with the overall total as a quiet caption beneath.
 
 ### Fixed
+- **The empty-Trips hint on the dashboard now describes road-trip detection accurately** — it no longer implies distance alone qualifies; a road-trip needs multiple drives linked by a DC fast-charge (#314).
 - **Recent DC charges no longer show as AC in the charges list** — until a charge's details are synced, its type is now inferred from average power instead of defaulting to AC, so a fast charge isn't mislabeled while it waits to be processed (#313).
 - **Drives and charges in a merged-and-renamed trip now show the trip's current name** on their detail screen, instead of the original auto-generated "city → city" name.
 - **Short drives and charges now stay hidden on the Trips screens too** — when "Show short drives / charges" is off (the default), short legs no longer clutter the trip timeline strips, the trip detail timeline, or the leg list. The setting is now honoured everywhere drives and charges are listed.

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -148,7 +148,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">Encara no hi ha viatges</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">Els viatges de més de 300 km apareixen aquí</string>
+    <string name="trips_empty_hint">Els trajectes llargs units per una càrrega ràpida DC apareixen aquí</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">Un viatge es detecta automàticament quan tens:</string>
     <!-- Trips list empty state: rule 1 -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -148,7 +148,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">Noch keine Trips</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">Trips über 300 km erscheinen hier</string>
+    <string name="trips_empty_hint">Lange Fahrten, verbunden durch eine DC-Schnellladung, erscheinen hier</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">Ein Trip wird automatisch erkannt, wenn du Folgendes hast:</string>
     <!-- Trips list empty state: rule 1 -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -148,7 +148,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">Aún no hay viajes</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">Los viajes de más de 300 km aparecen aquí</string>
+    <string name="trips_empty_hint">Los trayectos largos unidos por una carga rápida DC aparecen aquí</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">Un viaje se detecta automáticamente cuando tienes:</string>
     <!-- Trips list empty state: rule 1 -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -148,7 +148,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">Ancora nessun viaggio</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">I viaggi oltre 300 km appaiono qui</string>
+    <string name="trips_empty_hint">I tragitti lunghi uniti da una ricarica rapida DC compaiono qui</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">Un viaggio viene rilevato automaticamente quando hai:</string>
     <!-- Trips list empty state: rule 1 -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -148,7 +148,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">暂无长途旅程</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">超过 300 公里的旅程会显示在这里</string>
+    <string name="trips_empty_hint">由直流快充连接的长途行程会显示在这里</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">满足以下条件时会自动识别为一次旅程：</string>
     <!-- Trips list empty state: rule 1 -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,7 +151,7 @@
     <!-- Trips hero empty state: shown when no road-trips have been detected yet -->
     <string name="trips_empty_title">No road-trips yet</string>
     <!-- Trips hero empty state hint -->
-    <string name="trips_empty_hint">Trips over 300 km show up here</string>
+    <string name="trips_empty_hint">Long drives joined by a DC fast-charge show up here</string>
     <!-- Trips list empty state: intro before the auto-detection rules -->
     <string name="trips_empty_intro">A road-trip is detected automatically when you have:</string>
     <!-- Trips list empty state: rule 1 -->


### PR DESCRIPTION
## Summary
The dashboard's empty-Trips hint implied that any trip over 300 km becomes a road-trip, so a reporter's 393 km single drive (no charge) confusingly stayed in the regular Trips tab.

Fixes #314

## Root Cause
The `trips_empty_hint` string ("Trips over 300 km show up here", and equivalents in each locale) described only the distance threshold. The real auto-detection rule in `TripDetector` requires **all three**: 2+ drives in a row, linked by at least one DC fast-charge stop, totalling 300 km or more. A single long drive with no DC charge correctly never becomes a road-trip; the hint just didn't say so.

## Solution
Reword `trips_empty_hint` in all 6 locales to a short sentence that reflects the real rule (long drives joined by a DC fast-charge), dropping the misleading distance-only phrasing. The empty Trips screen already lists the full three-rule breakdown, so it's left unchanged as the detailed explanation.

| Locale | New hint |
|---|---|
| en | Long drives joined by a DC fast-charge show up here |
| it | I tragitti lunghi uniti da una ricarica rapida DC compaiono qui |
| es | Los trayectos largos unidos por una carga rápida DC aparecen aquí |
| ca | Els trajectes llargs units per una càrrega ràpida DC apareixen aquí |
| de | Lange Fahrten, verbunden durch eine DC-Schnellladung, erscheinen hier |
| zh | 由直流快充连接的长途行程会显示在这里 |

## Test Plan
- [x] `./gradlew lintDebug testDebugUnitTest` passes (no MissingTranslation, no hardcoded strings)
- [ ] Manual: dashboard Trips tile with no detected road-trips shows the new hint in each language

Generated with [Claude Code](https://claude.com/claude-code)