### PR TITLE
Tier 2: full de-duplication pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.
+
 ### Fixed
 - **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.
 

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -24,6 +24,7 @@ import java.net.UnknownHostException
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.net.ssl.SSLException
+import retrofit2.Response
 
 sealed class ApiResult<out T> {
     data class Success<T>(val data: T) : ApiResult<T>()
@@ -214,63 +215,38 @@ class TeslamateRepository @Inject constructor(
         }
     }
 
-    suspend fun getCars(): ApiResult<List<CarData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCars()
-                if (response.isSuccessful) {
-                    val cars = response.body()?.data?.cars ?: emptyList()
-                    ApiResult.Success(cars)
-                } else {
-                    ApiResult.Error("Failed to fetch cars: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e // Let executeWithFallback handle it
-            }
+    /**
+     * Map a Retrofit [Response] to an [ApiResult]: on a successful HTTP status,
+     * run [extract] on the (nullable) body and wrap a non-null result as Success,
+     * otherwise report the missing payload; on a non-2xx status, surface the code.
+     * [what] names the resource for the error messages.
+     *
+     * Any thrown exception propagates to [executeWithFallback], which owns the
+     * network-error / secondary-server handling.
+     */
+    private inline fun <B, T> Response<B>.toResult(
+        what: String,
+        extract: (B?) -> T?
+    ): ApiResult<T> =
+        if (isSuccessful) {
+            extract(body())?.let { ApiResult.Success(it) }
+                ?: ApiResult.Error("No $what returned")
+        } else {
+            ApiResult.Error("Failed to fetch $what: ${code()}", code())
         }
-    }
 
