### PR TITLE
Tier 2: de-duplication pass (repo wrappers, formatters, shared composables, charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.
+
 ### Fixed
 - **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.
 

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -24,6 +24,7 @@ import java.net.UnknownHostException
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.net.ssl.SSLException
+import retrofit2.Response
 
 sealed class ApiResult<out T> {
     data class Success<T>(val data: T) : ApiResult<T>()
@@ -214,63 +215,38 @@ class TeslamateRepository @Inject constructor(
         }
     }
 
-    suspend fun getCars(): ApiResult<List<CarData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCars()
-                if (response.isSuccessful) {
-                    val cars = response.body()?.data?.cars ?: emptyList()
-                    ApiResult.Success(cars)
-                } else {
-                    ApiResult.Error("Failed to fetch cars: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e // Let executeWithFallback handle it
-            }
+    /**
+     * Map a Retrofit [Response] to an [ApiResult]: on a successful HTTP status,
+     * run [extract] on the (nullable) body and wrap a non-null result as Success,
+     * otherwise report the missing payload; on a non-2xx status, surface the code.
+     * [what] names the resource for the error messages.
+     *
+     * Any thrown exception propagates to [executeWithFallback], which owns the
+     * network-error / secondary-server handling.
+     */
+    private inline fun <B, T> Response<B>.toResult(
+        what: String,
+        extract: (B?) -> T?
+    ): ApiResult<T> =
+        if (isSuccessful) {
+            extract(body())?.let { ApiResult.Success(it) }
+                ?: ApiResult.Error("No $what returned")
+        } else {
+            ApiResult.Error("Failed to fetch $what: ${code()}", code())
         }
-    }
 
-    suspend fun getCar(carId: Int): ApiResult<CarData> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCar(carId)
-                if (response.isSuccessful) {
-                    val car = response.body()?.data?.cars?.firstOrNull()
-                    if (car != null) {
-                        ApiResult.Success(car)
-                    } else {
-                        ApiResult.Error("No car data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch car: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getCars(): ApiResult<List<CarData>> =
+        executeWithFallback { api -> api.getCars().toResult("cars") { it?.data?.cars ?: emptyList() } }
 
-    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCarStatus(carId)
-                if (response.isSuccessful) {
-                    val data = response.body()?.data
-                    val status = data?.status
-                    val units = data?.units ?: Units()
-                    if (status != null) {
-                        ApiResult.Success(CarStatusWithUnits(status, units))
-                    } else {
-                        ApiResult.Error("No status data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch status: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
+    suspend fun getCar(carId: Int): ApiResult<CarData> =
+        executeWithFallback { api -> api.getCar(carId).toResult("car") { it?.data?.cars?.firstOrNull() } }
+
+    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> =
+        executeWithFallback { api ->
+            api.getCarStatus(carId).toResult("status") { body ->
+                body?.data?.let { data -> data.status?.let { CarStatusWithUnits(it, data.units ?: Units()) } }
             }
         }
-    }
 
     suspend fun getCharges(
         carId: Int,
@@ -278,66 +254,35 @@ class TeslamateRepository @Inject constructor(
         endDate: String? = null,
         page: Int = 1,
         show: Int = 50000
-    ): ApiResult<List<ChargeData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCharges(carId, startDate, endDate, page = page, show = show)
-                if (response.isSuccessful) {
-                    val charges = response.body()?.data?.charges ?: emptyList()
-                    ApiResult.Success(charges)
-                } else {
-                    ApiResult.Error("Failed to fetch charges: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    ): ApiResult<List<ChargeData>> =
+        executeWithFallback { api ->
+            api.getCharges(carId, startDate, endDate, page = page, show = show)
+                .toResult("charges") { it?.data?.charges ?: emptyList() }
         }
-    }
 
     suspend fun getCurrentCharge(carId: Int): ApiResult<CurrentChargeOutcome> {
         return executeWithFallback { api ->
-            try {
-                val response = api.getCurrentCharge(carId)
-                if (response.isSuccessful) {
-                    val body = response.body()
-                    val detail = body?.data?.charge
-                    when {
-                        detail != null -> ApiResult.Success(CurrentChargeOutcome.Active(detail))
-                        // TeslamateAPI answers 200 + {"error": "..."} (or 204) when there is
-                        // no active charge — an authoritative answer, not a failure. At charge
-                        // start this is returned for a short while before the charge appears.
-                        body?.error != null || response.code() == 204 ->
-                            ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
-                        else -> ApiResult.Error("No current charge data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch current charge: ${response.code()}", response.code())
+            val response = api.getCurrentCharge(carId)
+            if (response.isSuccessful) {
+                val body = response.body()
+                val detail = body?.data?.charge
+                when {
+                    detail != null -> ApiResult.Success(CurrentChargeOutcome.Active(detail))
+                    // TeslamateAPI answers 200 + {"error": "..."} (or 204) when there is
+                    // no active charge — an authoritative answer, not a failure. At charge
+                    // start this is returned for a short while before the charge appears.
+                    body?.error != null || response.code() == 204 ->
+                        ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+                    else -> ApiResult.Error("No current charge data returned")
                 }
-            } catch (e: Exception) {
-                throw e
+            } else {
+                ApiResult.Error("Failed to fetch current charge: ${response.code()}", response.code())
             }
         }
     }
 
-    suspend fun getChargeDetail(carId: Int, chargeId: Int): ApiResult<ChargeDetail> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getChargeDetail(carId, chargeId)
-                if (response.isSuccessful) {
-                    val detail = response.body()?.data?.charge
-                    if (detail != null) {
-                        ApiResult.Success(detail)
-                    } else {
-                        ApiResult.Error("No charge detail returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch charge detail: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getChargeDetail(carId: Int, chargeId: Int): ApiResult<ChargeDetail> =
+        executeWithFallback { api -> api.getChargeDetail(carId, chargeId).toResult("charge detail") { it?.data?.charge } }
 
     suspend fun getDrives(
         carId: Int,
@@ -345,95 +290,23 @@ class TeslamateRepository @Inject constructor(
         endDate: String? = null,
         page: Int = 1,
         show: Int = 50000
-    ): ApiResult<List<DriveData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getDrives(carId, startDate, endDate, page = page, show = show)
-                if (response.isSuccessful) {
-                    val drives = response.body()?.data?.drives ?: emptyList()
-                    ApiResult.Success(drives)
-                } else {
-                    ApiResult.Error("Failed to fetch drives: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    ): ApiResult<List<DriveData>> =
+        executeWithFallback { api ->
+            api.getDrives(carId, startDate, endDate, page = page, show = show)
+                .toResult("drives") { it?.data?.drives ?: emptyList() }
         }
-    }
 
-    suspend fun getDriveDetail(carId: Int, driveId: Int): ApiResult<DriveDetail> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getDriveDetail(carId, driveId)
-                if (response.isSuccessful) {
-                    val detail = response.body()?.data?.drive
-                    if (detail != null) {
-                        ApiResult.Success(detail)
-                    } else {
-                        ApiResult.Error("No drive detail returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch drive detail: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getDriveDetail(carId: Int, driveId: Int): ApiResult<DriveDetail> =
+        executeWithFallback { api -> api.getDriveDetail(carId, driveId).toResult("drive detail") { it?.data?.drive } }
 
-    suspend fun getBatteryHealth(carId: Int): ApiResult<BatteryHealth> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getBatteryHealth(carId)
-                if (response.isSuccessful) {
-                    val health = response.body()?.data?.batteryHealth
-                    if (health != null) {
-                        ApiResult.Success(health)
-                    } else {
-                        ApiResult.Error("No battery health data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch battery health: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getBatteryHealth(carId: Int): ApiResult<BatteryHealth> =
+        executeWithFallback { api -> api.getBatteryHealth(carId).toResult("battery health") { it?.data?.batteryHealth } }
 
-    suspend fun getUpdates(carId: Int): ApiResult<List<UpdateData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getUpdates(carId, page = 1, show = 50000)
-                if (response.isSuccessful) {
-                    val updates = response.body()?.data?.updates ?: emptyList()
-                    ApiResult.Success(updates)
-                } else {
-                    ApiResult.Error("Failed to fetch updates: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    suspend fun getUpdates(carId: Int): ApiResult<List<UpdateData>> =
+        executeWithFallback { api ->
+            api.getUpdates(carId, page = 1, show = 50000).toResult("updates") { it?.data?.updates ?: emptyList() }
         }
-    }
 
-    suspend fun getGlobalSettings(): ApiResult<GlobalSettingsData> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getGlobalSettings()
-                if (response.isSuccessful) {
-                    val data = response.body()?.data
-                    if (data != null) {
-                        ApiResult.Success(data)
-                    } else {
-                        ApiResult.Error("No global settings data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch global settings: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getGlobalSettings(): ApiResult<GlobalSettingsData> =
+        executeWithFallback { api -> api.getGlobalSettings().toResult("global settings") { it?.data } }
 }

--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -133,4 +133,18 @@ object UnitFormatter {
     fun getSpeedUnit(units: Units?): String {
         return if (units?.isImperial == true) "mph" else "km/h"
     }
+
+    /**
+     * Format an energy amount given in kWh, rolling over to MWh at 1,000 kWh.
+     * Energy is not affected by the unit system, so no [Units] is needed.
+     */
+    fun formatEnergy(kwh: Double): String =
+        if (kwh >= 1000) "%,.1f MWh".format(kwh / 1000) else "%.0f kWh".format(kwh)
+
+    /**
+     * Format a monetary amount with its currency [symbol]. Uses 2 decimals for
+     * absolute amounts and 3 for per-kWh prices (which are typically well below 1).
+     */
+    fun formatCost(value: Double, symbol: String, perKwh: Boolean = false): String =
+        if (perKwh) "%,.3f %s".format(value, symbol) else "%,.2f %s".format(value, symbol)
 }

--- a/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
@@ -38,13 +38,6 @@ data class SelectedPoint(
     val position: Offset
 )
 
-data class DualChartData(
-    val displayPoints: List<Float>,
-    val minValue: Float,
-    val maxValue: Float,
-    val range: Float
-)
-
 data class DualSelectedPoint(
     val index: Int,
     val valueLeft: Float?,
@@ -80,18 +73,6 @@ fun prepareChartData(
     val maxValue = fixedMinMax?.second ?: displayPoints.maxOrNull() ?: 1f
     val range = (maxValue - minValue).coerceAtLeast(1f)
     return ChartData(displayPoints, minValue, maxValue, range)
-}
-
-fun prepareDualChartData(data: List<Float>): DualChartData {
-    val displayPoints = if (data.size > MAX_DISPLAY_POINTS) {
-        downsampleLTTB(data, MAX_DISPLAY_POINTS)
-    } else {
-        data
-    }
-    val minValue = displayPoints.minOrNull() ?: 0f
-    val maxValue = displayPoints.maxOrNull() ?: 1f
-    val range = (maxValue - minValue).coerceAtLeast(1f)
-    return DualChartData(displayPoints, minValue, maxValue, range)
 }
 
 // ── LTTB Downsampling ───────────────────────────────────────────────────────
@@ -406,6 +387,16 @@ fun DrawScope.drawGlowIndicator(center: Offset, color: Color) {
 }
 
 /**
+ * The [steps] + 1 Y-axis label values (top → bottom) plus a format string that
+ * switches to one decimal when adjacent integer labels would collide.
+ */
+private fun axisLabelValues(chartData: ChartData, steps: Int = 4): Pair<List<Float>, String> {
+    val rawValues = (0..steps).map { i -> chartData.maxValue - (chartData.range * i / steps) }
+    val needsDecimal = rawValues.zipWithNext().any { (a, b) -> "%.0f".format(a) == "%.0f".format(b) }
+    return rawValues to if (needsDecimal) "%.1f" else "%.0f"
+}
+
+/**
  * Draws Y-axis labels at 5 positions (including max), with automatic decimal
  * precision when the range is too small to differentiate integer values.
  */
@@ -422,18 +413,10 @@ fun DrawScope.drawYAxisLabels(
             isAntiAlias = true
         }
 
-        val gridLineCount = 4
+        val (rawValues, format) = axisLabelValues(chartData)
 
-        val rawValues = (0..gridLineCount).map { i ->
-            chartData.maxValue - (chartData.range * i / gridLineCount)
-        }
-        val needsDecimal = rawValues.zipWithNext().any { (a, b) ->
-            "%.0f".format(a) == "%.0f".format(b)
-        }
-        val format = if (needsDecimal) "%.1f" else "%.0f"
-
-        for (i in 0..gridLineCount) {
-            val y = height * i / gridLineCount
+        for (i in rawValues.indices) {
+            val y = height * i / (rawValues.size - 1)
             val label = format.format(rawValues[i]) + " $unit"
             // Position the label above line
             val textY = y - 4f
@@ -446,7 +429,7 @@ fun DrawScope.drawYAxisLabels(
  * Draws Y-axis labels for dual-axis chart (left or right side).
  */
 fun DrawScope.drawDualYAxisLabels(
-    chartData: DualChartData,
+    chartData: ChartData,
     unit: String,
     height: Float,
     isLeft: Boolean,
@@ -460,18 +443,11 @@ fun DrawScope.drawDualYAxisLabels(
             isAntiAlias = true
             textAlign = if (isLeft) Paint.Align.LEFT else Paint.Align.RIGHT
         }
-        val gridLineCount = 4
 
-        val rawValues = (0..gridLineCount).map { i ->
-            chartData.maxValue - (chartData.range * i / gridLineCount)
-        }
-        val needsDecimal = rawValues.zipWithNext().any { (a, b) ->
-            "%.0f".format(a) == "%.0f".format(b)
-        }
-        val format = if (needsDecimal) "%.1f" else "%.0f"
+        val (rawValues, format) = axisLabelValues(chartData)
 
-        for (i in 0..gridLineCount) {
-            val y = height * i / gridLineCount
+        for (i in rawValues.indices) {
+            val y = height * i / (rawValues.size - 1)
             val label = format.format(rawValues[i]) + " $unit"
             // Position the label above line
             val textY = y - 4f

--- a/app/src/main/java/com/matedroid/ui/components/ComparisonStats.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ComparisonStats.kt
@@ -2,14 +2,20 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -122,4 +128,60 @@ fun ComparisonVerdict(
             )
         }
     }
+}
+
+/** A selectable sort chip tinted with the car's [accent] colour when selected. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = accent.copy(alpha = 0.16f),
+            selectedLabelColor = accent
+        )
+    )
+}
+
+/** A coloured dot + label, used in the overlay-chart legends. */
+@Composable
+fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(5.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/** A small rounded pill for a secondary metric on a leaderboard row. */
+@Composable
+fun Pill(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 7.dp, vertical = 3.dp)
+    )
+}
+
+/** Medal emoji for the top three ranks, otherwise the plain rank number. */
+fun rankBadge(rank: Int): String = when (rank) {
+    1 -> "🥇"
+    2 -> "🥈"
+    3 -> "🥉"
+    else -> "$rank"
 }

--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -71,8 +71,8 @@ fun DualAxisLineChart(
     val tooltipBg = MaterialTheme.colorScheme.inverseSurface
     val tooltipFg = MaterialTheme.colorScheme.inverseOnSurface
 
-    val chartDataLeft = remember(dataLeft) { prepareDualChartData(dataLeft) }
-    val chartDataRight = remember(dataRight) { prepareDualChartData(dataRight) }
+    val chartDataLeft = remember(dataLeft) { prepareChartData(dataLeft, fixedMinMax = null) { it } }
+    val chartDataRight = remember(dataRight) { prepareChartData(dataRight, fixedMinMax = null) { it } }
 
     val density = LocalDensity.current
     val chartHeightPx = with(density) { chartHeight.toPx() }

--- a/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.util.formatDuration
 import kotlin.math.PI
@@ -249,7 +250,7 @@ private fun DonutCanvas(
                     maxLines = 1
                 )
                 Text(
-                    text = "%.2f %s".format(stop.cost, currencySymbol),
+                    text = UnitFormatter.formatCost(stop.cost, currencySymbol),
                     style = MaterialTheme.typography.headlineSmall,
                     color = color,
                     fontWeight = FontWeight.Bold
@@ -270,7 +271,7 @@ private fun DonutCanvas(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = "%.2f %s".format(totalCost, currencySymbol),
+                    text = UnitFormatter.formatCost(totalCost, currencySymbol),
                     style = MaterialTheme.typography.headlineSmall,
                     color = palette.accent,
                     fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -28,8 +27,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -63,12 +60,16 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.ComparisonVerdict
 import com.matedroid.ui.components.DeltaChip
 import com.matedroid.ui.components.DeltaTone
+import com.matedroid.ui.components.LegendItem
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.Pill
 import com.matedroid.ui.components.PowerSocOverlayChart
 import com.matedroid.ui.components.RowDelta
+import com.matedroid.ui.components.SortChip
 import com.matedroid.ui.components.isBetter
 import com.matedroid.ui.components.percentDelta
+import com.matedroid.ui.components.rankBadge
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDurationCompact
@@ -268,19 +269,6 @@ private fun CompareContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) },
-        colors = FilterChipDefaults.filterChipColors(
-            selectedContainerColor = accent.copy(alpha = 0.16f),
-            selectedLabelColor = accent
-        )
-    )
-}
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -362,23 +350,6 @@ private fun OverlayChartCard(
     }
 }
 
-@Composable
-private fun LegendItem(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(color)
-        )
-        Spacer(modifier = Modifier.width(5.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
 
 @Composable
 private fun CompareRow(
@@ -472,25 +443,6 @@ private fun chargeAvgMetricValue(a: ChargeAverage, sort: CompareSort): Double? =
 
 private fun chargeHigherIsBetter(sort: CompareSort): Boolean = sort == CompareSort.PEAK
 
-@Composable
-private fun Pill(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 7.dp, vertical = 3.dp)
-    )
-}
-
-private fun rankBadge(rank: Int): String = when (rank) {
-    1 -> "🥇"
-    2 -> "🥈"
-    3 -> "🥉"
-    else -> "$rank"
-}
 
 private fun valueFor(
     charge: ComparableCharge,

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -31,8 +30,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -69,12 +66,16 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.ComparisonVerdict
 import com.matedroid.ui.components.DeltaChip
 import com.matedroid.ui.components.DeltaTone
+import com.matedroid.ui.components.LegendItem
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.Pill
 import com.matedroid.ui.components.PowerSocOverlayChart
 import com.matedroid.ui.components.RowDelta
+import com.matedroid.ui.components.SortChip
 import com.matedroid.ui.components.isBetter
 import com.matedroid.ui.components.percentDelta
+import com.matedroid.ui.components.rankBadge
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDurationCompact
@@ -393,19 +394,6 @@ private fun averageValue(average: DriveAverage, sort: DriveCompareSort, units: U
         DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
     }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) },
-        colors = FilterChipDefaults.filterChipColors(
-            selectedContainerColor = accent.copy(alpha = 0.16f),
-            selectedLabelColor = accent
-        )
-    )
-}
 
 @Composable
 private fun OverlayChartCard(
@@ -624,23 +612,6 @@ private fun DurationBars(
     }
 }
 
-@Composable
-private fun LegendItem(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(color)
-        )
-        Spacer(modifier = Modifier.width(5.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
 
 @Composable
 private fun CompareRow(
@@ -701,25 +672,6 @@ private fun CompareRow(
     }
 }
 
-@Composable
-private fun Pill(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 7.dp, vertical = 3.dp)
-    )
-}
-
-private fun rankBadge(rank: Int): String = when (rank) {
-    1 -> "🥇"
-    2 -> "🥈"
-    3 -> "🥉"
-    else -> "$rank"
-}
 
 private fun valueFor(drive: ComparableDrive, sort: DriveCompareSort, units: Units?): String =
     when (sort) {

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -419,7 +419,7 @@ private fun YearRow(
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(yearData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(yearData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
@@ -662,7 +662,7 @@ private fun MonthRow(
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(monthData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(monthData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
@@ -871,12 +871,12 @@ private fun MonthSummaryCard(
             ) {
                 StatChip(
                     icon = Icons.Filled.ElectricBolt,
-                    value = formatEnergy(totalEnergy),
+                    value = UnitFormatter.formatEnergy(totalEnergy),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     icon = Icons.Filled.AttachMoney,
-                    value = "%,.2f %s".format(monthData?.totalEnergyCost ?: 0.0, currencySymbol),
+                    value = UnitFormatter.formatCost(monthData?.totalEnergyCost ?: 0.0, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -986,7 +986,7 @@ private fun SummaryRow(
             )
             SummaryItem(
                 icon = Icons.Filled.AttachMoney,
-                value = "%,.2f %s".format(totalEnergyCost ?: 0.0, currencySymbol),
+                value = UnitFormatter.formatCost(totalEnergyCost ?: 0.0, currencySymbol),
                 label = stringResource(R.string.mileage_total),
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -994,7 +994,7 @@ private fun SummaryRow(
             )
             SummaryItem(
                 icon = Icons.Outlined.BatteryChargingFull,
-                value = formatEnergy(totalEnergyUsed),
+                value = UnitFormatter.formatEnergy(totalEnergyUsed),
                 label = stringResource(R.string.mileage_total),
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -1299,7 +1299,7 @@ private fun DayTripRow(
                     // Energy cost
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(dayData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(dayData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
@@ -1346,9 +1346,6 @@ private fun DayTripRow(
         }
     }
 }
-
-private fun formatEnergy(kwh: Double): String =
-    if (kwh >= 1000) "%,.1f MWh".format(kwh / 1000) else "%.0f kWh".format(kwh)
 
 // ============================================================================
 // Level 4: Day Detail
@@ -1523,12 +1520,12 @@ private fun DaySummaryCard(
             ) {
                 StatChip(
                     icon = Icons.Filled.ElectricBolt,
-                    value = formatEnergy(dayData.totalEnergy),
+                    value = UnitFormatter.formatEnergy(dayData.totalEnergy),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     icon = Icons.Filled.AttachMoney,
-                    value = "%,.2f %s".format(dayData.totalEnergyCost ?: 0.0, currencySymbol),
+                    value = UnitFormatter.formatCost(dayData.totalEnergyCost ?: 0.0, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,7 +50,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -63,7 +61,6 @@ import com.matedroid.domain.model.YearFilter
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -333,37 +330,6 @@ private fun CountryCard(
     }
 }
 
-@Composable
-private fun StatChip(
-    icon: ImageVector,
-    value: String,
-    palette: CarColorPalette,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(palette.onSurface.copy(alpha = 0.05f))
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(14.dp),
-            tint = palette.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.labelMedium,
-            color = palette.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
 
 @Composable
 private fun EmptyState(palette: CarColorPalette) {
@@ -389,11 +355,3 @@ private fun EmptyState(palette: CarColorPalette) {
  * Get the localized country name for a given ISO country code.
  * Falls back to the country code if localization fails.
  */
-private fun getLocalizedCountryName(countryCode: String): String {
-    return try {
-        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
-            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
-    } catch (e: Exception) {
-        countryCode
-    }
-}

--- a/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
@@ -1,0 +1,65 @@
+package com.matedroid.ui.screens.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.matedroid.ui.theme.CarColorPalette
+import java.util.Locale
+
+/** Icon + value chip used on the countries- and regions-visited cards. */
+@Composable
+fun StatChip(
+    icon: ImageVector,
+    value: String,
+    palette: CarColorPalette,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(palette.onSurface.copy(alpha = 0.05f))
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = palette.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.labelMedium,
+            color = palette.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/** Resolve an ISO country code to its display name in the current locale, falling back to the code. */
+fun getLocalizedCountryName(countryCode: String): String {
+    return try {
+        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
+            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
+    } catch (e: Exception) {
+        countryCode
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -57,7 +56,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -1033,37 +1031,6 @@ private fun RegionCard(
     }
 }
 
-@Composable
-private fun StatChip(
-    icon: ImageVector,
-    value: String,
-    palette: CarColorPalette,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(palette.onSurface.copy(alpha = 0.05f))
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(14.dp),
-            tint = palette.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.labelMedium,
-            color = palette.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
 
 @Composable
 private fun EmptyState(palette: CarColorPalette) {
@@ -1094,12 +1061,4 @@ private fun formatDate(dateStr: String): String {
  * Get the localized country name for a given ISO country code.
  * Falls back to the country code if localization fails.
  */
-private fun getLocalizedCountryName(countryCode: String): String {
-    return try {
-        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
-            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
-    } catch (e: Exception) {
-        countryCode
-    }
-}
 

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -655,7 +655,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
             )
             StatItem(
                 label = stringResource(R.string.stats_energy_used),
-                value = formatEnergy(quickStats.totalEnergyConsumedKwh),
+                value = UnitFormatter.formatEnergy(quickStats.totalEnergyConsumedKwh),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -668,7 +668,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
             )
             StatItem(
                 label = stringResource(R.string.stats_cost_per_distance, UnitFormatter.getDistanceUnit(units)),
-                value = costPer100Km?.let { "%.2f %s".format(it, currencySymbol) } ?: "N/A",
+                value = costPer100Km?.let { UnitFormatter.formatCost(it, currencySymbol) } ?: "N/A",
                 modifier = Modifier.weight(1f)
             )
         }
@@ -690,7 +690,7 @@ private fun QuickStatsChargesCard(quickStats: QuickStats, palette: CarColorPalet
             )
             StatItem(
                 label = stringResource(R.string.energy_added),
-                value = formatEnergy(quickStats.totalEnergyAddedKwh),
+                value = UnitFormatter.formatEnergy(quickStats.totalEnergyAddedKwh),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -699,12 +699,12 @@ private fun QuickStatsChargesCard(quickStats: QuickStats, palette: CarColorPalet
             Row(modifier = Modifier.fillMaxWidth()) {
                 StatItem(
                     label = stringResource(R.string.total_cost),
-                    value = "%.2f %s".format(quickStats.totalCost, currencySymbol),
+                    value = UnitFormatter.formatCost(quickStats.totalCost, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
                 StatItem(
                     label = stringResource(R.string.stats_avg_cost_kwh),
-                    value = quickStats.avgCostPerKwh?.let { "%.3f %s".format(it, currencySymbol) } ?: "N/A",
+                    value = quickStats.avgCostPerKwh?.let { UnitFormatter.formatCost(it, currencySymbol, perKwh = true) } ?: "N/A",
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -820,13 +820,13 @@ private fun RecordsCard(
     }
     quickStats.mostExpensiveCharge?.let { charge ->
         charge.cost?.let { cost ->
-            batteryRecords.add(RecordData("💸", labelMostExpensive, "%.2f %s".format(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+            batteryRecords.add(RecordData("💸", labelMostExpensive, UnitFormatter.formatCost(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
         }
     }
     quickStats.mostExpensivePerKwhCharge?.let { charge ->
         charge.cost?.let { cost ->
             if (charge.energyAdded > 0) {
-                batteryRecords.add(RecordData("📈", labelPriciestKwh, "%.3f %s".format(cost / charge.energyAdded, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+                batteryRecords.add(RecordData("📈", labelPriciestKwh, UnitFormatter.formatCost(cost / charge.energyAdded, currencySymbol, perKwh = true), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
             }
         }
     }
@@ -1135,14 +1135,6 @@ private fun TemperatureStatsCard(deepStats: DeepStats, palette: CarColorPalette,
     }
 }
 
-private fun formatEnergy(kwh: Double): String {
-    return if (kwh >= 1000) {
-        "%.1f MWh".format(kwh / 1000)
-    } else {
-        "%.0f kWh".format(kwh)
-    }
-}
-
 @Composable
 private fun AcDcRatioCard(deepStats: DeepStats, palette: CarColorPalette) {
     val totalEnergy = deepStats.acChargeEnergyKwh + deepStats.dcChargeEnergyKwh
@@ -1163,12 +1155,12 @@ private fun AcDcRatioCard(deepStats: DeepStats, palette: CarColorPalette) {
         Row(modifier = Modifier.fillMaxWidth()) {
             StatItem(
                 label = stringResource(R.string.stats_ac_energy),
-                value = formatEnergy(deepStats.acChargeEnergyKwh),
+                value = UnitFormatter.formatEnergy(deepStats.acChargeEnergyKwh),
                 modifier = Modifier.weight(1f)
             )
             StatItem(
                 label = stringResource(R.string.stats_dc_energy),
-                value = formatEnergy(deepStats.dcChargeEnergyKwh),
+                value = UnitFormatter.formatEnergy(deepStats.dcChargeEnergyKwh),
                 modifier = Modifier.weight(1f)
             )
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -597,7 +597,7 @@ private fun ChargeCostCard(
                         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
                     ) {
                         EfficiencyPill(
-                            value = "%.2f %s".format(perKwh, currencySymbol),
+                            value = UnitFormatter.formatCost(perKwh, currencySymbol),
                             unit = "/ kWh",
                             palette = palette
                         )
@@ -647,7 +647,7 @@ private fun ChargeCostCard(
                                     )
                                 }
                                 Text(
-                                    text = "%.2f %s".format(charge.cost, currencySymbol),
+                                    text = UnitFormatter.formatCost(charge.cost ?: 0.0, currencySymbol),
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.Bold,
                                     color = shade


### PR DESCRIPTION
Second slice of the clean-code pass — **Tier 2 de-duplication**. Pure refactor, no behavioural change except one minor, deliberate formatting polish (noted below).

> **Base branch:** this PR targets `refactor/dead-code-and-unit-bugs` (PR #327), which it stacks on. Merge #327 first, or retarget this to `main` once #327 lands.

## What changed
- **`TeslamateRepository`: 12 API wrappers → one `Response.toResult` mapper.** Every fetch method repeated the same `executeWithFallback { isSuccessful … }` skeleton plus a dead `try/catch(e){throw e}`. Now each is one line; `getCurrentCharge` keeps its bespoke 204/`body.error` handling. ~180 lines gone.
- **Energy & cost formatting centralized in `UnitFormatter`.** Added `formatEnergy(kwh)` (kWh→MWh rollover) and `formatCost(value, symbol, perKwh)`. Removed two diverged copies of a private `formatEnergy` (one used `%,.1f`, the other `%.1f` for MWh) and routed the suffix-style `"…%s".format(x, currencySymbol)` cost sites through `formatCost`. Prefix-style `"$symbol%.2f"` sites left alone (different symbol placement).
- **Duplicated leaf composables extracted.** `SortChip`, `LegendItem`, `Pill`, `rankBadge` (byte-identical across the two Compare screens) → `ComparisonStats.kt`; `StatChip` + `getLocalizedCountryName` (identical across Countries/Regions) → new `GeoVisitedShared.kt`. Orphaned imports removed.
- **Chart data/label dedup.** `DualChartData` was field-identical to `ChartData` and `prepareDualChartData` was `prepareChartData(data, null){it}` — both removed. Extracted the shared Y-axis value/format computation into `axisLabelValues()`.

## User-visible
- Only one: large cost totals now show a thousands separator (e.g. `1,234.56`), consistent with distance/energy. Noted in CHANGELOG under Changed.

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleDebug` — all green.
- Installed on the test device.

## Deliberately NOT in this PR (deferred, per the agents' over-abstraction warnings and to keep this reviewable)
- Merging the duplicated `DateFilter`/`ChartGranularity`/sort-order enums + shared `SortMenu`
- Worker `ForegroundNotifier` extraction
- `FullscreenChartFrame` slot wrapper (unifies the two Fullscreen chart files)
- The `buildTimeSeries` generic binner for the Charges/Drives chart bucketing
- No `BaseComparisonViewModel`, no unified filter pipeline, no shared `GeoVisitedScreen` — these were judged over-abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)