### PR TITLE
Headline consumption & cost/100 metrics on trip detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Headline metrics on the trip detail screen** — the trip's average consumption (Wh/km) and charging cost per 100 km now appear as two accent tiles right below the route map, so the figures you compare trips by are up front instead of buried further down.
+- **Trip vitals on the map** — the trip detail map is now a full-height hero with the trip's average consumption (Wh/km) and charging cost per 100 km shown in a bar across the bottom, so the figures you compare trips by are front and centre (previously they were only in the energy-flow and cost cards further down).
 
 ## [1.10.0-beta1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Headline metrics on the trip detail screen** — the trip's average consumption (Wh/km) and charging cost per 100 km now appear as two accent tiles right below the route map, so the figures you compare trips by are up front instead of buried further down.
+
 ## [1.10.0-beta1] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Trip vitals on the map** — the trip detail map is now a full-height hero with the trip's average consumption (Wh/km) and charging cost per 100 km shown in a bar across the bottom, so the figures you compare trips by are front and centre (previously they were only in the energy-flow and cost cards further down).
+- **Trip vitals on the map** — the trip detail map is now a full-height hero showing the trip's distance, average consumption (Wh/km) and charging cost per 100 km in a bar across the bottom, so the figures you compare trips by are front and centre (previously they were only in the energy-flow and cost cards further down). Tap the expand button to view the map full screen; drag with two fingers to pan it.
 
 ## [1.10.0-beta1] - 2026-07-01
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -24,7 +24,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.clickable
@@ -34,6 +38,8 @@ import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -76,12 +82,16 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.activity.compose.BackHandler
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
@@ -1065,18 +1075,6 @@ private fun TripMapCard(
 ) {
     val isDark = isSystemInDarkTheme()
 
-    // Bridge: Android View click → Compose state → Compose navigation
-    var pendingChargeNav by remember { mutableIntStateOf(0) }
-    LaunchedEffect(pendingChargeNav) {
-        if (pendingChargeNav != 0) {
-            onChargeClick(pendingChargeNav)
-            pendingChargeNav = 0
-        }
-    }
-
-    // Track when the map has zoomed to the route — hides the world-view flash
-    var mapReady by remember { mutableStateOf(false) }
-
     val mapColors = remember(palette) {
         MapColors(
             start = StatusSuccess.toArgb(),
@@ -1089,26 +1087,9 @@ private fun TripMapCard(
         )
     }
 
-    // Cache marker drawables per color — drawables are heavy to create each pass.
-    val markerDrawables = remember { mutableMapOf<Pair<Int, Boolean>, android.graphics.drawable.Drawable>() }
-
-    // Track the last applied data so we can skip redrawing overlays when nothing changed.
-    val lastApplied = remember { arrayOfNulls<Any>(3) }
-
-    // Defer MapView instantiation by a short delay so the first frame of the surrounding screen
-    // paints and touch/scroll handlers become responsive before osmdroid's synchronous MapView
-    // constructor runs on the main thread. This matters most on back-navigation: the composition
-    // is torn down and rebuilt by NavHost, and mounting the MapView immediately would freeze the
-    // main thread for ~100–300ms.
-    var mapMounted by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        kotlinx.coroutines.delay(120)
-        mapMounted = true
-    }
-
-    // Precompute GeoPoint lists + BoundingBox off the main thread. For long trips this moves
-    // hundreds-to-thousands of object allocations + min/max scans off the UI thread, so when
-    // the AndroidView update runs it only does cheap attach work.
+    // Precompute GeoPoint lists + BoundingBox off the main thread, once, shared by the inline and
+    // fullscreen maps. For long trips this moves hundreds-to-thousands of allocations + min/max
+    // scans off the UI thread.
     var preparedRoute by remember(routeSegments) { mutableStateOf<PreparedRoute?>(null) }
     LaunchedEffect(routeSegments) {
         preparedRoute = if (routeSegments.isEmpty()) null else withContext(Dispatchers.Default) {
@@ -1134,183 +1115,372 @@ private fun TripMapCard(
         }
     }
 
+    var isFullscreen by rememberSaveable { mutableStateOf(false) }
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
-        Box(
+        TripMapContent(
+            preparedRoute = preparedRoute,
+            markers = markers,
+            mapColors = mapColors,
+            isDark = isDark,
+            isMapLoading = isMapLoading,
+            trip = trip,
+            units = units,
+            currencySymbol = currencySymbol,
+            dateRangeLabel = dateRangeLabel,
+            palette = palette,
+            singleFingerScrollsPage = true,
+            onChargeClick = onChargeClick,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(400.dp)
                 .clip(RoundedCornerShape(12.dp))
         ) {
-                if (mapMounted) AndroidView(
-                    factory = { mapCtx ->
-                        MapView(mapCtx).apply {
-                            setTileSource(TileSourceFactory.MAPNIK)
-                            setMultiTouchControls(true)
-                            // Dim + desaturate the tiles so the accent route and the docked
-                            // vitals bar read as a deliberate hero rather than raw map data.
-                            overlayManager.tilesOverlay.setColorFilter(mapDimFilter(isDark))
-                            // Tell the parent vertical scroll to stop intercepting
-                            // touches so single-finger drag pans the map instead
-                            // of scrolling the page.
-                            setOnTouchListener { v, event ->
-                                when (event.actionMasked) {
-                                    MotionEvent.ACTION_DOWN,
-                                    MotionEvent.ACTION_MOVE,
-                                    MotionEvent.ACTION_POINTER_DOWN ->
-                                        v.parent?.requestDisallowInterceptTouchEvent(true)
-                                    MotionEvent.ACTION_UP,
-                                    MotionEvent.ACTION_CANCEL ->
-                                        v.parent?.requestDisallowInterceptTouchEvent(false)
+            MapCornerButton(
+                icon = Icons.Default.Fullscreen,
+                contentDescription = stringResource(R.string.fullscreen),
+                onClick = { isFullscreen = true }
+            )
+        }
+    }
+
+    if (isFullscreen) {
+        TripMapFullscreen(
+            preparedRoute = preparedRoute,
+            markers = markers,
+            mapColors = mapColors,
+            isDark = isDark,
+            isMapLoading = isMapLoading,
+            trip = trip,
+            units = units,
+            currencySymbol = currencySymbol,
+            dateRangeLabel = dateRangeLabel,
+            palette = palette,
+            onChargeClick = onChargeClick,
+            onDismiss = { isFullscreen = false }
+        )
+    }
+}
+
+// Map + its overlays (date chip, docked vitals bar, and a corner button). Shared by the inline
+// hero card and the fullscreen dialog so both stay identical.
+@Composable
+private fun TripMapContent(
+    preparedRoute: PreparedRoute?,
+    markers: List<TripMapMarker>,
+    mapColors: MapColors,
+    isDark: Boolean,
+    isMapLoading: Boolean,
+    trip: Trip,
+    units: Units?,
+    currencySymbol: String,
+    dateRangeLabel: String,
+    palette: CarColorPalette,
+    singleFingerScrollsPage: Boolean,
+    onChargeClick: (chargeId: Int) -> Unit,
+    modifier: Modifier = Modifier,
+    overlayInsets: WindowInsets = WindowInsets(0, 0, 0, 0),
+    cornerButton: @Composable BoxScope.() -> Unit = {}
+) {
+    Box(modifier = modifier) {
+        TripMapAndroidView(
+            preparedRoute = preparedRoute,
+            markers = markers,
+            mapColors = mapColors,
+            isDark = isDark,
+            isMapLoading = isMapLoading,
+            singleFingerScrollsPage = singleFingerScrollsPage,
+            onChargeClick = onChargeClick,
+            modifier = Modifier.fillMaxSize()
+        )
+        // Overlays sit inside an inset box so they clear the system bars in fullscreen, while the
+        // map itself stays full-bleed behind them. Inline (zero insets) this is a no-op.
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .windowInsetsPadding(overlayInsets)
+        ) {
+            MapOverlayChip(
+                text = dateRangeLabel,
+                palette = palette,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+            )
+            MapVitalsOverlay(
+                trip = trip,
+                units = units,
+                currencySymbol = currencySymbol
+            )
+            cornerButton()
+        }
+    }
+}
+
+@Composable
+private fun TripMapAndroidView(
+    preparedRoute: PreparedRoute?,
+    markers: List<TripMapMarker>,
+    mapColors: MapColors,
+    isDark: Boolean,
+    isMapLoading: Boolean,
+    singleFingerScrollsPage: Boolean,
+    onChargeClick: (chargeId: Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Bridge: Android View click → Compose state → Compose navigation
+    var pendingChargeNav by remember { mutableIntStateOf(0) }
+    LaunchedEffect(pendingChargeNav) {
+        if (pendingChargeNav != 0) {
+            onChargeClick(pendingChargeNav)
+            pendingChargeNav = 0
+        }
+    }
+
+    // Track when the map has zoomed to the route — hides the world-view flash
+    var mapReady by remember { mutableStateOf(false) }
+
+    // Cache marker drawables per color — drawables are heavy to create each pass.
+    val markerDrawables = remember { mutableMapOf<Pair<Int, Boolean>, android.graphics.drawable.Drawable>() }
+
+    // Track the last applied data so we can skip redrawing overlays when nothing changed.
+    val lastApplied = remember { arrayOfNulls<Any>(3) }
+
+    // Defer MapView instantiation by a short delay so the first frame paints before osmdroid's
+    // synchronous MapView constructor runs on the main thread.
+    var mapMounted by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(120)
+        mapMounted = true
+    }
+
+    Box(modifier = modifier) {
+        if (mapMounted) AndroidView(
+            factory = { mapCtx ->
+                MapView(mapCtx).apply {
+                    setTileSource(TileSourceFactory.MAPNIK)
+                    setMultiTouchControls(true)
+                    // Dim + desaturate the tiles so the accent route and the docked vitals bar
+                    // read as a deliberate hero rather than raw map data.
+                    overlayManager.tilesOverlay.setColorFilter(mapDimFilter(isDark))
+                    if (singleFingerScrollsPage) {
+                        // Inline hero: one finger scrolls the surrounding page; two fingers
+                        // pan/zoom the map (we hold the parent off only with a second finger).
+                        setOnTouchListener { v, event ->
+                            v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
+                            false
+                        }
+                    }
+                }
+            },
+            update = { mapView ->
+                val prep = preparedRoute ?: return@AndroidView
+
+                // Skip the expensive overlay rebuild when the inputs haven't changed.
+                if (lastApplied[0] == prep &&
+                    lastApplied[1] == markers &&
+                    lastApplied[2] == mapColors
+                ) return@AndroidView
+                lastApplied[0] = prep
+                lastApplied[1] = markers
+                lastApplied[2] = mapColors
+
+                // Defer overlay creation to the next main-thread message so the first frame paints.
+                mapView.post {
+                    mapView.overlays.clear()
+
+                    var previousEnd: GeoPoint? = null
+                    prep.geoPointSegments.forEachIndexed { index, geoPoints ->
+                        if (geoPoints.size < 2) return@forEachIndexed
+
+                        // If this leg's start is far from the previous leg's end (car transported,
+                        // or a merge of non-contiguous trips), draw a dashed connector.
+                        val firstPoint = geoPoints.first()
+                        val prev = previousEnd
+                        if (prev != null) {
+                            val distanceMeters = prev.distanceToAsDouble(firstPoint)
+                            if (distanceMeters > GEO_JUMP_THRESHOLD_METERS) {
+                                val dashed = Polyline().apply {
+                                    setPoints(listOf(prev, firstPoint))
+                                    outlinePaint.color = mapColors.oddLeg
+                                    outlinePaint.strokeWidth = 6f
+                                    outlinePaint.strokeCap = Paint.Cap.ROUND
+                                    outlinePaint.pathEffect =
+                                        android.graphics.DashPathEffect(floatArrayOf(20f, 15f), 0f)
                                 }
-                                false
+                                mapView.overlays.add(dashed)
                             }
                         }
-                    },
-                    update = { mapView ->
-                        val prep = preparedRoute ?: return@AndroidView
 
-                        // Skip the expensive overlay rebuild when the inputs haven't changed.
-                        // Lists and MapColors compare structurally so this short-circuits on
-                        // return-from-child when the VM emits structurally-equal data.
-                        if (lastApplied[0] == prep &&
-                            lastApplied[1] == markers &&
-                            lastApplied[2] == mapColors
-                        ) return@AndroidView
-                        lastApplied[0] = prep
-                        lastApplied[1] = markers
-                        lastApplied[2] = mapColors
-
-                        // Defer all overlay creation to the next main-thread message so the
-                        // surrounding composition's first frame can paint (and the scroll view
-                        // becomes responsive) before we build polylines + markers.
-                        mapView.post {
-                        mapView.overlays.clear()
-
-                        var previousEnd: GeoPoint? = null
-                        prep.geoPointSegments.forEachIndexed { index, geoPoints ->
-                            if (geoPoints.size < 2) return@forEachIndexed
-
-                            // If there's a previous leg, check if this leg's start is geographically
-                            // far from the previous leg's end (car was transported, or between
-                            // non-contiguous trips that were merged). Draw a dashed connector.
-                            val firstPoint = geoPoints.first()
-                            val prev = previousEnd
-                            if (prev != null) {
-                                val distanceMeters = prev.distanceToAsDouble(firstPoint)
-                                if (distanceMeters > GEO_JUMP_THRESHOLD_METERS) {
-                                    val dashed = Polyline().apply {
-                                        setPoints(listOf(prev, firstPoint))
-                                        outlinePaint.color = mapColors.oddLeg
-                                        outlinePaint.strokeWidth = 6f
-                                        outlinePaint.strokeCap = Paint.Cap.ROUND
-                                        outlinePaint.pathEffect =
-                                            android.graphics.DashPathEffect(floatArrayOf(20f, 15f), 0f)
-                                    }
-                                    mapView.overlays.add(dashed)
-                                }
-                            }
-
-                            val polyline = Polyline().apply {
-                                setPoints(geoPoints)
-                                outlinePaint.color =
-                                    if (index % 2 == 0) mapColors.oddLeg
-                                    else mapColors.evenLeg
-                                outlinePaint.strokeWidth = 8f
-                                outlinePaint.strokeCap = Paint.Cap.ROUND
-                                outlinePaint.strokeJoin = Paint.Join.ROUND
-                            }
-                            mapView.overlays.add(polyline)
-                            previousEnd = geoPoints.last()
+                        val polyline = Polyline().apply {
+                            setPoints(geoPoints)
+                            outlinePaint.color =
+                                if (index % 2 == 0) mapColors.oddLeg
+                                else mapColors.evenLeg
+                            outlinePaint.strokeWidth = 8f
+                            outlinePaint.strokeCap = Paint.Cap.ROUND
+                            outlinePaint.strokeJoin = Paint.Join.ROUND
                         }
+                        mapView.overlays.add(polyline)
+                        previousEnd = geoPoints.last()
+                    }
 
-                        val mapCtx = mapView.context
-                        markers.forEach { point ->
-                            val color = when (point.type) {
-                                TripMapPointType.START -> mapColors.start
-                                TripMapPointType.CHARGE -> mapColors.charge
-                                TripMapPointType.END -> mapColors.end
-                            }
-                            val isCharge = point.type == TripMapPointType.CHARGE
-                            val markerIcon = markerDrawables.getOrPut(color to isCharge) {
-                                if (isCharge) createZapMarkerDrawable(mapCtx.resources, color)
-                                else createPinMarkerDrawable(mapCtx.resources, color)
-                            }
-                            val marker = Marker(mapView).apply {
-                                position = GeoPoint(point.latitude, point.longitude)
-                                setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-                                title = point.label
-                                icon = markerIcon
-                                if (point.chargeId != null) {
-                                    val cid = point.chargeId
-                                    infoWindow = object : org.osmdroid.views.overlay.infowindow.MarkerInfoWindow(
-                                        org.osmdroid.library.R.layout.bonuspack_bubble, mapView
-                                    ) {
-                                        override fun onOpen(item: Any?) {
-                                            super.onOpen(item)
-                                            val clickListener = android.view.View.OnClickListener {
-                                                close()
-                                                pendingChargeNav = cid
-                                            }
-                                            view?.setOnClickListener(clickListener)
-                                            (view as? android.view.ViewGroup)?.let { vg ->
-                                                for (i in 0 until vg.childCount) {
-                                                    vg.getChildAt(i).setOnClickListener(clickListener)
-                                                }
+                    val mapCtx = mapView.context
+                    markers.forEach { point ->
+                        val color = when (point.type) {
+                            TripMapPointType.START -> mapColors.start
+                            TripMapPointType.CHARGE -> mapColors.charge
+                            TripMapPointType.END -> mapColors.end
+                        }
+                        val isCharge = point.type == TripMapPointType.CHARGE
+                        val markerIcon = markerDrawables.getOrPut(color to isCharge) {
+                            if (isCharge) createZapMarkerDrawable(mapCtx.resources, color)
+                            else createPinMarkerDrawable(mapCtx.resources, color)
+                        }
+                        val marker = Marker(mapView).apply {
+                            position = GeoPoint(point.latitude, point.longitude)
+                            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                            title = point.label
+                            icon = markerIcon
+                            if (point.chargeId != null) {
+                                val cid = point.chargeId
+                                infoWindow = object : org.osmdroid.views.overlay.infowindow.MarkerInfoWindow(
+                                    org.osmdroid.library.R.layout.bonuspack_bubble, mapView
+                                ) {
+                                    override fun onOpen(item: Any?) {
+                                        super.onOpen(item)
+                                        val clickListener = android.view.View.OnClickListener {
+                                            close()
+                                            pendingChargeNav = cid
+                                        }
+                                        view?.setOnClickListener(clickListener)
+                                        (view as? android.view.ViewGroup)?.let { vg ->
+                                            for (i in 0 until vg.childCount) {
+                                                vg.getChildAt(i).setOnClickListener(clickListener)
                                             }
                                         }
                                     }
                                 }
                             }
-                            mapView.overlays.add(marker)
                         }
+                        mapView.overlays.add(marker)
+                    }
 
-                        val bb = prep.boundingBox
-                        if (bb != null) {
-                            mapView.zoomToBoundingBox(bb, false)
-                            mapView.invalidate()
-                            mapReady = true
-                        }
-                        } // end mapView.post
-                    },
-                    modifier = Modifier.fillMaxSize()
-                )
-                // Opaque cover hides the world-view zoom until route is drawn
-                val overlayAlpha by animateFloatAsState(
-                    targetValue = if (mapReady) 0f else 1f,
-                    animationSpec = tween(durationMillis = 300),
-                    label = "mapOverlay"
-                )
-                if (overlayAlpha > 0f) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.surface.copy(alpha = overlayAlpha)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (isMapLoading) {
-                            CircularProgressIndicator(modifier = Modifier.size(32.dp))
-                        }
+                    val bb = prep.boundingBox
+                    if (bb != null) {
+                        mapView.zoomToBoundingBox(bb, false)
+                        mapView.invalidate()
+                        mapReady = true
                     }
                 }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
 
-                MapOverlayChip(
-                    text = dateRangeLabel,
-                    palette = palette,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(12.dp)
-                )
-                MapVitalsOverlay(
-                    trip = trip,
-                    units = units,
-                    currencySymbol = currencySymbol
-                )
+        // Opaque cover hides the world-view zoom until the route is drawn
+        val overlayAlpha by animateFloatAsState(
+            targetValue = if (mapReady) 0f else 1f,
+            animationSpec = tween(durationMillis = 300),
+            label = "mapOverlay"
+        )
+        if (overlayAlpha > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = overlayAlpha)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isMapLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                }
+            }
         }
+    }
+}
+
+// Fullscreen map overlay — fills the screen in the current orientation (no landscape lock). The
+// map draws full-bleed behind the system bars; the overlays are inset so they clear the status
+// bar / clock. Back or the corner button exits.
+@Composable
+private fun TripMapFullscreen(
+    preparedRoute: PreparedRoute?,
+    markers: List<TripMapMarker>,
+    mapColors: MapColors,
+    isDark: Boolean,
+    isMapLoading: Boolean,
+    trip: Trip,
+    units: Units?,
+    currencySymbol: String,
+    dateRangeLabel: String,
+    palette: CarColorPalette,
+    onChargeClick: (chargeId: Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    BackHandler { onDismiss() }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        TripMapContent(
+            preparedRoute = preparedRoute,
+            markers = markers,
+            mapColors = mapColors,
+            isDark = isDark,
+            isMapLoading = isMapLoading,
+            trip = trip,
+            units = units,
+            currencySymbol = currencySymbol,
+            dateRangeLabel = dateRangeLabel,
+            palette = palette,
+            singleFingerScrollsPage = false,
+            onChargeClick = onChargeClick,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            overlayInsets = WindowInsets.systemBars
+        ) {
+            MapCornerButton(
+                icon = Icons.Default.FullscreenExit,
+                contentDescription = stringResource(R.string.exit_fullscreen),
+                onClick = onDismiss
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.MapCornerButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .align(Alignment.TopEnd)
+            .padding(12.dp)
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurface
+        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1354,12 +1354,11 @@ private fun BoxScope.MapVitalsOverlay(
     val costNumber = per100?.let { "%.2f".format(it) } ?: "—"
     val costUnit = if (per100 != null) currencySymbol else ""
     val distanceUnit = UnitFormatter.getDistanceUnit(units)
+    val distanceNumber = "%,.0f".format(trip.totalDistance)
 
     val resources = LocalContext.current.resources
-    val contextLine = remember(trip.totalDistance, trip.totalDurationMin, units) {
-        val dist = UnitFormatter.formatDistance(trip.totalDistance, units, decimals = 0)
-        val dur = formatDuration(resources, trip.totalDurationMin)
-        "$dist · $dur"
+    val durationLine = remember(trip.totalDurationMin) {
+        formatDuration(resources, trip.totalDurationMin)
     }
 
     Column(
@@ -1383,18 +1382,19 @@ private fun BoxScope.MapVitalsOverlay(
             verticalAlignment = Alignment.CenterVertically
         ) {
             MapVitalStat(
+                label = stringResource(R.string.distance),
+                number = distanceNumber,
+                unit = distanceUnit,
+                modifier = Modifier.weight(1f)
+            )
+            VitalDivider()
+            MapVitalStat(
                 label = stringResource(R.string.consumption),
                 number = consumptionNumber,
                 unit = consumptionUnit,
                 modifier = Modifier.weight(1f)
             )
-            Box(
-                modifier = Modifier
-                    .width(1.dp)
-                    .fillMaxHeight()
-                    .padding(vertical = 2.dp)
-                    .background(Color.White.copy(alpha = 0.16f))
-            )
+            VitalDivider()
             MapVitalStat(
                 label = stringResource(R.string.trip_cost_per_100, distanceUnit),
                 number = costNumber,
@@ -1403,12 +1403,23 @@ private fun BoxScope.MapVitalsOverlay(
             )
         }
         Text(
-            text = contextLine,
+            text = durationLine,
             style = MaterialTheme.typography.bodySmall,
             color = Color.White.copy(alpha = 0.68f),
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
     }
+}
+
+@Composable
+private fun VitalDivider() {
+    Box(
+        modifier = Modifier
+            .width(1.dp)
+            .fillMaxHeight()
+            .padding(vertical = 2.dp)
+            .background(Color.White.copy(alpha = 0.16f))
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1,5 +1,7 @@
 package com.matedroid.ui.screens.trips
 
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import android.view.MotionEvent
 import androidx.compose.foundation.Canvas
@@ -9,6 +11,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
@@ -31,8 +34,6 @@ import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.Payments
-import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -78,7 +79,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -314,9 +314,6 @@ private fun TripDetailContent(
         val dateRangeLabel = remember(trip.startDate, trip.endDate) {
             formatTripDateRange(trip.startDate, trip.endDate)
         }
-        val distanceLabel = remember(trip.totalDistance, units) {
-            UnitFormatter.formatDistance(trip.totalDistance, units, decimals = 0)
-        }
         val startCity = remember(trip.startAddress) { extractCity(trip.startAddress) }
         val endCity = remember(trip.endAddress) { extractCity(trip.endAddress) }
         val timelineSegments = remember(trip, dcChargeIds, showShortDrivesCharges) {
@@ -335,15 +332,10 @@ private fun TripDetailContent(
             isMapLoading = isMapLoading,
             palette = palette,
             dateRangeLabel = dateRangeLabel,
-            distanceLabel = distanceLabel,
-            onChargeClick = onChargeClick
-        )
-
-        TripHeadlineMetrics(
             trip = trip,
             units = units,
             currencySymbol = currencySymbol,
-            palette = palette
+            onChargeClick = onChargeClick
         )
 
         TripTimeline(
@@ -376,8 +368,7 @@ private fun TripDetailContent(
         BatteryEnergyFlowCard(
             trip = trip,
             dcChargeIds = dcChargeIds,
-            palette = palette,
-            units = units
+            palette = palette
         )
 
         val legs = remember(trip, showShortDrivesCharges) { buildLegList(trip, showShortDrivesCharges) }
@@ -504,97 +495,6 @@ private fun TripDetailContent(
     }
 }
 
-// === Headline metrics — the two figures you compare trips by, right under the map ===
-
-@Composable
-private fun TripHeadlineMetrics(
-    trip: Trip,
-    units: Units?,
-    currencySymbol: String,
-    palette: CarColorPalette
-) {
-    // Average consumption (Wh/km or Wh/mi). Prefer the pre-computed value; fall back to
-    // energy-consumed / distance (same fallback the energy-flow card uses).
-    val efficiency = trip.avgEfficiency
-        ?: trip.totalDistance.takeIf { it > 0.0 }?.let { trip.totalEnergyConsumed * 1000.0 / it }
-    val consumptionValue = efficiency
-        ?.let { UnitFormatter.formatEfficiency(it, units, decimals = 0) }
-        ?: "—"
-
-    // Charging cost per 100 distance units. Distance is already in the user's unit (API
-    // pre-converts), so this arithmetic yields "/100 km" or "/100 mi" with no conversion.
-    val per100 = trip.totalChargeCost?.takeIf { trip.totalDistance > 0.0 }
-        ?.let { it / trip.totalDistance * 100.0 }
-    val costValue = per100?.let { "%.2f %s".format(it, currencySymbol) } ?: "—"
-    val distanceUnit = UnitFormatter.getDistanceUnit(units)
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        HeadlineMetricTile(
-            icon = Icons.Filled.Speed,
-            label = stringResource(R.string.consumption),
-            value = consumptionValue,
-            accent = palette.accent,
-            modifier = Modifier.weight(1f)
-        )
-        HeadlineMetricTile(
-            icon = Icons.Filled.Payments,
-            label = stringResource(R.string.trip_cost_per_100, distanceUnit),
-            value = costValue,
-            accent = palette.accent,
-            modifier = Modifier.weight(1f)
-        )
-    }
-}
-
-// Accent stat tile — mirrors DurationTile so the headline metrics read as one family with
-// the Driving / Charging tiles in the timeline below.
-@Composable
-private fun HeadlineMetricTile(
-    icon: ImageVector,
-    label: String,
-    value: String,
-    accent: Color,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .background(accent.copy(alpha = 0.12f))
-            .padding(vertical = 12.dp, horizontal = 12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(15.dp),
-                tint = accent
-            )
-            Spacer(Modifier.width(6.dp))
-            Text(
-                text = label.uppercase(java.util.Locale.getDefault()),
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                softWrap = false
-            )
-        }
-        Text(
-            text = value,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = accent,
-            maxLines = 1,
-            softWrap = false
-        )
-    }
-}
-
 // === Charge Cost Card ===
 
 @Composable
@@ -677,32 +577,20 @@ private fun ChargeCostCard(
                     currencySymbol = currencySymbol
                 )
 
-                // Always-visible efficiency pills below the donut — the "at-a-glance verdict"
-                // on how expensive the trip was per distance / per energy.
-                val distanceUnit = UnitFormatter.getDistanceUnit(units)
-                val per100 = trip.totalChargeCost?.takeIf { trip.totalDistance > 0.0 }
-                    ?.let { it / trip.totalDistance * 100.0 }
+                // Per-kWh cost pill below the donut — the "at-a-glance verdict" on how expensive
+                // the energy was. (Cost per 100 km now lives in the map vitals bar.)
                 val perKwh = trip.totalChargeCost?.takeIf { trip.totalEnergyCharged > 0.0 }
                     ?.let { it / trip.totalEnergyCharged }
-                if (per100 != null || perKwh != null) {
+                if (perKwh != null) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
                     ) {
-                        per100?.let {
-                            EfficiencyPill(
-                                value = "%.2f %s".format(it, currencySymbol),
-                                unit = "/ 100 $distanceUnit",
-                                palette = palette
-                            )
-                        }
-                        perKwh?.let {
-                            EfficiencyPill(
-                                value = "%.2f %s".format(it, currencySymbol),
-                                unit = "/ kWh",
-                                palette = palette
-                            )
-                        }
+                        EfficiencyPill(
+                            value = "%.2f %s".format(perKwh, currencySymbol),
+                            unit = "/ kWh",
+                            palette = palette
+                        )
                     }
                 }
             }
@@ -806,8 +694,7 @@ private fun EfficiencyPill(
 private fun BatteryEnergyFlowCard(
     trip: Trip,
     dcChargeIds: Set<Int>,
-    palette: CarColorPalette,
-    units: Units?
+    palette: CarColorPalette
 ) {
     val dcCharges = remember(trip, dcChargeIds) { trip.charges.filter { it.chargeId in dcChargeIds } }
     val acCharges = remember(trip, dcChargeIds) { trip.charges.filter { it.chargeId !in dcChargeIds } }
@@ -818,9 +705,6 @@ private fun BatteryEnergyFlowCard(
     val dcAvgKw = if (dcDurationMin > 0) dcKwh * 60.0 / dcDurationMin else 0.0
     val acAvgKw = if (acDurationMin > 0) acKwh * 60.0 / acDurationMin else 0.0
     val usedKwh = trip.totalEnergyConsumed
-    val efficiencyWhPerDist = trip.avgEfficiency
-        ?: trip.totalDistance.takeIf { it > 0.0 }?.let { usedKwh * 1000.0 / it }
-    val efficiencyUnit = UnitFormatter.getEfficiencyUnit(units)
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -850,8 +734,6 @@ private fun BatteryEnergyFlowCard(
                 dcKwh = dcKwh, dcAvgKw = dcAvgKw,
                 acKwh = acKwh, acAvgKw = acAvgKw,
                 usedKwh = usedKwh,
-                efficiencyWhPerDist = efficiencyWhPerDist,
-                efficiencyUnit = efficiencyUnit,
                 palette = palette
             )
         }
@@ -863,8 +745,6 @@ private fun HorizontalEnergyFlow(
     dcKwh: Double, dcAvgKw: Double,
     acKwh: Double, acAvgKw: Double,
     usedKwh: Double,
-    efficiencyWhPerDist: Double?,
-    efficiencyUnit: String,
     palette: CarColorPalette
 ) {
     val totalCharged = dcKwh + acKwh
@@ -1150,13 +1030,6 @@ private fun HorizontalEnergyFlow(
                 fontWeight = FontWeight.Bold,
                 color = usedColor
             )
-            if (efficiencyWhPerDist != null) {
-                Text(
-                    text = "%.0f %s".format(efficiencyWhPerDist, efficiencyUnit),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         }
     }
 }
@@ -1185,9 +1058,13 @@ private fun TripMapCard(
     isMapLoading: Boolean,
     palette: CarColorPalette,
     dateRangeLabel: String,
-    distanceLabel: String,
+    trip: Trip,
+    units: Units?,
+    currencySymbol: String,
     onChargeClick: (chargeId: Int) -> Unit = {}
 ) {
+    val isDark = isSystemInDarkTheme()
+
     // Bridge: Android View click → Compose state → Compose navigation
     var pendingChargeNav by remember { mutableIntStateOf(0) }
     LaunchedEffect(pendingChargeNav) {
@@ -1244,11 +1121,13 @@ private fun TripMapCard(
                 val south = allPoints.minOf { it.latitude }
                 val east = allPoints.maxOf { it.longitude }
                 val west = allPoints.minOf { it.longitude }
-                val latPad = (north - south) * 0.15
+                val latSpan = north - south
                 val lonPad = (east - west) * 0.15
+                // Bias the route into the upper ~70% of the map by reserving extra space below
+                // it (pad the south edge more than the north) for the docked vitals bar.
                 BoundingBox(
-                    north + latPad, east + lonPad,
-                    south - latPad, west - lonPad
+                    north + latSpan * 0.15, east + lonPad,
+                    south - latSpan * 0.55, west - lonPad
                 )
             } else null
             PreparedRoute(geoPointSegments, bb)
@@ -1264,7 +1143,7 @@ private fun TripMapCard(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(320.dp)
+                .height(400.dp)
                 .clip(RoundedCornerShape(12.dp))
         ) {
                 if (mapMounted) AndroidView(
@@ -1272,6 +1151,9 @@ private fun TripMapCard(
                         MapView(mapCtx).apply {
                             setTileSource(TileSourceFactory.MAPNIK)
                             setMultiTouchControls(true)
+                            // Dim + desaturate the tiles so the accent route and the docked
+                            // vitals bar read as a deliberate hero rather than raw map data.
+                            overlayManager.tilesOverlay.setColorFilter(mapDimFilter(isDark))
                             // Tell the parent vertical scroll to stop intercepting
                             // touches so single-finger drag pans the map instead
                             // of scrolling the page.
@@ -1423,13 +1305,150 @@ private fun TripMapCard(
                         .align(Alignment.TopStart)
                         .padding(12.dp)
                 )
-                MapOverlayChip(
-                    text = distanceLabel,
-                    palette = palette,
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(12.dp)
+                MapVitalsOverlay(
+                    trip = trip,
+                    units = units,
+                    currencySymbol = currencySymbol
                 )
+        }
+    }
+}
+
+// Dim + desaturate map tiles so overlaid data stays legible. The route polyline and markers
+// are separate overlays and are unaffected by this tile-only filter.
+private fun mapDimFilter(isDark: Boolean): ColorMatrixColorFilter {
+    val matrix = ColorMatrix().apply { setSaturation(if (isDark) 0.35f else 0.55f) }
+    val toneScale = if (isDark) 0.60f else 0.92f
+    val toneLift = if (isDark) 0f else 18f
+    matrix.postConcat(
+        ColorMatrix(
+            floatArrayOf(
+                toneScale, 0f, 0f, 0f, toneLift,
+                0f, toneScale, 0f, 0f, toneLift,
+                0f, 0f, toneScale, 0f, toneLift,
+                0f, 0f, 0f, 1f, 0f
+            )
+        )
+    )
+    return ColorMatrixColorFilter(matrix)
+}
+
+// Docked vitals bar — the two figures you compare trips by (consumption, cost/100), sitting on
+// a scrim across the bottom of the hero map. Values are white so they stay legible over the map
+// regardless of the car's accent luminance; the context line carries distance + duration.
+@Composable
+private fun BoxScope.MapVitalsOverlay(
+    trip: Trip,
+    units: Units?,
+    currencySymbol: String
+) {
+    val efficiency = trip.avgEfficiency
+        ?: trip.totalDistance.takeIf { it > 0.0 }?.let { trip.totalEnergyConsumed * 1000.0 / it }
+    val consumptionNumber = efficiency?.let { "%.0f".format(it) } ?: "—"
+    val consumptionUnit = if (efficiency != null) UnitFormatter.getEfficiencyUnit(units) else ""
+
+    // Distance is already in the user's unit (API pre-converts), so this yields cost per
+    // 100 km or per 100 mi with no conversion.
+    val per100 = trip.totalChargeCost?.takeIf { trip.totalDistance > 0.0 }
+        ?.let { it / trip.totalDistance * 100.0 }
+    val costNumber = per100?.let { "%.2f".format(it) } ?: "—"
+    val costUnit = if (per100 != null) currencySymbol else ""
+    val distanceUnit = UnitFormatter.getDistanceUnit(units)
+
+    val resources = LocalContext.current.resources
+    val contextLine = remember(trip.totalDistance, trip.totalDurationMin, units) {
+        val dist = UnitFormatter.formatDistance(trip.totalDistance, units, decimals = 0)
+        val dur = formatDuration(resources, trip.totalDurationMin)
+        "$dist · $dur"
+    }
+
+    Column(
+        modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(
+                    0f to Color.Transparent,
+                    0.45f to Color.Black.copy(alpha = 0.55f),
+                    1f to Color.Black.copy(alpha = 0.90f)
+                )
+            )
+            .padding(start = 18.dp, end = 18.dp, top = 44.dp, bottom = 18.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            MapVitalStat(
+                label = stringResource(R.string.consumption),
+                number = consumptionNumber,
+                unit = consumptionUnit,
+                modifier = Modifier.weight(1f)
+            )
+            Box(
+                modifier = Modifier
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .padding(vertical = 2.dp)
+                    .background(Color.White.copy(alpha = 0.16f))
+            )
+            MapVitalStat(
+                label = stringResource(R.string.trip_cost_per_100, distanceUnit),
+                number = costNumber,
+                unit = costUnit,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Text(
+            text = contextLine,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.68f),
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+    }
+}
+
+@Composable
+private fun MapVitalStat(
+    label: String,
+    number: String,
+    unit: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        Text(
+            text = label.uppercase(java.util.Locale.getDefault()),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White.copy(alpha = 0.62f),
+            maxLines = 1,
+            softWrap = false
+        )
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                text = number,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                maxLines = 1
+            )
+            if (unit.isNotEmpty()) {
+                Spacer(Modifier.width(3.dp))
+                Text(
+                    text = unit,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White.copy(alpha = 0.82f),
+                    modifier = Modifier.padding(bottom = 3.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material.icons.filled.Payments
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -76,6 +78,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -336,6 +339,13 @@ private fun TripDetailContent(
             onChargeClick = onChargeClick
         )
 
+        TripHeadlineMetrics(
+            trip = trip,
+            units = units,
+            currencySymbol = currencySymbol,
+            palette = palette
+        )
+
         TripTimeline(
             segments = timelineSegments,
             startDate = trip.startDate,
@@ -491,6 +501,97 @@ private fun TripDetailContent(
         )
 
         Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+// === Headline metrics — the two figures you compare trips by, right under the map ===
+
+@Composable
+private fun TripHeadlineMetrics(
+    trip: Trip,
+    units: Units?,
+    currencySymbol: String,
+    palette: CarColorPalette
+) {
+    // Average consumption (Wh/km or Wh/mi). Prefer the pre-computed value; fall back to
+    // energy-consumed / distance (same fallback the energy-flow card uses).
+    val efficiency = trip.avgEfficiency
+        ?: trip.totalDistance.takeIf { it > 0.0 }?.let { trip.totalEnergyConsumed * 1000.0 / it }
+    val consumptionValue = efficiency
+        ?.let { UnitFormatter.formatEfficiency(it, units, decimals = 0) }
+        ?: "—"
+
+    // Charging cost per 100 distance units. Distance is already in the user's unit (API
+    // pre-converts), so this arithmetic yields "/100 km" or "/100 mi" with no conversion.
+    val per100 = trip.totalChargeCost?.takeIf { trip.totalDistance > 0.0 }
+        ?.let { it / trip.totalDistance * 100.0 }
+    val costValue = per100?.let { "%.2f %s".format(it, currencySymbol) } ?: "—"
+    val distanceUnit = UnitFormatter.getDistanceUnit(units)
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        HeadlineMetricTile(
+            icon = Icons.Filled.Speed,
+            label = stringResource(R.string.consumption),
+            value = consumptionValue,
+            accent = palette.accent,
+            modifier = Modifier.weight(1f)
+        )
+        HeadlineMetricTile(
+            icon = Icons.Filled.Payments,
+            label = stringResource(R.string.trip_cost_per_100, distanceUnit),
+            value = costValue,
+            accent = palette.accent,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+// Accent stat tile — mirrors DurationTile so the headline metrics read as one family with
+// the Driving / Charging tiles in the timeline below.
+@Composable
+private fun HeadlineMetricTile(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(accent.copy(alpha = 0.12f))
+            .padding(vertical = 12.dp, horizontal = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(15.dp),
+                tint = accent
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = label.uppercase(java.util.Locale.getDefault()),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                softWrap = false
+            )
+        }
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1,
+            softWrap = false
+        )
     }
 }
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1100,6 +1100,10 @@
     <string name="trip_driving_time">Temps de conducció</string>
     <string name="trip_energy_charged">Energia carregada</string>
     <string name="trip_charge_cost">Cost de càrrega</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">Consum</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">Cost / 100 %1$s</string>
     <string name="trip_leg_drive">Trajecte %1$d</string>
     <string name="trip_leg_charge">Càrrega %1$d</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1128,6 +1128,10 @@
     <string name="trip_energy_charged">Geladene Energie</string>
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Ladekosten</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">Verbrauch</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">Kosten / 100 %1$s</string>
     <!-- Drive leg label with number -->
     <string name="trip_leg_drive">Fahrt %1$d</string>
     <!-- Charge leg label with number -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1100,6 +1100,10 @@
     <string name="trip_driving_time">Tiempo de conducción</string>
     <string name="trip_energy_charged">Energía cargada</string>
     <string name="trip_charge_cost">Coste de carga</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">Consumo</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">Coste / 100 %1$s</string>
     <string name="trip_leg_drive">Trayecto %1$d</string>
     <string name="trip_leg_charge">Carga %1$d</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1100,6 +1100,10 @@
     <string name="trip_driving_time">Tempo di guida</string>
     <string name="trip_energy_charged">Energia ricaricata</string>
     <string name="trip_charge_cost">Costo ricarica</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">Consumo</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">Costo / 100 %1$s</string>
     <string name="trip_leg_drive">Tratta %1$d</string>
     <string name="trip_leg_charge">Ricarica %1$d</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1101,6 +1101,10 @@
     <string name="trip_driving_time">驾驶时间</string>
     <string name="trip_energy_charged">充入能量</string>
     <string name="trip_charge_cost">充电费用</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">能耗</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">费用 / 100 %1$s</string>
     <string name="trip_leg_drive">行驶 %1$d</string>
     <string name="trip_leg_charge">充电 %1$d</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1131,6 +1131,10 @@
     <string name="trip_energy_charged">Energy charged</string>
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Charge cost</string>
+    <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
+    <string name="consumption">Consumption</string>
+    <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->
+    <string name="trip_cost_per_100">Cost / 100 %1$s</string>
     <!-- Drive leg label with number -->
     <string name="trip_leg_drive">Drive %1$d</string>
     <!-- Charge leg label with number -->


### PR DESCRIPTION
## What

Adds two headline metric tiles directly below the route map on the **Trip Detail** screen:

- **Consumption** — the trip's average efficiency (`Wh/km` / `Wh/mi`)
- **Cost / 100 km** — charging cost per 100 distance units (`/100 km` / `/100 mi`)

These are the two figures you actually compare trips by. Both values already existed on the screen but were buried lower down (the energy-flow card and the cost-donut pill); this promotes them to the top.

## How

- New `TripHeadlineMetrics` composable inserted between `TripMapCard` and `TripTimeline` in `TripDetailContent`.
- Tiles are a clone of the existing `DurationTile` (accent @ 12% bg, 12dp radius, `headlineSmall` accent value, uppercase `labelSmall` label) so they read as one family with the Driving / Charging tiles just below.
- **Consumption** = `Trip.avgEfficiency`, falling back to `energyConsumed·1000 / distance` (same fallback the energy-flow card uses).
- **Cost / 100** = `totalChargeCost / totalDistance · 100`.
- Units: values come pre-converted from the API — **no conversion math**; labels come from `UnitFormatter.getEfficiencyUnit` / `getDistanceUnit`. Missing values (e.g. a trip with no charging) render a muted `—`.
- New strings `consumption` and `trip_cost_per_100` (with a `%1$s` unit placeholder) added to all six locales (en, it, es, ca, de, zh).

## Testing

- `./gradlew lintDebug` — clean (no hardcoded-string violations).
- Installed on Pixel 6a and verified the tiles render below the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)