-    suspend fun getCar(carId: Int): ApiResult<CarData> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCar(carId)
-                if (response.isSuccessful) {
-                    val car = response.body()?.data?.cars?.firstOrNull()
-                    if (car != null) {
-                        ApiResult.Success(car)
-                    } else {
-                        ApiResult.Error("No car data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch car: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getCars(): ApiResult<List<CarData>> =
+        executeWithFallback { api -> api.getCars().toResult("cars") { it?.data?.cars ?: emptyList() } }
 
-    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCarStatus(carId)
-                if (response.isSuccessful) {
-                    val data = response.body()?.data
-                    val status = data?.status
-                    val units = data?.units ?: Units()
-                    if (status != null) {
-                        ApiResult.Success(CarStatusWithUnits(status, units))
-                    } else {
-                        ApiResult.Error("No status data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch status: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
+    suspend fun getCar(carId: Int): ApiResult<CarData> =
+        executeWithFallback { api -> api.getCar(carId).toResult("car") { it?.data?.cars?.firstOrNull() } }
+
+    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> =
+        executeWithFallback { api ->
+            api.getCarStatus(carId).toResult("status") { body ->
+                body?.data?.let { data -> data.status?.let { CarStatusWithUnits(it, data.units ?: Units()) } }
             }
         }
-    }
 
     suspend fun getCharges(
         carId: Int,
@@ -278,66 +254,35 @@ class TeslamateRepository @Inject constructor(
         endDate: String? = null,
         page: Int = 1,
         show: Int = 50000
-    ): ApiResult<List<ChargeData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getCharges(carId, startDate, endDate, page = page, show = show)
-                if (response.isSuccessful) {
-                    val charges = response.body()?.data?.charges ?: emptyList()
-                    ApiResult.Success(charges)
-                } else {
-                    ApiResult.Error("Failed to fetch charges: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    ): ApiResult<List<ChargeData>> =
+        executeWithFallback { api ->
+            api.getCharges(carId, startDate, endDate, page = page, show = show)
+                .toResult("charges") { it?.data?.charges ?: emptyList() }
         }
-    }
 
     suspend fun getCurrentCharge(carId: Int): ApiResult<CurrentChargeOutcome> {
         return executeWithFallback { api ->
-            try {
-                val response = api.getCurrentCharge(carId)
-                if (response.isSuccessful) {
-                    val body = response.body()
-                    val detail = body?.data?.charge
-                    when {
-                        detail != null -> ApiResult.Success(CurrentChargeOutcome.Active(detail))
-                        // TeslamateAPI answers 200 + {"error": "..."} (or 204) when there is
-                        // no active charge — an authoritative answer, not a failure. At charge
-                        // start this is returned for a short while before the charge appears.
-                        body?.error != null || response.code() == 204 ->
-                            ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
-                        else -> ApiResult.Error("No current charge data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch current charge: ${response.code()}", response.code())
+            val response = api.getCurrentCharge(carId)
+            if (response.isSuccessful) {
+                val body = response.body()
+                val detail = body?.data?.charge
+                when {
+                    detail != null -> ApiResult.Success(CurrentChargeOutcome.Active(detail))
+                    // TeslamateAPI answers 200 + {"error": "..."} (or 204) when there is
+                    // no active charge — an authoritative answer, not a failure. At charge
+                    // start this is returned for a short while before the charge appears.
+                    body?.error != null || response.code() == 204 ->
+                        ApiResult.Success(CurrentChargeOutcome.NoActiveCharge)
+                    else -> ApiResult.Error("No current charge data returned")
                 }
-            } catch (e: Exception) {
-                throw e
+            } else {
+                ApiResult.Error("Failed to fetch current charge: ${response.code()}", response.code())
             }
         }
     }
 
-    suspend fun getChargeDetail(carId: Int, chargeId: Int): ApiResult<ChargeDetail> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getChargeDetail(carId, chargeId)
-                if (response.isSuccessful) {
-                    val detail = response.body()?.data?.charge
-                    if (detail != null) {
-                        ApiResult.Success(detail)
-                    } else {
-                        ApiResult.Error("No charge detail returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch charge detail: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getChargeDetail(carId: Int, chargeId: Int): ApiResult<ChargeDetail> =
+        executeWithFallback { api -> api.getChargeDetail(carId, chargeId).toResult("charge detail") { it?.data?.charge } }
 
     suspend fun getDrives(
         carId: Int,
@@ -345,95 +290,23 @@ class TeslamateRepository @Inject constructor(
         endDate: String? = null,
         page: Int = 1,
         show: Int = 50000
-    ): ApiResult<List<DriveData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getDrives(carId, startDate, endDate, page = page, show = show)
-                if (response.isSuccessful) {
-                    val drives = response.body()?.data?.drives ?: emptyList()
-                    ApiResult.Success(drives)
-                } else {
-                    ApiResult.Error("Failed to fetch drives: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    ): ApiResult<List<DriveData>> =
+        executeWithFallback { api ->
+            api.getDrives(carId, startDate, endDate, page = page, show = show)
+                .toResult("drives") { it?.data?.drives ?: emptyList() }
         }
-    }
 
-    suspend fun getDriveDetail(carId: Int, driveId: Int): ApiResult<DriveDetail> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getDriveDetail(carId, driveId)
-                if (response.isSuccessful) {
-                    val detail = response.body()?.data?.drive
-                    if (detail != null) {
-                        ApiResult.Success(detail)
-                    } else {
-                        ApiResult.Error("No drive detail returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch drive detail: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getDriveDetail(carId: Int, driveId: Int): ApiResult<DriveDetail> =
+        executeWithFallback { api -> api.getDriveDetail(carId, driveId).toResult("drive detail") { it?.data?.drive } }
 
-    suspend fun getBatteryHealth(carId: Int): ApiResult<BatteryHealth> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getBatteryHealth(carId)
-                if (response.isSuccessful) {
-                    val health = response.body()?.data?.batteryHealth
-                    if (health != null) {
-                        ApiResult.Success(health)
-                    } else {
-                        ApiResult.Error("No battery health data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch battery health: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getBatteryHealth(carId: Int): ApiResult<BatteryHealth> =
+        executeWithFallback { api -> api.getBatteryHealth(carId).toResult("battery health") { it?.data?.batteryHealth } }
 
-    suspend fun getUpdates(carId: Int): ApiResult<List<UpdateData>> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getUpdates(carId, page = 1, show = 50000)
-                if (response.isSuccessful) {
-                    val updates = response.body()?.data?.updates ?: emptyList()
-                    ApiResult.Success(updates)
-                } else {
-                    ApiResult.Error("Failed to fetch updates: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
+    suspend fun getUpdates(carId: Int): ApiResult<List<UpdateData>> =
+        executeWithFallback { api ->
+            api.getUpdates(carId, page = 1, show = 50000).toResult("updates") { it?.data?.updates ?: emptyList() }
         }
-    }
 
-    suspend fun getGlobalSettings(): ApiResult<GlobalSettingsData> {
-        return executeWithFallback { api ->
-            try {
-                val response = api.getGlobalSettings()
-                if (response.isSuccessful) {
-                    val data = response.body()?.data
-                    if (data != null) {
-                        ApiResult.Success(data)
-                    } else {
-                        ApiResult.Error("No global settings data returned")
-                    }
-                } else {
-                    ApiResult.Error("Failed to fetch global settings: ${response.code()}", response.code())
-                }
-            } catch (e: Exception) {
-                throw e
-            }
-        }
-    }
+    suspend fun getGlobalSettings(): ApiResult<GlobalSettingsData> =
+        executeWithFallback { api -> api.getGlobalSettings().toResult("global settings") { it?.data } }
 }

--- a/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
@@ -1,11 +1,6 @@
 package com.matedroid.data.sync
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.ServiceInfo
-import android.os.Build
-import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
@@ -61,6 +56,15 @@ class DataSyncWorker @AssistedInject constructor(
 
     // Track if foreground service is available (may fail on Android 14+ from background)
     private var foregroundAvailable = true
+
+    private val foregroundNotifier = WorkerForegroundNotifier(
+        context = applicationContext,
+        channelId = CHANNEL_ID,
+        channelName = "Data Sync",
+        channelDescription = "Background sync for stats data",
+        notificationId = NOTIFICATION_ID,
+        contentTitle = "MateDroid Sync",
+    )
 
     override suspend fun doWork(): Result {
         log("Starting data sync worker (attempt ${runAttemptCount})")
@@ -199,45 +203,6 @@ class DataSyncWorker @AssistedInject constructor(
         }
     }
 
-    /**
-     * Create foreground info for the notification.
-     */
-    private fun createForegroundInfo(progress: String): ForegroundInfo {
-        val context = applicationContext
-
-        // Create notification channel (required for Android 8.0+)
-        createNotificationChannel()
-
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setContentTitle("MateDroid Sync")
-            .setContentText(progress)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setOngoing(true)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .build()
-
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ForegroundInfo(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            )
-        } else {
-            ForegroundInfo(NOTIFICATION_ID, notification)
-        }
-    }
-
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                "Data Sync",
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                description = "Background sync for stats data"
-            }
-            val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
+    private fun createForegroundInfo(progress: String): ForegroundInfo =
+        foregroundNotifier.createForegroundInfo(progress)
 }

--- a/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
@@ -1,11 +1,6 @@
 package com.matedroid.data.sync
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.ServiceInfo
-import android.os.Build
-import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
@@ -51,6 +46,15 @@ class GeocodeWorker @AssistedInject constructor(
     }
 
     private var foregroundAvailable = true
+
+    private val foregroundNotifier = WorkerForegroundNotifier(
+        context = applicationContext,
+        channelId = CHANNEL_ID,
+        channelName = "Location Identification",
+        channelDescription = "Background geocoding for location stats",
+        notificationId = NOTIFICATION_ID,
+        contentTitle = "MateDroid",
+    )
 
     override suspend fun doWork(): Result {
         Log.d(TAG, "=== Starting geocode worker (attempt ${runAttemptCount}) ===")
@@ -203,39 +207,6 @@ class GeocodeWorker @AssistedInject constructor(
         }
     }
 
-    private fun createForegroundInfo(progress: String): ForegroundInfo {
-        createNotificationChannel()
-
-        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
-            .setContentTitle("MateDroid")
-            .setContentText(progress)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setOngoing(true)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .build()
-
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ForegroundInfo(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            )
-        } else {
-            ForegroundInfo(NOTIFICATION_ID, notification)
-        }
-    }
-
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                "Location Identification",
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                description = "Background geocoding for location stats"
-            }
-            val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
+    private fun createForegroundInfo(progress: String): ForegroundInfo =
+        foregroundNotifier.createForegroundInfo(progress)
 }

--- a/app/src/main/java/com/matedroid/data/sync/WorkerForegroundNotifier.kt
+++ b/app/src/main/java/com/matedroid/data/sync/WorkerForegroundNotifier.kt
@@ -1,0 +1,61 @@
+package com.matedroid.data.sync
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.ForegroundInfo
+import com.matedroid.R
+
+/**
+ * Builds the ongoing foreground-service notification (and its channel) shared by the
+ * data-sync and geocode workers. Only the channel identity and content title differ
+ * between them, so those are passed in; the rest of the plumbing lives here.
+ */
+class WorkerForegroundNotifier(
+    private val context: Context,
+    private val channelId: String,
+    private val channelName: String,
+    private val channelDescription: String,
+    private val notificationId: Int,
+    private val contentTitle: String,
+) {
+    fun createForegroundInfo(progress: String): ForegroundInfo {
+        createNotificationChannel()
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setContentTitle(contentTitle)
+            .setContentText(progress)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                notificationId,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(notificationId, notification)
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                channelName,
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = channelDescription
+            }
+            val notificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -133,4 +133,18 @@ object UnitFormatter {
     fun getSpeedUnit(units: Units?): String {
         return if (units?.isImperial == true) "mph" else "km/h"
     }
+
+    /**
+     * Format an energy amount given in kWh, rolling over to MWh at 1,000 kWh.
+     * Energy is not affected by the unit system, so no [Units] is needed.
+     */
+    fun formatEnergy(kwh: Double): String =
+        if (kwh >= 1000) "%,.1f MWh".format(kwh / 1000) else "%.0f kWh".format(kwh)
+
+    /**
+     * Format a monetary amount with its currency [symbol]. Uses 2 decimals for
+     * absolute amounts and 3 for per-kWh prices (which are typically well below 1).
+     */
+    fun formatCost(value: Double, symbol: String, perKwh: Boolean = false): String =
+        if (perKwh) "%,.3f %s".format(value, symbol) else "%,.2f %s".format(value, symbol)
 }

--- a/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
@@ -38,13 +38,6 @@ data class SelectedPoint(
     val position: Offset
 )
 
-data class DualChartData(
-    val displayPoints: List<Float>,
-    val minValue: Float,
-    val maxValue: Float,
-    val range: Float
-)
-
 data class DualSelectedPoint(
     val index: Int,
     val valueLeft: Float?,
@@ -80,18 +73,6 @@ fun prepareChartData(
     val maxValue = fixedMinMax?.second ?: displayPoints.maxOrNull() ?: 1f
     val range = (maxValue - minValue).coerceAtLeast(1f)
     return ChartData(displayPoints, minValue, maxValue, range)
-}
-
-fun prepareDualChartData(data: List<Float>): DualChartData {
-    val displayPoints = if (data.size > MAX_DISPLAY_POINTS) {
-        downsampleLTTB(data, MAX_DISPLAY_POINTS)
-    } else {
-        data
-    }
-    val minValue = displayPoints.minOrNull() ?: 0f
-    val maxValue = displayPoints.maxOrNull() ?: 1f
-    val range = (maxValue - minValue).coerceAtLeast(1f)
-    return DualChartData(displayPoints, minValue, maxValue, range)
 }
 
 // ── LTTB Downsampling ───────────────────────────────────────────────────────
@@ -406,6 +387,16 @@ fun DrawScope.drawGlowIndicator(center: Offset, color: Color) {
 }
 
 /**
+ * The [steps] + 1 Y-axis label values (top → bottom) plus a format string that
+ * switches to one decimal when adjacent integer labels would collide.
+ */
+private fun axisLabelValues(chartData: ChartData, steps: Int = 4): Pair<List<Float>, String> {
+    val rawValues = (0..steps).map { i -> chartData.maxValue - (chartData.range * i / steps) }
+    val needsDecimal = rawValues.zipWithNext().any { (a, b) -> "%.0f".format(a) == "%.0f".format(b) }
+    return rawValues to if (needsDecimal) "%.1f" else "%.0f"
+}
+
+/**
  * Draws Y-axis labels at 5 positions (including max), with automatic decimal
  * precision when the range is too small to differentiate integer values.
  */
@@ -422,18 +413,10 @@ fun DrawScope.drawYAxisLabels(
             isAntiAlias = true
         }
 
-        val gridLineCount = 4
+        val (rawValues, format) = axisLabelValues(chartData)
 
-        val rawValues = (0..gridLineCount).map { i ->
-            chartData.maxValue - (chartData.range * i / gridLineCount)
-        }
-        val needsDecimal = rawValues.zipWithNext().any { (a, b) ->
-            "%.0f".format(a) == "%.0f".format(b)
-        }
-        val format = if (needsDecimal) "%.1f" else "%.0f"
-
-        for (i in 0..gridLineCount) {
-            val y = height * i / gridLineCount
+        for (i in rawValues.indices) {
+            val y = height * i / (rawValues.size - 1)
             val label = format.format(rawValues[i]) + " $unit"
             // Position the label above line
             val textY = y - 4f
@@ -446,7 +429,7 @@ fun DrawScope.drawYAxisLabels(
  * Draws Y-axis labels for dual-axis chart (left or right side).
  */
 fun DrawScope.drawDualYAxisLabels(
-    chartData: DualChartData,
+    chartData: ChartData,
     unit: String,
     height: Float,
     isLeft: Boolean,
@@ -460,18 +443,11 @@ fun DrawScope.drawDualYAxisLabels(
             isAntiAlias = true
             textAlign = if (isLeft) Paint.Align.LEFT else Paint.Align.RIGHT
         }
-        val gridLineCount = 4
 
-        val rawValues = (0..gridLineCount).map { i ->
-            chartData.maxValue - (chartData.range * i / gridLineCount)
-        }
-        val needsDecimal = rawValues.zipWithNext().any { (a, b) ->
-            "%.0f".format(a) == "%.0f".format(b)
-        }
-        val format = if (needsDecimal) "%.1f" else "%.0f"
+        val (rawValues, format) = axisLabelValues(chartData)
 
-        for (i in 0..gridLineCount) {
-            val y = height * i / gridLineCount
+        for (i in rawValues.indices) {
+            val y = height * i / (rawValues.size - 1)
             val label = format.format(rawValues[i]) + " $unit"
             // Position the label above line
             val textY = y - 4f

--- a/app/src/main/java/com/matedroid/ui/components/ComparisonStats.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ComparisonStats.kt
@@ -2,14 +2,20 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -122,4 +128,60 @@ fun ComparisonVerdict(
             )
         }
     }
+}
+
+/** A selectable sort chip tinted with the car's [accent] colour when selected. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = accent.copy(alpha = 0.16f),
+            selectedLabelColor = accent
+        )
+    )
+}
+
+/** A coloured dot + label, used in the overlay-chart legends. */
+@Composable
+fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(5.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/** A small rounded pill for a secondary metric on a leaderboard row. */
+@Composable
+fun Pill(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 7.dp, vertical = 3.dp)
+    )
+}
+
+/** Medal emoji for the top three ranks, otherwise the plain rank number. */
+fun rankBadge(rank: Int): String = when (rank) {
+    1 -> "🥇"
+    2 -> "🥈"
+    3 -> "🥉"
+    else -> "$rank"
 }

--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -71,8 +71,8 @@ fun DualAxisLineChart(
     val tooltipBg = MaterialTheme.colorScheme.inverseSurface
     val tooltipFg = MaterialTheme.colorScheme.inverseOnSurface
 
-    val chartDataLeft = remember(dataLeft) { prepareDualChartData(dataLeft) }
-    val chartDataRight = remember(dataRight) { prepareDualChartData(dataRight) }
+    val chartDataLeft = remember(dataLeft) { prepareChartData(dataLeft, fixedMinMax = null) { it } }
+    val chartDataRight = remember(dataRight) { prepareChartData(dataRight, fixedMinMax = null) { it } }
 
     val density = LocalDensity.current
     val chartHeightPx = with(density) { chartHeight.toPx() }

--- a/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
+++ b/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
@@ -58,7 +58,8 @@ fun FullscreenChartFrame(
     fullscreen: @Composable (chartHeight: Dp) -> Unit,
 ) {
     var isFullscreen by rememberSaveable { mutableStateOf(false) }
-    val activity = LocalContext.current as? Activity
+    val context = LocalContext.current
+    val activity = context as? Activity
 
     Box(modifier = modifier) {
         inline()

--- a/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
+++ b/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
@@ -1,0 +1,181 @@
+package com.matedroid.ui.components
+
+import android.app.Activity
+import android.content.pm.ActivityInfo
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.SecureFlagPolicy
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import com.matedroid.R
+
+/**
+ * Fullscreen chrome shared by the line-chart wrappers: renders [inline] with a small
+ * fullscreen button in the lower-right corner, and on tap opens a landscape dialog
+ * (orientation lock + hidden system bars + back button) hosting [fullscreen], to which
+ * it passes the height available for the chart body.
+ *
+ * @param hasTimeLabels whether the chart draws an X-axis label row (reserves space for it).
+ */
+@Composable
+fun FullscreenChartFrame(
+    modifier: Modifier = Modifier,
+    hasTimeLabels: Boolean,
+    inline: @Composable () -> Unit,
+    fullscreen: @Composable (chartHeight: Dp) -> Unit,
+) {
+    var isFullscreen by rememberSaveable { mutableStateOf(false) }
+    val activity = LocalContext.current as? Activity
+
+    Box(modifier = modifier) {
+        inline()
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(4.dp)
+                .size(28.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
+                    isFullscreen = true
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Fullscreen,
+                contentDescription = stringResource(R.string.fullscreen),
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+
+    if (isFullscreen) {
+        FullscreenChartOverlay(
+            activity = activity,
+            hasTimeLabels = hasTimeLabels,
+            onDismiss = { isFullscreen = false },
+            chart = fullscreen
+        )
+    }
+}
+
+@Composable
+private fun FullscreenChartOverlay(
+    activity: Activity?,
+    hasTimeLabels: Boolean,
+    onDismiss: () -> Unit,
+    chart: @Composable (chartHeight: Dp) -> Unit,
+) {
+    val view = LocalView.current
+
+    // Lock orientation to landscape and hide system bars for the duration of the overlay.
+    DisposableEffect(Unit) {
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+        activity?.window?.let { window ->
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            val controller = WindowInsetsControllerCompat(window, view)
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+        onDispose {
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            activity?.window?.let { window ->
+                WindowCompat.setDecorFitsSystemWindows(window, true)
+                val controller = WindowInsetsControllerCompat(window, view)
+                controller.show(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+    }
+
+    BackHandler { onDismiss() }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+            securePolicy = SecureFlagPolicy.Inherit
+        )
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            val verticalPadding = 48.dp // top + bottom padding
+            val timeLabelHeight = if (hasTimeLabels) 20.dp else 0.dp
+            val availableChartHeight = maxHeight - verticalPadding - timeLabelHeight
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = 56.dp,  // Space for back button
+                        end = 24.dp,
+                        top = 24.dp,
+                        bottom = 24.dp
+                    )
+            ) {
+                chart(availableChartHeight)
+            }
+
+            // Back button in top-left corner
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(8.dp)
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f))
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.exit_fullscreen),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/components/FullscreenDualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/FullscreenDualAxisLineChart.kt
@@ -1,46 +1,10 @@
 package com.matedroid.ui.components
 
-import android.app.Activity
-import android.content.pm.ActivityInfo
-import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.SecureFlagPolicy
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
-import com.matedroid.R
 
 /**
  * A dual-axis line chart with fullscreen capability.
@@ -62,119 +26,10 @@ fun FullscreenDualAxisLineChart(
 ) {
     if (dataLeft.size < 2 && dataRight.size < 2) return
 
-    var isFullscreen by rememberSaveable { mutableStateOf(false) }
-    val context = LocalContext.current
-    val activity = context as? Activity
-
-    Box(modifier = modifier) {
-        DualAxisLineChart(
-            dataLeft = dataLeft,
-            dataRight = dataRight,
-            colorLeft = colorLeft,
-            colorRight = colorRight,
-            unitLeft = unitLeft,
-            unitRight = unitRight,
-            timeLabels = timeLabels,
-            externalSelectedFraction = externalSelectedFraction,
-            onXSelected = onXSelected,
-            fractionToTimeLabel = fractionToTimeLabel,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        // Fullscreen icon button
-        Box(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(4.dp)
-                .size(28.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) {
-                    isFullscreen = true
-                },
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.Fullscreen,
-                contentDescription = stringResource(R.string.fullscreen),
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-
-    if (isFullscreen) {
-        FullscreenDualChartOverlay(
-            dataLeft = dataLeft,
-            dataRight = dataRight,
-            colorLeft = colorLeft,
-            colorRight = colorRight,
-            unitLeft = unitLeft,
-            unitRight = unitRight,
-            timeLabels = timeLabels,
-            activity = activity,
-            onDismiss = { isFullscreen = false }
-        )
-    }
-}
-
-@Composable
-private fun FullscreenDualChartOverlay(
-    dataLeft: List<Float>,
-    dataRight: List<Float>,
-    colorLeft: Color,
-    colorRight: Color,
-    unitLeft: String,
-    unitRight: String,
-    timeLabels: List<String>,
-    activity: Activity?,
-    onDismiss: () -> Unit
-) {
-    val view = LocalView.current
-
-    DisposableEffect(Unit) {
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-        activity?.window?.let { window ->
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            val controller = WindowInsetsControllerCompat(window, view)
-            controller.hide(WindowInsetsCompat.Type.systemBars())
-            controller.systemBarsBehavior =
-                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
-        onDispose {
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            activity?.window?.let { window ->
-                WindowCompat.setDecorFitsSystemWindows(window, true)
-                val controller = WindowInsetsControllerCompat(window, view)
-                controller.show(WindowInsetsCompat.Type.systemBars())
-            }
-        }
-    }
-
-    BackHandler { onDismiss() }
-
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(
-            dismissOnBackPress = true,
-            dismissOnClickOutside = false,
-            usePlatformDefaultWidth = false,
-            decorFitsSystemWindows = false,
-            securePolicy = SecureFlagPolicy.Inherit
-        )
-    ) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface)
-        ) {
-            val verticalPadding = 48.dp
-            val timeLabelHeight = if (timeLabels.isNotEmpty()) 20.dp else 0.dp
-            val availableChartHeight = maxHeight - verticalPadding - timeLabelHeight
-
+    FullscreenChartFrame(
+        modifier = modifier,
+        hasTimeLabels = timeLabels.isNotEmpty(),
+        inline = {
             DualAxisLineChart(
                 dataLeft = dataLeft,
                 dataRight = dataRight,
@@ -183,32 +38,24 @@ private fun FullscreenDualChartOverlay(
                 unitLeft = unitLeft,
                 unitRight = unitRight,
                 timeLabels = timeLabels,
-                chartHeight = availableChartHeight,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = 56.dp,
-                        end = 24.dp,
-                        top = 24.dp,
-                        bottom = 24.dp
-                    )
+                externalSelectedFraction = externalSelectedFraction,
+                onXSelected = onXSelected,
+                fractionToTimeLabel = fractionToTimeLabel,
+                modifier = Modifier.fillMaxWidth()
             )
-
-            IconButton(
-                onClick = onDismiss,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(8.dp)
-                    .size(40.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f))
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.exit_fullscreen),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+        },
+        fullscreen = { chartHeight ->
+            DualAxisLineChart(
+                dataLeft = dataLeft,
+                dataRight = dataRight,
+                colorLeft = colorLeft,
+                colorRight = colorRight,
+                unitLeft = unitLeft,
+                unitRight = unitRight,
+                timeLabels = timeLabels,
+                chartHeight = chartHeight,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
-    }
+    )
 }

--- a/app/src/main/java/com/matedroid/ui/components/FullscreenLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/FullscreenLineChart.kt
@@ -1,46 +1,10 @@
 package com.matedroid.ui.components
 
-import android.app.Activity
-import android.content.pm.ActivityInfo
-import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import com.matedroid.R
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.SecureFlagPolicy
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * A line chart component with fullscreen capability.
@@ -65,134 +29,26 @@ fun FullscreenLineChart(
 ) {
     if (data.size < 2) return
 
-    var isFullscreen by rememberSaveable { mutableStateOf(false) }
-    val context = LocalContext.current
-    val activity = context as? Activity
-
-    Box(modifier = modifier) {
-        // Regular chart
-        OptimizedLineChart(
-            data = data,
-            color = color,
-            unit = unit,
-            showZeroLine = showZeroLine,
-            fixedMinMax = fixedMinMax,
-            timeLabels = timeLabels,
-            convertValue = convertValue,
-            externalSelectedFraction = externalSelectedFraction,
-            onXSelected = onXSelected,
-            fractionToTimeLabel = fractionToTimeLabel,
-            annotationRanges = annotationRanges,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        // Fullscreen icon button in lower-right corner
-        Box(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(4.dp)
-                .size(28.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) {
-                    isFullscreen = true
-                },
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.Fullscreen,
-                contentDescription = stringResource(R.string.fullscreen),
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+    FullscreenChartFrame(
+        modifier = modifier,
+        hasTimeLabels = timeLabels.isNotEmpty(),
+        inline = {
+            OptimizedLineChart(
+                data = data,
+                color = color,
+                unit = unit,
+                showZeroLine = showZeroLine,
+                fixedMinMax = fixedMinMax,
+                timeLabels = timeLabels,
+                convertValue = convertValue,
+                externalSelectedFraction = externalSelectedFraction,
+                onXSelected = onXSelected,
+                fractionToTimeLabel = fractionToTimeLabel,
+                annotationRanges = annotationRanges,
+                modifier = Modifier.fillMaxWidth()
             )
-        }
-    }
-
-    // Fullscreen overlay
-    if (isFullscreen) {
-        FullscreenChartOverlay(
-            data = data,
-            color = color,
-            unit = unit,
-            showZeroLine = showZeroLine,
-            fixedMinMax = fixedMinMax,
-            timeLabels = timeLabels,
-            convertValue = convertValue,
-            annotationRanges = annotationRanges,
-            activity = activity,
-            onDismiss = { isFullscreen = false }
-        )
-    }
-}
-
-@Composable
-private fun FullscreenChartOverlay(
-    data: List<Float>,
-    color: Color,
-    unit: String,
-    showZeroLine: Boolean,
-    fixedMinMax: Pair<Float, Float>?,
-    timeLabels: List<String>,
-    convertValue: (Float) -> Float,
-    annotationRanges: List<AnnotationRange>,
-    activity: Activity?,
-    onDismiss: () -> Unit
-) {
-    val view = LocalView.current
-
-    // Lock orientation to landscape and hide system bars
-    DisposableEffect(Unit) {
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-
-        // Hide system bars on the activity window
-        activity?.window?.let { window ->
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            val controller = WindowInsetsControllerCompat(window, view)
-            controller.hide(WindowInsetsCompat.Type.systemBars())
-            controller.systemBarsBehavior =
-                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
-
-        onDispose {
-            // Restore portrait mode and show system bars
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            activity?.window?.let { window ->
-                WindowCompat.setDecorFitsSystemWindows(window, true)
-                val controller = WindowInsetsControllerCompat(window, view)
-                controller.show(WindowInsetsCompat.Type.systemBars())
-            }
-        }
-    }
-
-    // Handle back button press
-    BackHandler {
-        onDismiss()
-    }
-
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(
-            dismissOnBackPress = true,
-            dismissOnClickOutside = false,
-            usePlatformDefaultWidth = false,
-            decorFitsSystemWindows = false,
-            securePolicy = SecureFlagPolicy.Inherit
-        )
-    ) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface)
-        ) {
-            // Calculate chart height based on available space minus padding and time labels
-            val verticalPadding = 48.dp // top + bottom padding
-            val timeLabelHeight = if (timeLabels.isNotEmpty()) 20.dp else 0.dp
-            val availableChartHeight = maxHeight - verticalPadding - timeLabelHeight
-
-            // Fullscreen chart with padding
+        },
+        fullscreen = { chartHeight ->
             OptimizedLineChart(
                 data = data,
                 color = color,
@@ -202,33 +58,9 @@ private fun FullscreenChartOverlay(
                 timeLabels = timeLabels,
                 convertValue = convertValue,
                 annotationRanges = annotationRanges,
-                chartHeight = availableChartHeight,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = 56.dp,  // Space for back button
-                        end = 24.dp,
-                        top = 24.dp,
-                        bottom = 24.dp
-                    )
+                chartHeight = chartHeight,
+                modifier = Modifier.fillMaxWidth()
             )
-
-            // Back button in top-left corner
-            IconButton(
-                onClick = onDismiss,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(8.dp)
-                    .size(40.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f))
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.exit_fullscreen),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         }
-    }
+    )
 }

--- a/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.util.formatDuration
 import kotlin.math.PI
@@ -249,7 +250,7 @@ private fun DonutCanvas(
                     maxLines = 1
                 )
                 Text(
-                    text = "%.2f %s".format(stop.cost, currencySymbol),
+                    text = UnitFormatter.formatCost(stop.cost, currencySymbol),
                     style = MaterialTheme.typography.headlineSmall,
                     color = color,
                     fontWeight = FontWeight.Bold
@@ -270,7 +271,7 @@ private fun DonutCanvas(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = "%.2f %s".format(totalCost, currencySymbol),
+                    text = UnitFormatter.formatCost(totalCost, currencySymbol),
                     style = MaterialTheme.typography.headlineSmall,
                     color = palette.accent,
                     fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -72,6 +72,8 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.ChargeData
+import com.matedroid.ui.screens.common.ChartGranularity
+import com.matedroid.ui.screens.common.DateFilter
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.BarSegment
 import com.matedroid.ui.components.DateRangePickerDialog

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -33,20 +33,8 @@ import java.util.Locale
 import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
 import javax.inject.Inject
-
-enum class ChartGranularity {
-    DAILY, WEEKLY, MONTHLY
-}
-
-enum class DateFilter(@get:StringRes val labelRes: Int, val days: Long?) {
-    TODAY(R.string.filter_today, 0),
-    LAST_7_DAYS(R.string.filter_last_7_days, 7),
-    LAST_30_DAYS(R.string.filter_last_30_days, 30),
-    LAST_90_DAYS(R.string.filter_last_90_days, 90),
-    LAST_YEAR(R.string.filter_last_year, 365),
-    ALL_TIME(R.string.filter_all_time, null),
-    CUSTOM(R.string.filter_custom, -1)
-}
+import com.matedroid.ui.screens.common.ChartGranularity
+import com.matedroid.ui.screens.common.DateFilter
 
 enum class ChargeTypeFilter(val label: String) {
     ALL("All"),

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -23,18 +23,12 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.YearMonth
-import com.matedroid.util.formatMonthYear
-import com.matedroid.util.formatShortNoYear
-import com.matedroid.util.formatWeekLabel
-import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.time.temporal.ChronoUnit
-import java.time.temporal.WeekFields
 import javax.inject.Inject
 import com.matedroid.ui.screens.common.ChartGranularity
 import com.matedroid.ui.screens.common.DateFilter
+import com.matedroid.ui.screens.common.buildTimeSeries
 
 enum class ChargeTypeFilter(val label: String) {
     ALL("All"),
@@ -449,130 +443,21 @@ class ChargesViewModel @Inject constructor(
         }
     }
 
-    private fun calculateChartData(charges: List<ChargeData>, granularity: ChartGranularity, startDate: LocalDate?): List<ChargeChartData> {
-        if (charges.isEmpty()) return emptyList()
-
-        val formatter = DateTimeFormatter.ISO_DATE_TIME
-        val weekFields = WeekFields.of(Locale.getDefault())
-
-        // Group the charges by day
-        val chargesByDay = charges.mapNotNull { charge ->
-            charge.startDate?.let {
-                try {
-                    // Use of localdatetime to support the full ISO format
-                    val date = LocalDateTime.parse(it, formatter).toLocalDate()
-                    date.toEpochDay() to charge
-                } catch (e: Exception) { null }
-            }
-        }.groupBy({ it.first }, { it.second })
-
-        return when (granularity) {
-            ChartGranularity.DAILY -> {
-                // DAILY ranges (today, last 7 and last 30 days)
-                // If not startDate (All Time), get the first trip, or today
-                val start = startDate ?: (chargesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-                val result = mutableListOf<ChargeChartData>()
-                var current = start
-                while (!current.isAfter(end)) {
-                    val key = current.toEpochDay()
-                    val itemsInDay = chargesByDay[key] ?: emptyList()
-                    result.add(
-                        createChargeChartPoint(
-                            label = current.formatShortNoYear(Locale.getDefault()),
-                            sortKey = key,
-                            charges = itemsInDay,
-                            dcChargeIds = _uiState.value.dcChargeIds
-                        )
-                    )
-                    current = current.plusDays(1)
-                }
-                result
-            }
-            ChartGranularity.WEEKLY -> {
-                // WEEKLY range (last 90 days = ~13 weeks)
-                val start = startDate ?: (chargesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-
-                // Get first day of the week for start date
-                var weekStart = start.with(weekFields.dayOfWeek(), 1)
-                // If weekStart is before start, advance to the next week
-                if (weekStart.isBefore(start)) {
-                    weekStart = weekStart.plusWeeks(1)
-                }
-
-                // Group charges by week
-                val chargesByWeek = charges.mapNotNull { charge ->
-                    charge.startDate?.let { dateStr ->
-                        try {
-                            val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
-                            val firstDayOfWeek = date.with(weekFields.dayOfWeek(), 1)
-                            firstDayOfWeek.toEpochDay() to charge
-                        } catch (e: Exception) { null }
-                    }
-                }.groupBy({ it.first }, { it.second })
-
-                // Generate all weeks in range
-                val result = mutableListOf<ChargeChartData>()
-                var currentWeek = weekStart
-                while (!currentWeek.isAfter(end)) {
-                    val key = currentWeek.toEpochDay()
-                    val chargesInWeek = chargesByWeek[key] ?: emptyList()
-                    val weekOfYear = currentWeek.get(weekFields.weekOfYear())
-                    result.add(
-                        createChargeChartPoint(
-                            label = formatWeekLabel(appContext.resources, weekOfYear),
-                            sortKey = key,
-                            charges = chargesInWeek,
-                            dcChargeIds = _uiState.value.dcChargeIds
-                        )
-                    )
-                    currentWeek = currentWeek.plusWeeks(1)
-                }
-                result
-            }
-
-            ChartGranularity.MONTHLY -> {
-                // MONTHLY range (last year = 12 months)
-                val start = startDate ?: (chargesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-
-                // Get first day of month for start date
-                val monthStart = YearMonth.from(start).atDay(1)
-                val monthEnd = YearMonth.from(end)
-
-                // Group charges by month
-                val chargesByMonth = charges.mapNotNull { charge ->
-                    charge.startDate?.let { dateStr ->
-                        try {
-                            val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
-                            val firstDayOfMonth = YearMonth.from(date).atDay(1)
-                            firstDayOfMonth.toEpochDay() to charge
-                        } catch (e: Exception) { null }
-                    }
-                }.groupBy({ it.first }, { it.second })
-
-                // Generate all months in range
-                val result = mutableListOf<ChargeChartData>()
-                var currentMonth = YearMonth.from(monthStart)
-                while (!currentMonth.isAfter(monthEnd)) {
-                    val firstDay = currentMonth.atDay(1)
-                    val key = firstDay.toEpochDay()
-                    val chargesInMonth = chargesByMonth[key] ?: emptyList()
-                    result.add(
-                        createChargeChartPoint(
-                            label = firstDay.formatMonthYear(Locale.getDefault()),
-                            sortKey = key,
-                            charges = chargesInMonth,
-                            dcChargeIds = _uiState.value.dcChargeIds
-                        )
-                    )
-                    currentMonth = currentMonth.plusMonths(1)
-                }
-                result
-            }
+    private fun calculateChartData(charges: List<ChargeData>, granularity: ChartGranularity, startDate: LocalDate?): List<ChargeChartData> =
+        buildTimeSeries(
+            items = charges,
+            granularity = granularity,
+            startDate = startDate,
+            resources = appContext.resources,
+            dateOf = { it.startDate },
+        ) { label, sortKey, bucket ->
+            createChargeChartPoint(
+                label = label,
+                sortKey = sortKey,
+                charges = bucket,
+                dcChargeIds = _uiState.value.dcChargeIds
+            )
         }
-    }
 
     // Helper function to centralize chart data creation
     private fun createChargeChartPoint(

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CompareChargesScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -28,8 +27,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -63,12 +60,16 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.ComparisonVerdict
 import com.matedroid.ui.components.DeltaChip
 import com.matedroid.ui.components.DeltaTone
+import com.matedroid.ui.components.LegendItem
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.Pill
 import com.matedroid.ui.components.PowerSocOverlayChart
 import com.matedroid.ui.components.RowDelta
+import com.matedroid.ui.components.SortChip
 import com.matedroid.ui.components.isBetter
 import com.matedroid.ui.components.percentDelta
+import com.matedroid.ui.components.rankBadge
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDurationCompact
@@ -268,19 +269,6 @@ private fun CompareContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) },
-        colors = FilterChipDefaults.filterChipColors(
-            selectedContainerColor = accent.copy(alpha = 0.16f),
-            selectedLabelColor = accent
-        )
-    )
-}
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -362,23 +350,6 @@ private fun OverlayChartCard(
     }
 }
 
-@Composable
-private fun LegendItem(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(color)
-        )
-        Spacer(modifier = Modifier.width(5.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
 
 @Composable
 private fun CompareRow(
@@ -472,25 +443,6 @@ private fun chargeAvgMetricValue(a: ChargeAverage, sort: CompareSort): Double? =
 
 private fun chargeHigherIsBetter(sort: CompareSort): Boolean = sort == CompareSort.PEAK
 
-@Composable
-private fun Pill(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 7.dp, vertical = 3.dp)
-    )
-}
-
-private fun rankBadge(rank: Int): String = when (rank) {
-    1 -> "🥇"
-    2 -> "🥈"
-    3 -> "🥉"
-    else -> "$rank"
-}
 
 private fun valueFor(
     charge: ComparableCharge,

--- a/app/src/main/java/com/matedroid/ui/screens/common/ChartBinning.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/common/ChartBinning.kt
@@ -1,0 +1,111 @@
+package com.matedroid.ui.screens.common
+
+import android.content.res.Resources
+import com.matedroid.util.formatMonthYear
+import com.matedroid.util.formatShortNoYear
+import com.matedroid.util.formatWeekLabel
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.temporal.WeekFields
+import java.util.Locale
+
+/**
+ * Bucket [items] into a contiguous daily/weekly/monthly time series (no gaps), from
+ * [startDate] (or the earliest item when null) through today, and hand each bucket to
+ * [aggregate] to build the chart point.
+ *
+ * This is the shared engine behind the charges and drives list charts; the two differ
+ * only in the item type, the [dateOf] accessor, and what [aggregate] produces.
+ *
+ * @param dateOf the item's start timestamp in ISO date-time format (null items are skipped).
+ * @param aggregate builds a point from the bucket's display label, epoch-day sort key and items.
+ */
+fun <T, R> buildTimeSeries(
+    items: List<T>,
+    granularity: ChartGranularity,
+    startDate: LocalDate?,
+    resources: Resources,
+    dateOf: (T) -> String?,
+    aggregate: (label: String, sortKey: Long, bucket: List<T>) -> R,
+): List<R> {
+    if (items.isEmpty()) return emptyList()
+
+    val formatter = DateTimeFormatter.ISO_DATE_TIME
+    val weekFields = WeekFields.of(Locale.getDefault())
+
+    fun localDateOf(item: T): LocalDate? = dateOf(item)?.let {
+        try {
+            // LocalDateTime to support the full ISO format
+            LocalDateTime.parse(it, formatter).toLocalDate()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    // Group by day up front; used directly for DAILY and for the earliest-date fallback.
+    val itemsByDay = items.mapNotNull { item -> localDateOf(item)?.let { it.toEpochDay() to item } }
+        .groupBy({ it.first }, { it.second })
+
+    val earliest = { itemsByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now() }
+
+    return when (granularity) {
+        ChartGranularity.DAILY -> {
+            val start = startDate ?: earliest()
+            val end = LocalDate.now()
+            val result = mutableListOf<R>()
+            var current = start
+            while (!current.isAfter(end)) {
+                val key = current.toEpochDay()
+                result.add(aggregate(current.formatShortNoYear(Locale.getDefault()), key, itemsByDay[key] ?: emptyList()))
+                current = current.plusDays(1)
+            }
+            result
+        }
+
+        ChartGranularity.WEEKLY -> {
+            val start = startDate ?: earliest()
+            val end = LocalDate.now()
+
+            // First day of the week for the start date; advance if it fell before start.
+            var weekStart = start.with(weekFields.dayOfWeek(), 1)
+            if (weekStart.isBefore(start)) {
+                weekStart = weekStart.plusWeeks(1)
+            }
+
+            val itemsByWeek = items.mapNotNull { item ->
+                localDateOf(item)?.let { it.with(weekFields.dayOfWeek(), 1).toEpochDay() to item }
+            }.groupBy({ it.first }, { it.second })
+
+            val result = mutableListOf<R>()
+            var currentWeek = weekStart
+            while (!currentWeek.isAfter(end)) {
+                val key = currentWeek.toEpochDay()
+                val weekOfYear = currentWeek.get(weekFields.weekOfYear())
+                result.add(aggregate(formatWeekLabel(resources, weekOfYear), key, itemsByWeek[key] ?: emptyList()))
+                currentWeek = currentWeek.plusWeeks(1)
+            }
+            result
+        }
+
+        ChartGranularity.MONTHLY -> {
+            val start = startDate ?: earliest()
+            val monthEnd = YearMonth.from(LocalDate.now())
+
+            val itemsByMonth = items.mapNotNull { item ->
+                localDateOf(item)?.let { YearMonth.from(it).atDay(1).toEpochDay() to item }
+            }.groupBy({ it.first }, { it.second })
+
+            val result = mutableListOf<R>()
+            var currentMonth = YearMonth.from(start)
+            while (!currentMonth.isAfter(monthEnd)) {
+                val firstDay = currentMonth.atDay(1)
+                val key = firstDay.toEpochDay()
+                result.add(aggregate(firstDay.formatMonthYear(Locale.getDefault()), key, itemsByMonth[key] ?: emptyList()))
+                currentMonth = currentMonth.plusMonths(1)
+            }
+            result
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/common/ListFilters.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/common/ListFilters.kt
@@ -1,0 +1,20 @@
+package com.matedroid.ui.screens.common
+
+import androidx.annotation.StringRes
+import com.matedroid.R
+
+/** Time-bucket granularity for the charges/drives list charts. */
+enum class ChartGranularity {
+    DAILY, WEEKLY, MONTHLY
+}
+
+/** Date-range filter shared by the charges and drives lists. */
+enum class DateFilter(@get:StringRes val labelRes: Int, val days: Long?) {
+    TODAY(R.string.filter_today, 0),
+    LAST_7_DAYS(R.string.filter_last_7_days, 7),
+    LAST_30_DAYS(R.string.filter_last_30_days, 30),
+    LAST_90_DAYS(R.string.filter_last_90_days, 90),
+    LAST_YEAR(R.string.filter_last_year, 365),
+    ALL_TIME(R.string.filter_all_time, null),
+    CUSTOM(R.string.filter_custom, -1)
+}

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -31,8 +30,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -69,12 +66,16 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.ComparisonVerdict
 import com.matedroid.ui.components.DeltaChip
 import com.matedroid.ui.components.DeltaTone
+import com.matedroid.ui.components.LegendItem
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.components.OverlayCurve
+import com.matedroid.ui.components.Pill
 import com.matedroid.ui.components.PowerSocOverlayChart
 import com.matedroid.ui.components.RowDelta
+import com.matedroid.ui.components.SortChip
 import com.matedroid.ui.components.isBetter
 import com.matedroid.ui.components.percentDelta
+import com.matedroid.ui.components.rankBadge
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.util.formatDurationCompact
@@ -393,19 +394,6 @@ private fun averageValue(average: DriveAverage, sort: DriveCompareSort, units: U
         DriveCompareSort.SPEED -> UnitFormatter.formatSpeed(average.speedAvg.toDouble(), units)
     }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SortChip(label: String, selected: Boolean, accent: Color, onClick: () -> Unit) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) },
-        colors = FilterChipDefaults.filterChipColors(
-            selectedContainerColor = accent.copy(alpha = 0.16f),
-            selectedLabelColor = accent
-        )
-    )
-}
 
 @Composable
 private fun OverlayChartCard(
@@ -624,23 +612,6 @@ private fun DurationBars(
     }
 }
 
-@Composable
-private fun LegendItem(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(color)
-        )
-        Spacer(modifier = Modifier.width(5.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
 
 @Composable
 private fun CompareRow(
@@ -701,25 +672,6 @@ private fun CompareRow(
     }
 }
 
-@Composable
-private fun Pill(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 7.dp, vertical = 3.dp)
-    )
-}
-
-private fun rankBadge(rank: Int): String = when (rank) {
-    1 -> "🥇"
-    2 -> "🥈"
-    3 -> "🥉"
-    else -> "$rank"
-}
 
 private fun valueFor(drive: ComparableDrive, sort: DriveCompareSort, units: Units?): String =
     when (sort) {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -63,6 +63,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.DriveData
 import com.matedroid.data.api.models.Units
+import com.matedroid.ui.screens.common.ChartGranularity
+import com.matedroid.ui.screens.common.DateFilter
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.BarChartData
 import com.matedroid.ui.components.DateRangePickerDialog
@@ -179,9 +181,9 @@ fun DrivesScreen(
 private fun DrivesContent(
     drives: List<DriveData>,
     chartData: List<DriveChartData>,
-    chartGranularity: DriveChartGranularity,
+    chartGranularity: ChartGranularity,
     summary: DrivesSummary,
-    selectedDateFilter: DriveDateFilter,
+    selectedDateFilter: DateFilter,
     selectedDistanceFilter: DriveDistanceFilter,
     customStartDate: LocalDate?,
     customEndDate: LocalDate?,
@@ -189,7 +191,7 @@ private fun DrivesContent(
     palette: CarColorPalette,
     listState: androidx.compose.foundation.lazy.LazyListState,
     isFilterLoading: Boolean,
-    onDateFilterSelected: (DriveDateFilter) -> Unit,
+    onDateFilterSelected: (DateFilter) -> Unit,
     onCustomRangeSelected: (LocalDate, LocalDate) -> Unit,
     onDistanceFilterSelected: (DriveDistanceFilter) -> Unit,
     onDriveClick: (driveId: Int) -> Unit
@@ -318,11 +320,11 @@ private fun DrivesContent(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DateFilterChips(
-    selectedFilter: DriveDateFilter,
+    selectedFilter: DateFilter,
     customStartDate: LocalDate?,
     customEndDate: LocalDate?,
     palette: CarColorPalette,
-    onFilterSelected: (DriveDateFilter) -> Unit,
+    onFilterSelected: (DateFilter) -> Unit,
     onCustomRangeSelected: (LocalDate, LocalDate) -> Unit
 ) {
     var showDatePicker by remember { mutableStateOf(false) }
@@ -330,7 +332,7 @@ private fun DateFilterChips(
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        items(DriveDateFilter.entries.filter { it != DriveDateFilter.CUSTOM }) { filter ->
+        items(DateFilter.entries.filter { it != DateFilter.CUSTOM }) { filter ->
             FilterChip(
                 selected = filter == selectedFilter,
                 onClick = { onFilterSelected(filter) },
@@ -342,13 +344,13 @@ private fun DateFilterChips(
             )
         }
         item {
-            val label = if (selectedFilter == DriveDateFilter.CUSTOM && customStartDate != null && customEndDate != null) {
+            val label = if (selectedFilter == DateFilter.CUSTOM && customStartDate != null && customEndDate != null) {
                 "${formatShortDate(customStartDate)} – ${formatShortDate(customEndDate)}"
             } else {
                 stringResource(R.string.filter_custom)
             }
             FilterChip(
-                selected = selectedFilter == DriveDateFilter.CUSTOM,
+                selected = selectedFilter == DateFilter.CUSTOM,
                 onClick = { showDatePicker = true },
                 label = { Text(label) },
                 colors = FilterChipDefaults.filterChipColors(
@@ -555,7 +557,7 @@ private enum class DrivesChartType {
 @Composable
 private fun DrivesChartsPager(
     chartData: List<DriveChartData>,
-    granularity: DriveChartGranularity,
+    granularity: ChartGranularity,
     units: Units?,
     palette: CarColorPalette
 ) {
@@ -616,7 +618,7 @@ private fun DrivesChartsPager(
 @Composable
 private fun DrivesChartPage(
     chartData: List<DriveChartData>,
-    granularity: DriveChartGranularity,
+    granularity: ChartGranularity,
     chartType: DrivesChartType,
     units: Units?,
     palette: CarColorPalette
@@ -627,24 +629,24 @@ private fun DrivesChartPage(
 
     val (title, icon) = when (chartType) {
         DrivesChartType.COUNT -> when (granularity) {
-            DriveChartGranularity.DAILY -> stringResource(R.string.chart_drives_per_day)
-            DriveChartGranularity.WEEKLY -> stringResource(R.string.chart_drives_per_week)
-            DriveChartGranularity.MONTHLY -> stringResource(R.string.chart_drives_per_month)
+            ChartGranularity.DAILY -> stringResource(R.string.chart_drives_per_day)
+            ChartGranularity.WEEKLY -> stringResource(R.string.chart_drives_per_week)
+            ChartGranularity.MONTHLY -> stringResource(R.string.chart_drives_per_month)
         } to Icons.Default.DirectionsCar
         DrivesChartType.TIME -> when (granularity) {
-            DriveChartGranularity.DAILY -> stringResource(R.string.chart_time_per_day)
-            DriveChartGranularity.WEEKLY -> stringResource(R.string.chart_time_per_week)
-            DriveChartGranularity.MONTHLY -> stringResource(R.string.chart_time_per_month)
+            ChartGranularity.DAILY -> stringResource(R.string.chart_time_per_day)
+            ChartGranularity.WEEKLY -> stringResource(R.string.chart_time_per_week)
+            ChartGranularity.MONTHLY -> stringResource(R.string.chart_time_per_month)
         } to Icons.Default.Timer
         DrivesChartType.DISTANCE -> when (granularity) {
-            DriveChartGranularity.DAILY -> stringResource(R.string.chart_distance_per_day)
-            DriveChartGranularity.WEEKLY -> stringResource(R.string.chart_distance_per_week)
-            DriveChartGranularity.MONTHLY -> stringResource(R.string.chart_distance_per_month)
+            ChartGranularity.DAILY -> stringResource(R.string.chart_distance_per_day)
+            ChartGranularity.WEEKLY -> stringResource(R.string.chart_distance_per_week)
+            ChartGranularity.MONTHLY -> stringResource(R.string.chart_distance_per_month)
         } to CustomIcons.SteeringWheel
         DrivesChartType.TOP_SPEED -> when (granularity) {
-            DriveChartGranularity.DAILY -> stringResource(R.string.chart_speed_per_day)
-            DriveChartGranularity.WEEKLY -> stringResource(R.string.chart_speed_per_week)
-            DriveChartGranularity.MONTHLY -> stringResource(R.string.chart_speed_per_month)
+            ChartGranularity.DAILY -> stringResource(R.string.chart_speed_per_day)
+            ChartGranularity.WEEKLY -> stringResource(R.string.chart_speed_per_week)
+            ChartGranularity.MONTHLY -> stringResource(R.string.chart_speed_per_month)
         } to Icons.Default.Speed
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -21,18 +21,12 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.YearMonth
-import com.matedroid.util.formatMonthYear
-import com.matedroid.util.formatShortNoYear
-import com.matedroid.util.formatWeekLabel
-import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.time.temporal.ChronoUnit
-import java.time.temporal.WeekFields
 import javax.inject.Inject
 import com.matedroid.ui.screens.common.ChartGranularity
 import com.matedroid.ui.screens.common.DateFilter
+import com.matedroid.ui.screens.common.buildTimeSeries
 
 enum class DriveDistanceFilter(
     val maxDistanceKm: Double?,
@@ -338,127 +332,16 @@ class DrivesViewModel @Inject constructor(
         }
     }
 
-    private fun calculateChartData(drives: List<DriveData>, granularity: ChartGranularity, startDate: LocalDate?): List<DriveChartData> {
-        if (drives.isEmpty()) return emptyList()
-
-        val formatter = DateTimeFormatter.ISO_DATE_TIME
-        val weekFields = WeekFields.of(Locale.getDefault())
-
-        // Group the drives by day
-        val drivesByDay = drives.mapNotNull { drive ->
-            drive.startDate?.let {
-                try {
-                    val date = LocalDateTime.parse(it, formatter).toLocalDate()
-                    date.toEpochDay() to drive
-                } catch (e: Exception) { null }
-            }
-        }.groupBy({ it.first }, { it.second })
-
-        return when (granularity) {
-            ChartGranularity.DAILY -> {
-                // DAILY ranges (today, last 7 and last 30 days)
-                // If not startDate (All Time), get the first trip, or today
-                val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-                val result = mutableListOf<DriveChartData>()
-                var current = start
-                while (!current.isAfter(end)) {
-                    val key = current.toEpochDay()
-                    val drivesInDay = drivesByDay[key] ?: emptyList()
-                    result.add(
-                        createChartPoint(
-                            label = current.formatShortNoYear(Locale.getDefault()),
-                            sortKey = key,
-                            drives = drivesInDay
-                        )
-                    )
-                    current = current.plusDays(1)
-                }
-                result
-            }
-
-            ChartGranularity.WEEKLY -> {
-                // WEEKLY range (last 90 days = ~13 weeks)
-                val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-
-                // Get first day of the week for start date
-                var weekStart = start.with(weekFields.dayOfWeek(), 1)
-                // If weekStart is before start, advance to the next week
-                if (weekStart.isBefore(start)) {
-                    weekStart = weekStart.plusWeeks(1)
-                }
-
-                // Group drives by week
-                val drivesByWeek = drives.mapNotNull { drive ->
-                    drive.startDate?.let { dateStr ->
-                        try {
-                            val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
-                            val firstDayOfWeek = date.with(weekFields.dayOfWeek(), 1)
-                            firstDayOfWeek.toEpochDay() to drive
-                        } catch (e: Exception) { null }
-                    }
-                }.groupBy({ it.first }, { it.second })
-
-                // Generate all weeks in range
-                val result = mutableListOf<DriveChartData>()
-                var currentWeek = weekStart
-                while (!currentWeek.isAfter(end)) {
-                    val key = currentWeek.toEpochDay()
-                    val drivesInWeek = drivesByWeek[key] ?: emptyList()
-                    val weekOfYear = currentWeek.get(weekFields.weekOfYear())
-                    result.add(
-                        createChartPoint(
-                            label = formatWeekLabel(appContext.resources, weekOfYear),
-                            sortKey = key,
-                            drives = drivesInWeek
-                        )
-                    )
-                    currentWeek = currentWeek.plusWeeks(1)
-                }
-                result
-            }
-
-            ChartGranularity.MONTHLY -> {
-                // MONTHLY range (last year = 12 months)
-                val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
-                val end = LocalDate.now()
-
-                // Get first day of month for start date
-                val monthStart = YearMonth.from(start).atDay(1)
-                val monthEnd = YearMonth.from(end)
-
-                // Group drives by month
-                val drivesByMonth = drives.mapNotNull { drive ->
-                    drive.startDate?.let { dateStr ->
-                        try {
-                            val date = LocalDateTime.parse(dateStr, formatter).toLocalDate()
-                            val firstDayOfMonth = YearMonth.from(date).atDay(1)
-                            firstDayOfMonth.toEpochDay() to drive
-                        } catch (e: Exception) { null }
-                    }
-                }.groupBy({ it.first }, { it.second })
-
-                // Generate all months in range
-                val result = mutableListOf<DriveChartData>()
-                var currentMonth = YearMonth.from(monthStart)
-                while (!currentMonth.isAfter(monthEnd)) {
-                    val firstDay = currentMonth.atDay(1)
-                    val key = firstDay.toEpochDay()
-                    val drivesInMonth = drivesByMonth[key] ?: emptyList()
-                    result.add(
-                        createChartPoint(
-                            label = firstDay.formatMonthYear(Locale.getDefault()),
-                            sortKey = key,
-                            drives = drivesInMonth
-                        )
-                    )
-                    currentMonth = currentMonth.plusMonths(1)
-                }
-                result
-            }
+    private fun calculateChartData(drives: List<DriveData>, granularity: ChartGranularity, startDate: LocalDate?): List<DriveChartData> =
+        buildTimeSeries(
+            items = drives,
+            granularity = granularity,
+            startDate = startDate,
+            resources = appContext.resources,
+            dateOf = { it.startDate },
+        ) { label, sortKey, bucket ->
+            createChartPoint(label = label, sortKey = sortKey, drives = bucket)
         }
-    }
 
     // Helper function to centralize chart data creation
     private fun createChartPoint(label: String, sortKey: Long, drives: List<DriveData>): DriveChartData {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -1,6 +1,5 @@
 package com.matedroid.ui.screens.drives
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -32,10 +31,8 @@ import java.util.Locale
 import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
 import javax.inject.Inject
-
-enum class DriveChartGranularity {
-    DAILY, WEEKLY, MONTHLY
-}
+import com.matedroid.ui.screens.common.ChartGranularity
+import com.matedroid.ui.screens.common.DateFilter
 
 enum class DriveDistanceFilter(
     val maxDistanceKm: Double?,
@@ -66,15 +63,6 @@ data class DriveChartData(
     val sortKey: Long
 )
 
-enum class DriveDateFilter(@get:StringRes val labelRes: Int, val days: Long?) {
-    TODAY(R.string.filter_today, 0),
-    LAST_7_DAYS(R.string.filter_last_7_days, 7),
-    LAST_30_DAYS(R.string.filter_last_30_days, 30),
-    LAST_90_DAYS(R.string.filter_last_90_days, 90),
-    LAST_YEAR(R.string.filter_last_year, 365),
-    ALL_TIME(R.string.filter_all_time, null),
-    CUSTOM(R.string.filter_custom, -1)
-}
 
 data class DrivesUiState(
     val isLoading: Boolean = true,
@@ -86,14 +74,14 @@ data class DrivesUiState(
     val isFilterLoading: Boolean = false,
     val drives: List<DriveData> = emptyList(),
     val chartData: List<DriveChartData> = emptyList(),
-    val chartGranularity: DriveChartGranularity = DriveChartGranularity.MONTHLY,
+    val chartGranularity: ChartGranularity = ChartGranularity.MONTHLY,
     val error: String? = null,
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
     val summary: DrivesSummary = DrivesSummary(),
     val units: Units? = null,
     val distanceFilter: DriveDistanceFilter = DriveDistanceFilter.ALL,
-    val dateFilter: DriveDateFilter = DriveDateFilter.LAST_7_DAYS,
+    val dateFilter: DateFilter = DateFilter.LAST_7_DAYS,
     val customStartDate: LocalDate? = null,
     val customEndDate: LocalDate? = null,
     val scrollPosition: Int = 0,
@@ -133,8 +121,8 @@ class DrivesViewModel @Inject constructor(
 
         private fun restoreInitialState(handle: SavedStateHandle): DrivesUiState {
             val dateFilter = handle.get<String>(KEY_DATE_FILTER)
-                ?.let { runCatching { DriveDateFilter.valueOf(it) }.getOrNull() }
-                ?: DriveDateFilter.LAST_7_DAYS
+                ?.let { runCatching { DateFilter.valueOf(it) }.getOrNull() }
+                ?: DateFilter.LAST_7_DAYS
             val distanceFilter = handle.get<String>(KEY_DISTANCE_FILTER)
                 ?.let { runCatching { DriveDistanceFilter.valueOf(it) }.getOrNull() }
                 ?: DriveDistanceFilter.ALL
@@ -166,7 +154,7 @@ class DrivesViewModel @Inject constructor(
             val state = _uiState.value
             val customStart = state.customStartDate
             val customEnd = state.customEndDate
-            if (state.dateFilter == DriveDateFilter.CUSTOM && customStart != null && customEnd != null) {
+            if (state.dateFilter == DateFilter.CUSTOM && customStart != null && customEnd != null) {
                 setCustomDateRange(customStart, customEnd)
             } else {
                 setDateFilter(state.dateFilter)
@@ -174,8 +162,8 @@ class DrivesViewModel @Inject constructor(
         }
     }
 
-    fun setDateFilter(filter: DriveDateFilter) {
-        if (filter == DriveDateFilter.CUSTOM) return
+    fun setDateFilter(filter: DateFilter) {
+        if (filter == DateFilter.CUSTOM) return
         val endDate = LocalDate.now()
         val startDate = filter.days?.let { days ->
             if (days > 0) endDate.minusDays(days - 1) else endDate
@@ -195,13 +183,13 @@ class DrivesViewModel @Inject constructor(
 
     fun setCustomDateRange(start: LocalDate, end: LocalDate) {
         _uiState.update { it.copy(
-            dateFilter = DriveDateFilter.CUSTOM,
+            dateFilter = DateFilter.CUSTOM,
             startDate = start,
             endDate = end,
             customStartDate = start,
             customEndDate = end
         )}
-        savedStateHandle[KEY_DATE_FILTER] = DriveDateFilter.CUSTOM.name
+        savedStateHandle[KEY_DATE_FILTER] = DateFilter.CUSTOM.name
         savedStateHandle[KEY_CUSTOM_START] = start.toString()
         savedStateHandle[KEY_CUSTOM_END] = end.toString()
         loadDrives(start, end)
@@ -340,17 +328,17 @@ class DrivesViewModel @Inject constructor(
         }
     }
 
-    private fun determineGranularity(startDate: LocalDate?, endDate: LocalDate?): DriveChartGranularity {
-        if (startDate == null || endDate == null) return DriveChartGranularity.MONTHLY
+    private fun determineGranularity(startDate: LocalDate?, endDate: LocalDate?): ChartGranularity {
+        if (startDate == null || endDate == null) return ChartGranularity.MONTHLY
         val days = ChronoUnit.DAYS.between(startDate, endDate)
         return when {
-            days <= 30 -> DriveChartGranularity.DAILY
-            days <= 90 -> DriveChartGranularity.WEEKLY
-            else -> DriveChartGranularity.MONTHLY
+            days <= 30 -> ChartGranularity.DAILY
+            days <= 90 -> ChartGranularity.WEEKLY
+            else -> ChartGranularity.MONTHLY
         }
     }
 
-    private fun calculateChartData(drives: List<DriveData>, granularity: DriveChartGranularity, startDate: LocalDate?): List<DriveChartData> {
+    private fun calculateChartData(drives: List<DriveData>, granularity: ChartGranularity, startDate: LocalDate?): List<DriveChartData> {
         if (drives.isEmpty()) return emptyList()
 
         val formatter = DateTimeFormatter.ISO_DATE_TIME
@@ -367,7 +355,7 @@ class DrivesViewModel @Inject constructor(
         }.groupBy({ it.first }, { it.second })
 
         return when (granularity) {
-            DriveChartGranularity.DAILY -> {
+            ChartGranularity.DAILY -> {
                 // DAILY ranges (today, last 7 and last 30 days)
                 // If not startDate (All Time), get the first trip, or today
                 val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
@@ -389,7 +377,7 @@ class DrivesViewModel @Inject constructor(
                 result
             }
 
-            DriveChartGranularity.WEEKLY -> {
+            ChartGranularity.WEEKLY -> {
                 // WEEKLY range (last 90 days = ~13 weeks)
                 val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
                 val end = LocalDate.now()
@@ -431,7 +419,7 @@ class DrivesViewModel @Inject constructor(
                 result
             }
 
-            DriveChartGranularity.MONTHLY -> {
+            ChartGranularity.MONTHLY -> {
                 // MONTHLY range (last year = 12 months)
                 val start = startDate ?: (drivesByDay.keys.minOrNull()?.let { LocalDate.ofEpochDay(it) } ?: LocalDate.now())
                 val end = LocalDate.now()

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -419,7 +419,7 @@ private fun YearRow(
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(yearData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(yearData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
@@ -662,7 +662,7 @@ private fun MonthRow(
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(monthData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(monthData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
@@ -871,12 +871,12 @@ private fun MonthSummaryCard(
             ) {
                 StatChip(
                     icon = Icons.Filled.ElectricBolt,
-                    value = formatEnergy(totalEnergy),
+                    value = UnitFormatter.formatEnergy(totalEnergy),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     icon = Icons.Filled.AttachMoney,
-                    value = "%,.2f %s".format(monthData?.totalEnergyCost ?: 0.0, currencySymbol),
+                    value = UnitFormatter.formatCost(monthData?.totalEnergyCost ?: 0.0, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -986,7 +986,7 @@ private fun SummaryRow(
             )
             SummaryItem(
                 icon = Icons.Filled.AttachMoney,
-                value = "%,.2f %s".format(totalEnergyCost ?: 0.0, currencySymbol),
+                value = UnitFormatter.formatCost(totalEnergyCost ?: 0.0, currencySymbol),
                 label = stringResource(R.string.mileage_total),
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -994,7 +994,7 @@ private fun SummaryRow(
             )
             SummaryItem(
                 icon = Icons.Outlined.BatteryChargingFull,
-                value = formatEnergy(totalEnergyUsed),
+                value = UnitFormatter.formatEnergy(totalEnergyUsed),
                 label = stringResource(R.string.mileage_total),
                 iconColor = iconColor,
                 valueColor = valueColor,
@@ -1299,7 +1299,7 @@ private fun DayTripRow(
                     // Energy cost
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "%,.2f %s".format(dayData.totalEnergyCost ?: 0.0, currencySymbol),
+                            text = UnitFormatter.formatCost(dayData.totalEnergyCost ?: 0.0, currencySymbol),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
@@ -1346,9 +1346,6 @@ private fun DayTripRow(
         }
     }
 }
-
-private fun formatEnergy(kwh: Double): String =
-    if (kwh >= 1000) "%,.1f MWh".format(kwh / 1000) else "%.0f kWh".format(kwh)
 
 // ============================================================================
 // Level 4: Day Detail
@@ -1523,12 +1520,12 @@ private fun DaySummaryCard(
             ) {
                 StatChip(
                     icon = Icons.Filled.ElectricBolt,
-                    value = formatEnergy(dayData.totalEnergy),
+                    value = UnitFormatter.formatEnergy(dayData.totalEnergy),
                     modifier = Modifier.weight(1f)
                 )
                 StatChip(
                     icon = Icons.Filled.AttachMoney,
-                    value = "%,.2f %s".format(dayData.totalEnergyCost ?: 0.0, currencySymbol),
+                    value = UnitFormatter.formatCost(dayData.totalEnergyCost ?: 0.0, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,7 +50,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -63,7 +61,6 @@ import com.matedroid.domain.model.YearFilter
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -333,37 +330,6 @@ private fun CountryCard(
     }
 }
 
-@Composable
-private fun StatChip(
-    icon: ImageVector,
-    value: String,
-    palette: CarColorPalette,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(palette.onSurface.copy(alpha = 0.05f))
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(14.dp),
-            tint = palette.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.labelMedium,
-            color = palette.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
 
 @Composable
 private fun EmptyState(palette: CarColorPalette) {
@@ -389,11 +355,3 @@ private fun EmptyState(palette: CarColorPalette) {
  * Get the localized country name for a given ISO country code.
  * Falls back to the country code if localization fails.
  */
-private fun getLocalizedCountryName(countryCode: String): String {
-    return try {
-        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
-            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
-    } catch (e: Exception) {
-        countryCode
-    }
-}

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -103,53 +101,14 @@ fun CountriesVisitedScreen(
                                 contentDescription = stringResource(R.string.sort)
                             )
                         }
-                        DropdownMenu(
+                        GeoSortMenu(
                             expanded = showSortMenu,
-                            onDismissRequest = { showSortMenu = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_first_visit)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.FIRST_VISIT)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_alphabetically)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.ALPHABETICAL)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_drive_count)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.DRIVE_COUNT)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_distance)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.DISTANCE)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_energy)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.ENERGY)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_charges)) },
-                                onClick = {
-                                    viewModel.setSortOrder(CountrySortOrder.CHARGES)
-                                    showSortMenu = false
-                                }
-                            )
-                        }
+                            onDismiss = { showSortMenu = false },
+                            onSelect = {
+                                viewModel.setSortOrder(it)
+                                showSortMenu = false
+                            }
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedViewModel.kt
@@ -19,19 +19,11 @@ import javax.inject.Inject
 /**
  * Sorting options for the countries list.
  */
-enum class CountrySortOrder {
-    FIRST_VISIT,    // Chronological by first visit date (default)
-    ALPHABETICAL,   // A-Z by country name
-    DRIVE_COUNT,    // Most drives first
-    DISTANCE,       // Most distance first
-    ENERGY,         // Most energy charged first
-    CHARGES         // Most charges first
-}
 
 data class CountriesVisitedUiState(
     val isLoading: Boolean = true,
     val countries: List<CountryRecord> = emptyList(),
-    val sortOrder: CountrySortOrder = CountrySortOrder.FIRST_VISIT,
+    val sortOrder: GeoSortOrder = GeoSortOrder.FIRST_VISIT,
     val units: Units? = null,
     val error: String? = null
 )
@@ -80,7 +72,7 @@ class CountriesVisitedViewModel @Inject constructor(
         }
     }
 
-    fun setSortOrder(order: CountrySortOrder) {
+    fun setSortOrder(order: GeoSortOrder) {
         val sorted = sortCountries(originalCountries, order)
         _uiState.update {
             it.copy(
@@ -92,15 +84,15 @@ class CountriesVisitedViewModel @Inject constructor(
 
     private fun sortCountries(
         countries: List<CountryRecord>,
-        order: CountrySortOrder
+        order: GeoSortOrder
     ): List<CountryRecord> {
         return when (order) {
-            CountrySortOrder.FIRST_VISIT -> countries.sortedBy { it.firstVisitDate }
-            CountrySortOrder.ALPHABETICAL -> countries.sortedBy { it.countryName }
-            CountrySortOrder.DRIVE_COUNT -> countries.sortedByDescending { it.driveCount }
-            CountrySortOrder.DISTANCE -> countries.sortedByDescending { it.totalDistanceKm }
-            CountrySortOrder.ENERGY -> countries.sortedByDescending { it.totalChargeEnergyKwh }
-            CountrySortOrder.CHARGES -> countries.sortedByDescending { it.chargeCount }
+            GeoSortOrder.FIRST_VISIT -> countries.sortedBy { it.firstVisitDate }
+            GeoSortOrder.ALPHABETICAL -> countries.sortedBy { it.countryName }
+            GeoSortOrder.DRIVE_COUNT -> countries.sortedByDescending { it.driveCount }
+            GeoSortOrder.DISTANCE -> countries.sortedByDescending { it.totalDistanceKm }
+            GeoSortOrder.ENERGY -> countries.sortedByDescending { it.totalChargeEnergyKwh }
+            GeoSortOrder.CHARGES -> countries.sortedByDescending { it.chargeCount }
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
@@ -1,0 +1,65 @@
+package com.matedroid.ui.screens.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.matedroid.ui.theme.CarColorPalette
+import java.util.Locale
+
+/** Icon + value chip used on the countries- and regions-visited cards. */
+@Composable
+fun StatChip(
+    icon: ImageVector,
+    value: String,
+    palette: CarColorPalette,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(palette.onSurface.copy(alpha = 0.05f))
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = palette.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.labelMedium,
+            color = palette.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/** Resolve an ISO country code to its display name in the current locale, falling back to the code. */
+fun getLocalizedCountryName(countryCode: String): String {
+    return try {
+        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
+            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
+    } catch (e: Exception) {
+        countryCode
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/GeoVisitedShared.kt
@@ -1,5 +1,6 @@
 package com.matedroid.ui.screens.stats
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -8,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -16,10 +19,39 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.matedroid.R
 import com.matedroid.ui.theme.CarColorPalette
 import java.util.Locale
+
+/** Sort order shared by the countries- and regions-visited screens. */
+enum class GeoSortOrder(@get:StringRes val labelRes: Int) {
+    FIRST_VISIT(R.string.sort_by_first_visit),   // Chronological by first visit date (default)
+    ALPHABETICAL(R.string.sort_alphabetically),  // A-Z by name
+    DRIVE_COUNT(R.string.sort_by_drive_count),   // Most drives first
+    DISTANCE(R.string.sort_by_distance),         // Most distance first
+    ENERGY(R.string.sort_by_energy),             // Most energy charged first
+    CHARGES(R.string.sort_by_charges),           // Most charges first
+}
+
+/** The sort dropdown for the geo-visited screens; [onSelect] fires with the chosen order. */
+@Composable
+fun GeoSortMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onSelect: (GeoSortOrder) -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        GeoSortOrder.entries.forEach { order ->
+            DropdownMenuItem(
+                text = { Text(stringResource(order.labelRes)) },
+                onClick = { onSelect(order) }
+            )
+        }
+    }
+}
 
 /** Icon + value chip used on the countries- and regions-visited cards. */
 @Composable

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -27,8 +27,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -126,53 +124,14 @@ fun RegionsVisitedScreen(
                                 contentDescription = stringResource(R.string.sort)
                             )
                         }
-                        DropdownMenu(
+                        GeoSortMenu(
                             expanded = showSortMenu,
-                            onDismissRequest = { showSortMenu = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_first_visit)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.FIRST_VISIT)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_alphabetically)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.ALPHABETICAL)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_drive_count)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.DRIVE_COUNT)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_distance)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.DISTANCE)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_energy)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.ENERGY)
-                                    showSortMenu = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.sort_by_charges)) },
-                                onClick = {
-                                    viewModel.setSortOrder(RegionSortOrder.CHARGES)
-                                    showSortMenu = false
-                                }
-                            )
-                        }
+                            onDismiss = { showSortMenu = false },
+                            onSelect = {
+                                viewModel.setSortOrder(it)
+                                showSortMenu = false
+                            }
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EvStation
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -57,7 +56,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -1033,37 +1031,6 @@ private fun RegionCard(
     }
 }
 
-@Composable
-private fun StatChip(
-    icon: ImageVector,
-    value: String,
-    palette: CarColorPalette,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(palette.onSurface.copy(alpha = 0.05f))
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(14.dp),
-            tint = palette.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.labelMedium,
-            color = palette.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
 
 @Composable
 private fun EmptyState(palette: CarColorPalette) {
@@ -1094,12 +1061,4 @@ private fun formatDate(dateStr: String): String {
  * Get the localized country name for a given ISO country code.
  * Falls back to the country code if localization fails.
  */
-private fun getLocalizedCountryName(countryCode: String): String {
-    return try {
-        Locale.Builder().setRegion(countryCode).build().getDisplayCountry(Locale.getDefault())
-            .takeIf { it.isNotBlank() && it != countryCode } ?: countryCode
-    } catch (e: Exception) {
-        countryCode
-    }
-}
 

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
@@ -23,14 +23,6 @@ import javax.inject.Inject
 /**
  * Sorting options for the regions list.
  */
-enum class RegionSortOrder {
-    FIRST_VISIT,    // Chronological by first visit date (default)
-    ALPHABETICAL,   // A-Z by region name
-    DRIVE_COUNT,    // Most drives first
-    DISTANCE,       // Most distance first
-    ENERGY,         // Most energy charged first
-    CHARGES         // Most charges first
-}
 
 /**
  * Map view mode for switching between charges and drives.
@@ -61,7 +53,7 @@ data class RegionsVisitedUiState(
     val chargeTypeFilter: ChargeTypeFilter = ChargeTypeFilter.ALL,
     val availableYears: List<Int> = emptyList(),    // Years with data in this country
     val selectedMapYear: Int? = null,                // null = all years
-    val sortOrder: RegionSortOrder = RegionSortOrder.FIRST_VISIT,
+    val sortOrder: GeoSortOrder = GeoSortOrder.FIRST_VISIT,
     val error: String? = null
 ) {
     /** Charges filtered by type and year for map display */
@@ -167,7 +159,7 @@ class RegionsVisitedViewModel @Inject constructor(
         }
     }
 
-    fun setSortOrder(order: RegionSortOrder) {
+    fun setSortOrder(order: GeoSortOrder) {
         val sorted = sortRegions(originalRegions, order)
         _uiState.update {
             it.copy(
@@ -199,15 +191,15 @@ class RegionsVisitedViewModel @Inject constructor(
 
     private fun sortRegions(
         regions: List<RegionRecord>,
-        order: RegionSortOrder
+        order: GeoSortOrder
     ): List<RegionRecord> {
         return when (order) {
-            RegionSortOrder.FIRST_VISIT -> regions.sortedBy { it.firstVisitDate }
-            RegionSortOrder.ALPHABETICAL -> regions.sortedBy { it.regionName }
-            RegionSortOrder.DRIVE_COUNT -> regions.sortedByDescending { it.driveCount }
-            RegionSortOrder.DISTANCE -> regions.sortedByDescending { it.totalDistanceKm }
-            RegionSortOrder.ENERGY -> regions.sortedByDescending { it.totalChargeEnergyKwh }
-            RegionSortOrder.CHARGES -> regions.sortedByDescending { it.chargeCount }
+            GeoSortOrder.FIRST_VISIT -> regions.sortedBy { it.firstVisitDate }
+            GeoSortOrder.ALPHABETICAL -> regions.sortedBy { it.regionName }
+            GeoSortOrder.DRIVE_COUNT -> regions.sortedByDescending { it.driveCount }
+            GeoSortOrder.DISTANCE -> regions.sortedByDescending { it.totalDistanceKm }
+            GeoSortOrder.ENERGY -> regions.sortedByDescending { it.totalChargeEnergyKwh }
+            GeoSortOrder.CHARGES -> regions.sortedByDescending { it.chargeCount }
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -655,7 +655,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
             )
             StatItem(
                 label = stringResource(R.string.stats_energy_used),
-                value = formatEnergy(quickStats.totalEnergyConsumedKwh),
+                value = UnitFormatter.formatEnergy(quickStats.totalEnergyConsumedKwh),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -668,7 +668,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
             )
             StatItem(
                 label = stringResource(R.string.stats_cost_per_distance, UnitFormatter.getDistanceUnit(units)),
-                value = costPer100Km?.let { "%.2f %s".format(it, currencySymbol) } ?: "N/A",
+                value = costPer100Km?.let { UnitFormatter.formatCost(it, currencySymbol) } ?: "N/A",
                 modifier = Modifier.weight(1f)
             )
         }
@@ -690,7 +690,7 @@ private fun QuickStatsChargesCard(quickStats: QuickStats, palette: CarColorPalet
             )
             StatItem(
                 label = stringResource(R.string.energy_added),
-                value = formatEnergy(quickStats.totalEnergyAddedKwh),
+                value = UnitFormatter.formatEnergy(quickStats.totalEnergyAddedKwh),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -699,12 +699,12 @@ private fun QuickStatsChargesCard(quickStats: QuickStats, palette: CarColorPalet
             Row(modifier = Modifier.fillMaxWidth()) {
                 StatItem(
                     label = stringResource(R.string.total_cost),
-                    value = "%.2f %s".format(quickStats.totalCost, currencySymbol),
+                    value = UnitFormatter.formatCost(quickStats.totalCost, currencySymbol),
                     modifier = Modifier.weight(1f)
                 )
                 StatItem(
                     label = stringResource(R.string.stats_avg_cost_kwh),
-                    value = quickStats.avgCostPerKwh?.let { "%.3f %s".format(it, currencySymbol) } ?: "N/A",
+                    value = quickStats.avgCostPerKwh?.let { UnitFormatter.formatCost(it, currencySymbol, perKwh = true) } ?: "N/A",
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -820,13 +820,13 @@ private fun RecordsCard(
     }
     quickStats.mostExpensiveCharge?.let { charge ->
         charge.cost?.let { cost ->
-            batteryRecords.add(RecordData("💸", labelMostExpensive, "%.2f %s".format(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+            batteryRecords.add(RecordData("💸", labelMostExpensive, UnitFormatter.formatCost(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
         }
     }
     quickStats.mostExpensivePerKwhCharge?.let { charge ->
         charge.cost?.let { cost ->
             if (charge.energyAdded > 0) {
-                batteryRecords.add(RecordData("📈", labelPriciestKwh, "%.3f %s".format(cost / charge.energyAdded, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+                batteryRecords.add(RecordData("📈", labelPriciestKwh, UnitFormatter.formatCost(cost / charge.energyAdded, currencySymbol, perKwh = true), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
             }
         }
     }
@@ -1135,14 +1135,6 @@ private fun TemperatureStatsCard(deepStats: DeepStats, palette: CarColorPalette,
     }
 }
 
-private fun formatEnergy(kwh: Double): String {
-    return if (kwh >= 1000) {
-        "%.1f MWh".format(kwh / 1000)
-    } else {
-        "%.0f kWh".format(kwh)
-    }
-}
-
 @Composable
 private fun AcDcRatioCard(deepStats: DeepStats, palette: CarColorPalette) {
     val totalEnergy = deepStats.acChargeEnergyKwh + deepStats.dcChargeEnergyKwh
@@ -1163,12 +1155,12 @@ private fun AcDcRatioCard(deepStats: DeepStats, palette: CarColorPalette) {
         Row(modifier = Modifier.fillMaxWidth()) {
             StatItem(
                 label = stringResource(R.string.stats_ac_energy),
-                value = formatEnergy(deepStats.acChargeEnergyKwh),
+                value = UnitFormatter.formatEnergy(deepStats.acChargeEnergyKwh),
                 modifier = Modifier.weight(1f)
             )
             StatItem(
                 label = stringResource(R.string.stats_dc_energy),
-                value = formatEnergy(deepStats.dcChargeEnergyKwh),
+                value = UnitFormatter.formatEnergy(deepStats.dcChargeEnergyKwh),
                 modifier = Modifier.weight(1f)
             )
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -597,7 +597,7 @@ private fun ChargeCostCard(
                         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
                     ) {
                         EfficiencyPill(
-                            value = "%.2f %s".format(perKwh, currencySymbol),
+                            value = UnitFormatter.formatCost(perKwh, currencySymbol),
                             unit = "/ kWh",
                             palette = palette
                         )
@@ -647,7 +647,7 @@ private fun ChargeCostCard(
                                     )
                                 }
                                 Text(
-                                    text = "%.2f %s".format(charge.cost, currencySymbol),
+                                    text = UnitFormatter.formatCost(charge.cost ?: 0.0, currencySymbol),
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.Bold,
                                     color = shade


### PR DESCRIPTION
The complete **Tier 2 de-duplication** pass. Pure refactor, no behavioural change except one minor, deliberate formatting polish (cost thousands separators, in CHANGELOG). Each item is its own commit.

## Shared abstractions extracted
- **`TeslamateRepository`: 12 API wrappers → one `Response.toResult` mapper** (~180 lines + a dead `try/catch` gone); `getCurrentCharge` keeps its bespoke handling.
- **Energy & cost formatting → `UnitFormatter`** (`formatEnergy`, `formatCost`); removed two diverged `formatEnergy` copies and routed the suffix-style cost sites through the shared helper.
- **Duplicated leaf composables extracted** — `SortChip`/`LegendItem`/`Pill`/`rankBadge` → `ComparisonStats.kt`; `StatChip`/`getLocalizedCountryName` → new `GeoVisitedShared.kt`.
- **Chart data/label dedup** — dropped `DualChartData`/`prepareDualChartData` (identical to `ChartData`/`prepareChartData`); shared Y-label logic via `axisLabelValues()`.
- **`WorkerForegroundNotifier`** — extracted the near-verbatim foreground-notification + channel plumbing shared by `DataSyncWorker`/`GeocodeWorker`.
- **`FullscreenChartFrame`** — the two Fullscreen chart wrappers (~90% identical chrome: orientation lock, Dialog, back button) now share one slot-based frame; both are thin call sites.
- **Merged duplicated enums** — `DriveDateFilter`/`DriveChartGranularity` → shared `DateFilter`/`ChartGranularity` (`ui/screens/common/ListFilters.kt`); `CountrySortOrder`/`RegionSortOrder` → `GeoSortOrder` + a reusable `GeoSortMenu`.
- **`buildTimeSeries` binner** — the ~120-line daily/weekly/monthly bucketing duplicated in the Charges/Drives view-models is now a single generic engine; a bucketing fix lives in one place.

## User-visible
- Only one: large cost totals now show a thousands separator (`1,234.56`). In CHANGELOG under Changed.

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleDebug` — all green.
- Worth a visual spot-check on the Charges/Drives list charts (the `buildTimeSeries` extraction is faithful/byte-for-byte, but it's the one behaviour-adjacent change) and the compare/countries/regions screens.

## Deliberately NOT done (over-abstraction, per the analysis)
No `BaseComparisonViewModel`, no unified list-filter pipeline, no shared `GeoVisitedScreen`, no DAO `@RawQuery` rewrite — the divergent logic there is the substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
