### PR TITLE
Fix imperial-unit double-conversion + remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.
+
 ## [1.10.0] - 2026-07-01
 
 Compare drives and charges against your own history, a trip-detail screen that puts the map and its key numbers front and centre, and redesigned charge & drive detail screens.

--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -14,13 +14,7 @@ interface AggregateDao {
     // === Drive Detail Aggregates ===
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertDriveAggregate(aggregate: DriveDetailAggregate)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertDriveAggregates(aggregates: List<DriveDetailAggregate>)
-
-    @Query("SELECT * FROM drive_detail_aggregates WHERE driveId = :driveId")
-    suspend fun getDriveAggregate(driveId: Int): DriveDetailAggregate?
 
     @Query("SELECT * FROM drive_detail_aggregates WHERE carId = :carId")
     suspend fun getDriveAggregatesForCar(carId: Int): List<DriveDetailAggregate>
@@ -378,13 +372,6 @@ interface AggregateDao {
     @Query("SELECT COUNT(*) FROM charge_detail_aggregates WHERE carId = :carId AND schemaVersion >= :minVersion")
     suspend fun countChargeAggregatesWithSchema(carId: Int, minVersion: Int): Int
 
-    // Flow-based counts for real-time progress updates (Room emits on table changes)
-    @Query("SELECT COUNT(*) FROM drive_detail_aggregates WHERE carId = :carId")
-    fun observeDriveAggregateCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
-
-    @Query("SELECT COUNT(*) FROM charge_detail_aggregates WHERE carId = :carId")
-    fun observeChargeAggregateCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
-
     // Schema-version-aware Flow counts (for accurate progress during schema migrations)
     @Query("SELECT COUNT(*) FROM drive_detail_aggregates WHERE carId = :carId AND schemaVersion >= :minVersion")
     fun observeDriveAggregateCountWithSchema(carId: Int, minVersion: Int): kotlinx.coroutines.flow.Flow<Int>
@@ -560,37 +547,6 @@ interface AggregateDao {
     """)
     suspend fun countUniqueDriveCitiesInRange(carId: Int, startDate: String, endDate: String): Int
 
-    @Query("""
-        SELECT a.startCity as city, a.startCountryCode as countryCode, COUNT(*) as driveCount
-        FROM drive_detail_aggregates a
-        WHERE a.carId = :carId AND a.startCity IS NOT NULL
-        GROUP BY a.startCity, a.startCountryCode
-        ORDER BY driveCount DESC
-        LIMIT :limit
-    """)
-    suspend fun getTopDriveCities(carId: Int, limit: Int = 5): List<CityDriveCount>
-
-    @Query("""
-        SELECT a.startCity as city, a.startCountryCode as countryCode, COUNT(*) as driveCount
-        FROM drive_detail_aggregates a
-        JOIN drives_summary d ON a.driveId = d.driveId
-        WHERE a.carId = :carId AND a.startCity IS NOT NULL
-        AND d.startDate >= :startDate AND d.startDate < :endDate
-        GROUP BY a.startCity, a.startCountryCode
-        ORDER BY driveCount DESC
-        LIMIT :limit
-    """)
-    suspend fun getTopDriveCitiesInRange(carId: Int, startDate: String, endDate: String, limit: Int = 5): List<CityDriveCount>
-
-    @Query("""
-        SELECT a.startRegionName as region, a.startCountryCode as countryCode, COUNT(*) as driveCount
-        FROM drive_detail_aggregates a
-        WHERE a.carId = :carId AND a.startRegionName IS NOT NULL
-        GROUP BY a.startRegionName, a.startCountryCode
-        ORDER BY driveCount DESC
-    """)
-    suspend fun getDrivesByRegion(carId: Int): List<RegionDriveCount>
-
     // === Deep Stats: Cities/Countries for Charges ===
 
     @Query("""
@@ -598,12 +554,6 @@ interface AggregateDao {
         WHERE carId = :carId AND countryCode IS NOT NULL
     """)
     suspend fun countUniqueChargeCountries(carId: Int): Int
-
-    @Query("""
-        SELECT COUNT(DISTINCT city) FROM charge_detail_aggregates
-        WHERE carId = :carId AND city IS NOT NULL
-    """)
-    suspend fun countUniqueChargeCities(carId: Int): Int
 
     @Query("""
         SELECT a.city, a.countryCode, COUNT(*) as chargeCount, SUM(c.energyAdded) as totalEnergy
@@ -801,14 +751,6 @@ interface AggregateDao {
     suspend fun getDcChargeSummaries(carId: Int): List<ChargeSummary>
 
     /** Drive start coordinates for trip map markers. */
-    @Query("""
-        SELECT driveId, startLatitude, startLongitude
-        FROM drive_detail_aggregates
-        WHERE driveId IN (:driveIds)
-        AND startLatitude IS NOT NULL AND startLongitude IS NOT NULL
-    """)
-    suspend fun getDriveCoordinates(driveIds: List<Int>): List<DriveCoordinateResult>
-
     /** Drive start + end coordinates for trip country resolution. */
     @Query("""
         SELECT driveId, startLatitude, startLongitude, endLatitude, endLongitude
@@ -853,24 +795,6 @@ data class CountryVisitResult(
     val totalDistanceKm: Double,
     val totalChargeEnergyKwh: Double,
     val chargeCount: Int
-)
-
-/**
- * Result of top drive cities query.
- */
-data class CityDriveCount(
-    val city: String,
-    val countryCode: String?,
-    val driveCount: Int
-)
-
-/**
- * Result of drives by region query.
- */
-data class RegionDriveCount(
-    val region: String,
-    val countryCode: String?,
-    val driveCount: Int
 )
 
 /**
@@ -922,12 +846,6 @@ data class ChargeLocationResult(
 )
 
 // === Trip Detection Queries ===
-
-data class DriveCoordinateResult(
-    val driveId: Int,
-    val startLatitude: Double,
-    val startLongitude: Double
-)
 
 data class DriveEdgeCoordinateResult(
     val driveId: Int,

--- a/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
@@ -14,20 +14,11 @@ interface ChargeSummaryDao {
     @Upsert
     suspend fun upsertAll(charges: List<ChargeSummary>)
 
-    @Upsert
-    suspend fun upsert(charge: ChargeSummary)
-
     @Query("SELECT * FROM charges_summary WHERE chargeId = :chargeId")
     suspend fun get(chargeId: Int): ChargeSummary?
 
-    @Query("SELECT * FROM charges_summary WHERE carId = :carId ORDER BY startDate DESC")
-    fun observeAll(carId: Int): Flow<List<ChargeSummary>>
-
     @Query("SELECT * FROM charges_summary WHERE carId = :carId ORDER BY startDate ASC")
     suspend fun getAllForCar(carId: Int): List<ChargeSummary>
-
-    @Query("SELECT MAX(chargeId) FROM charges_summary WHERE carId = :carId")
-    suspend fun getMaxChargeId(carId: Int): Int?
 
     @Query("DELETE FROM charges_summary WHERE carId = :carId")
     suspend fun deleteAllForCar(carId: Int)

--- a/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
@@ -14,20 +14,11 @@ interface DriveSummaryDao {
     @Upsert
     suspend fun upsertAll(drives: List<DriveSummary>)
 
-    @Upsert
-    suspend fun upsert(drive: DriveSummary)
-
     @Query("SELECT * FROM drives_summary WHERE driveId = :driveId")
     suspend fun get(driveId: Int): DriveSummary?
 
-    @Query("SELECT * FROM drives_summary WHERE carId = :carId ORDER BY startDate DESC")
-    fun observeAll(carId: Int): Flow<List<DriveSummary>>
-
     @Query("SELECT * FROM drives_summary WHERE carId = :carId ORDER BY startDate ASC")
     suspend fun getAllForCar(carId: Int): List<DriveSummary>
-
-    @Query("SELECT MAX(driveId) FROM drives_summary WHERE carId = :carId")
-    suspend fun getMaxDriveId(carId: Int): Int?
 
     @Query("DELETE FROM drives_summary WHERE carId = :carId")
     suspend fun deleteAllForCar(carId: Int)

--- a/app/src/main/java/com/matedroid/data/local/dao/GeocodeQueueDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/GeocodeQueueDao.kt
@@ -45,10 +45,6 @@ interface GeocodeQueueDao {
     @Query("DELETE FROM geocode_queue WHERE carId = :carId")
     suspend fun clearForCar(carId: Int)
 
-    // Clear all failed items (attempts >= 3)
-    @Query("DELETE FROM geocode_queue WHERE attempts >= 3")
-    suspend fun clearFailed()
-
     // Count total items in queue (including failed)
     @Query("SELECT COUNT(*) FROM geocode_queue")
     suspend fun countTotal(): Int

--- a/app/src/main/java/com/matedroid/data/local/dao/SyncStateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/SyncStateDao.kt
@@ -4,9 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Update
 import com.matedroid.data.local.entity.SyncState
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface SyncStateDao {
@@ -14,17 +12,8 @@ interface SyncStateDao {
     @Query("SELECT * FROM sync_state WHERE carId = :carId")
     suspend fun get(carId: Int): SyncState?
 
-    @Query("SELECT * FROM sync_state WHERE carId = :carId")
-    fun observe(carId: Int): Flow<SyncState?>
-
-    @Query("SELECT * FROM sync_state")
-    fun observeAll(): Flow<List<SyncState>>
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(syncState: SyncState)
-
-    @Update
-    suspend fun update(syncState: SyncState)
 
     // Summary sync completion
     @Query("""
@@ -71,10 +60,4 @@ interface SyncStateDao {
         WHERE carId = :carId
     """)
     suspend fun resetForResync(carId: Int)
-
-    @Query("DELETE FROM sync_state WHERE carId = :carId")
-    suspend fun delete(carId: Int)
-
-    @Query("DELETE FROM sync_state")
-    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -54,14 +54,6 @@ object UnitFormatter {
     }
 
     /**
-     * Format distance value without unit label (just the number).
-     * Value is already in km (metric) or mi (imperial) as returned by the API.
-     */
-    fun formatDistanceValue(value: Double, units: Units?, decimals: Int = 1): Double {
-        return value
-    }
-
-    /**
      * Get the distance unit label
      */
     fun getDistanceUnit(units: Units?): String {
@@ -78,14 +70,6 @@ object UnitFormatter {
         } else {
             "%.${decimals}f°C".format(value)
         }
-    }
-
-    /**
-     * Format temperature value without unit label.
-     * Value is already in the user's preferred unit as returned by the API.
-     */
-    fun formatTemperatureValue(value: Double, units: Units?): Double {
-        return value
     }
 
     /**

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -2308,7 +2308,7 @@ private fun VehicleInfoCard(
                     NavButton(
                         title = stringResource(R.string.nav_mileage),
                         value = status.odometer?.let {
-                            val value = UnitFormatter.formatDistanceValue(it, units, 0)
+                            val value = it
                             "%,.0f %s".format(value, UnitFormatter.getDistanceUnit(units))
                         } ?: "--",
                         icon = CustomIcons.Road,
@@ -2450,7 +2450,7 @@ private fun TripsHeroTile(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
                                 text = run {
-                                    val v = UnitFormatter.formatDistanceValue(latestTrip.totalDistance, units, 0)
+                                    val v = latestTrip.totalDistance
                                     "%,.0f %s".format(v, UnitFormatter.getDistanceUnit(units))
                                 },
                                 style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -900,11 +900,8 @@ private fun SpeedChartCard(
     val speeds = remember(positions) { positions.mapNotNull { it.speed?.toFloat() } }
     if (speeds.size < 2) return
 
-    val isImperial = units?.isImperial == true
-    val stableConvertValue: (Float) -> Float = remember(isImperial) {
-        { value: Float -> if (isImperial) (value * 0.621371f) else value }
-    }
-
+    // Speed is already in the user's unit (the API pre-converts before we store
+    // it), so the chart plots the raw value — no km/h→mph math here.
     ChartCard(
         title = stringResource(R.string.speed_profile),
         icon = Icons.Default.Speed,
@@ -914,8 +911,7 @@ private fun SpeedChartCard(
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,
-        fractionToTimeLabel = fractionToTimeLabel,
-        convertValue = stableConvertValue
+        fractionToTimeLabel = fractionToTimeLabel
     )
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -523,7 +523,7 @@ private fun DriveItem(
         accent = palette.accent,
         dateline = formatEditorialDate(drive.startDate, is24Hour),
         title = "$startCity → $endCity",
-        heroValue = "%.0f".format(UnitFormatter.formatDistanceValue(drive.distance ?: 0.0, units)),
+        heroValue = "%.0f".format(drive.distance ?: 0.0),
         heroUnit = UnitFormatter.getDistanceUnit(units).uppercase(java.util.Locale.getDefault()),
         onClick = onClick,
     ) {

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -1298,13 +1298,6 @@ private fun DayTripRow(
                     Spacer(modifier = Modifier.height(4.dp))
                     // Energy cost
                     Row(verticalAlignment = Alignment.CenterVertically) {
-//                        Icon(
-//                            imageVector = Icons.Filled.AttachMoney,
-//                            contentDescription = null,
-//                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-//                            modifier = Modifier.size(14.dp)
-//                        )
-//                        Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = "%,.2f %s".format(dayData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodySmall

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageViewModel.kt
@@ -260,7 +260,6 @@ class MileageViewModel @Inject constructor(
                 is ApiResult.Success -> {
                     val drives = drivesResult.data
                     val charges = (chargesResult as? ApiResult.Success)?.data ?: emptyList()
-                    val isImperial = _uiState.value.units?.isImperial == true
 
                     // Pre-parse all dates and run the lifetime / yearly
                     // aggregation in a single Dispatchers.Default block so the
@@ -279,7 +278,7 @@ class MileageViewModel @Inject constructor(
                         val tc = charges.mapNotNull { c ->
                             parseDateTime(c.startDate)?.let { TimedCharge(c, it) }
                         }
-                        PreparedAndYear(td, tc, computeYearAggregation(td, tc, isImperial))
+                        PreparedAndYear(td, tc, computeYearAggregation(td, tc))
                     }
 
                     timedDrives = prepared.timedDrives
@@ -317,11 +316,10 @@ class MileageViewModel @Inject constructor(
     }
 
     private suspend fun aggregateByMonth(year: Int) {
-        val isImperial = _uiState.value.units?.isImperial == true
         val drivesSnapshot = timedDrives
         val chargesSnapshot = timedCharges
         val agg = withContext(Dispatchers.Default) {
-            computeMonthAggregation(drivesSnapshot, chargesSnapshot, year, isImperial)
+            computeMonthAggregation(drivesSnapshot, chargesSnapshot, year)
         }
         _uiState.update {
             it.copy(
@@ -387,7 +385,6 @@ private fun parseDateTime(dateStr: String?): LocalDateTime? =
 private fun computeYearAggregation(
     drives: List<TimedDrive>,
     charges: List<TimedCharge>,
-    isImperial: Boolean,
 ): YearAggregation {
     val grouped = drives.groupBy { it.dateTime.year }
     val chargesByYear = charges.groupBy { it.dateTime.year }
@@ -424,8 +421,9 @@ private fun computeYearAggregation(
     val totalLifetimeDistance = yearlyData.sumOf { it.totalDistance }
     val totalLifetimeDriveCount = yearlyData.sumOf { it.driveCount }
     val totalLifetimeEnergy = yearlyData.sumOf { it.totalEnergy }
-    val distanceForEfficiency = if (isImperial) totalLifetimeDistance * 0.621371 else totalLifetimeDistance
-    val avgLifetimeEnergyDistance = if (distanceForEfficiency > 0) (totalLifetimeEnergy * 1000.0) / distanceForEfficiency else 0.0
+    // Distance is already in the user's unit (the API pre-converts before we
+    // store it), so the efficiency denominator is used as-is — no km→mi math.
+    val avgLifetimeEnergyDistance = if (totalLifetimeDistance > 0) (totalLifetimeEnergy * 1000.0) / totalLifetimeDistance else 0.0
     val totalLifetimeEnergyCost = charges.mapNotNull { it.charge.cost }.sum().takeIf { it > 0 }
 
     val firstDriveDate = drives.minByOrNull { it.dateTime }?.dateTime?.toLocalDate()
@@ -457,7 +455,6 @@ private fun computeMonthAggregation(
     drives: List<TimedDrive>,
     charges: List<TimedCharge>,
     year: Int,
-    isImperial: Boolean,
 ): MonthAggregation {
     val yearDrives = drives.filter { it.dateTime.year == year }
     val grouped = yearDrives.groupBy { YearMonth.of(it.dateTime.year, it.dateTime.month) }
@@ -498,8 +495,9 @@ private fun computeMonthAggregation(
     val yearDriveCount = monthlyData.sumOf { it.driveCount }
     val avgMonthlyDistance = if (monthlyData.isNotEmpty()) yearTotalDistance / monthlyData.size else 0.0
     val yearTotalEnergy = monthlyData.sumOf { it.totalEnergy }
-    val distanceForEfficiency = if (isImperial) yearTotalDistance * 0.621371 else yearTotalDistance
-    val avgYearEnergyDistance = if (distanceForEfficiency > 0) (yearTotalEnergy * 1000.0) / distanceForEfficiency else 0.0
+    // Distance is already in the user's unit (the API pre-converts before we
+    // store it), so the efficiency denominator is used as-is — no km→mi math.
+    val avgYearEnergyDistance = if (yearTotalDistance > 0) (yearTotalEnergy * 1000.0) / yearTotalDistance else 0.0
     val yearTotalEnergyCost = monthlyData.mapNotNull { it.totalEnergyCost }.sum().takeIf { it > 0 }
 
     return MonthAggregation(

--- a/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
@@ -192,7 +192,7 @@ private fun PreviewSummary(preview: Trip?, units: com.matedroid.data.api.models.
             Spacer(Modifier.height(4.dp))
             val meta = if (preview != null) {
                 val dist = "%,.0f %s".format(
-                    UnitFormatter.formatDistanceValue(preview.totalDistance, units, 0),
+                    preview.totalDistance,
                     UnitFormatter.getDistanceUnit(units)
                 )
                 val dur = formatDuration(LocalContext.current.resources, preview.totalDurationMin)

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1732,7 +1732,7 @@ private fun DriveLegCard(
             Column(horizontalAlignment = Alignment.End) {
                 Text(
                     text = "%.1f %s".format(
-                        UnitFormatter.formatDistanceValue(leg.drive.distance, units),
+                        leg.drive.distance,
                         UnitFormatter.getDistanceUnit(units)
                     ),
                     style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
First slice of a clean-code pass over the codebase: **Tier 0** (correctness bugs surfaced during the audit) and **Tier 1** (verified dead code). No behavioural change beyond the two bug fixes.

## Tier 0 — correctness bugs (user-facing)
Per the project rule, TeslamateAPI pre-converts all values to the user's unit system, so `UnitFormatter`/downstream must never re-apply conversion math. Two spots violated this and shipped wrong numbers to **miles/imperial** users:

- `MileageViewModel` (lifetime + yearly efficiency): multiplied the already-miles distance by `0.621371`, making the Wh/mi denominator ~40% too small.
- `DriveDetailScreen` (speed-profile chart): multiplied already-mph speeds by `0.621371` (and it was the *distance* factor applied to a speed).

Both conversions removed; the now-dead `isImperial` plumbing that fed them was cleaned up.

## Tier 1 — dead code removal (internal, no user impact)
All verified zero-caller before removal:
- **20 unused DAO methods** across `AggregateDao`, `Charge/DriveSummaryDao`, `SyncStateDao`, `GeocodeQueueDao` (single-row `upsert`, `observeAll`, `getMax*`, `observe/update/delete/deleteAll`, the non-`WithSchema` aggregate-count flows superseded by their schema-aware variants, and several unused stats/coordinate queries).
- **Orphaned result types** left behind: `CityDriveCount`, `RegionDriveCount`, `DriveCoordinateResult`, plus now-unused `Flow`/`Update` imports.
- **`UnitFormatter.formatTemperatureValue`** (no callers) and **`formatDistanceValue`** (a no-op returning its input) — its 5 call sites inlined.
- A commented-out `Icon`/`Spacer` block in `MileageScreen`.

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleDebug` — all green.
- Installed on the test device.

This is part 1 of a larger refactor plan; the de-duplication/abstraction tiers (chart components, charge/drive parallel screens, repository wrappers, mega-screen splits) are deliberately **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)