### PR TITLE
Add read-only trip summary widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Trip summary home-screen widget** — a read-only widget over cached TeslaMate data showing distance, drives, driving days, energy, efficiency, charging cost, and cost/100 for 7/30/90-day ranges, with previous-period distance comparison and honest partial-cost labels. Never sends vehicle commands or polls the car.
+
 ### Changed
 - **Snappier throughout** — smoother list scrolling, lighter chart rendering, the Stats and Trips screens do their heavy work off the UI thread, and the dashboard stops polling for status while it's off screen (less background battery use). No change to how anything looks.
 - **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A native Android application for viewing Tesla vehicle data from your self-hoste
 
 - **Dashboard** - Real-time vehicle status at a glance with 3D car image matching your vehicle's color and wheels. Long tap it to change the picture.
 - **Notifications** - Sentry events notification, tyres pressure alert and Live notification (Android 16+) of charging sessions.
-- **Widget** - Home/lock screen widget for easy and safe read-only access to your car status. No more trunks opened due to a misstap!
+- **Widget** - Home/lock screen widgets for easy and safe read-only access: car status, plus a trip summary widget for distance, energy, efficiency, and charging costs over 7/30/90 days. No more trunks opened due to a misstap!
 - **Stats for Nerds** - Tap car image for advanced statistics: records, extremes, AC/DC ratio and much more!
 - **Charging History** - View all charging sessions with statistics and charts
 - **Charge Details** - Interactive map and detailed power/voltage/temperature charts

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,9 +87,31 @@
                 android:resource="@xml/car_widget_info" />
         </receiver>
 
+        <!-- Home screen widget: recent trip summary -->
+        <receiver
+            android:name=".widget.TripSummaryWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/trip_summary_widget_info" />
+        </receiver>
+
         <!-- Widget configuration activity: car selection -->
         <activity
             android:name=".widget.CarWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/Theme.MateDroid">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <!-- Widget configuration activity: car selection for trip summaries -->
+        <activity
+            android:name=".widget.TripSummaryWidgetConfigActivity"
             android:exported="true"
             android:theme="@style/Theme.MateDroid">
             <intent-filter>

--- a/app/src/main/java/com/matedroid/MainActivity.kt
+++ b/app/src/main/java/com/matedroid/MainActivity.kt
@@ -25,7 +25,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         currentIntent = intent
-        if (intent.hasExtra("EXTRA_CAR_ID")) {
+        if (intent.hasExtra("EXTRA_CAR_ID") &&
+            !intent.getBooleanExtra("EXTRA_SKIP_CAR_WIDGET_UPDATE", false)
+        ) {
             CarWidgetUpdateWorker.scheduleImmediateUpdate(this)
         }
         enableEdgeToEdge()

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -54,6 +54,7 @@ data class AppSettings(
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
     val teslamateBaseUrl: String = "",
+    val unitOfLength: String = "km",
     val lastSelectedCarId: Int? = null
 ) {
     val isConfigured: Boolean
@@ -76,6 +77,7 @@ class SettingsDataStore @Inject constructor(
     private val currencyCodeKey = stringPreferencesKey("currency_code")
     private val showShortDrivesChargesKey = booleanPreferencesKey("show_short_drives_charges")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
+    private val unitOfLengthKey = stringPreferencesKey("unit_of_length")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
     private val notificationPermissionAskedKey = booleanPreferencesKey("notification_permission_asked")
@@ -95,6 +97,7 @@ class SettingsDataStore @Inject constructor(
             currencyCode = preferences[currencyCodeKey] ?: "EUR",
             showShortDrivesCharges = preferences[showShortDrivesChargesKey] ?: false,
             teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
+            unitOfLength = preferences[unitOfLengthKey] ?: "km",
             lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
     }
@@ -191,6 +194,12 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveTeslamateBaseUrl(url: String) {
         context.dataStore.edit { preferences ->
             preferences[teslamateBaseUrlKey] = url
+        }
+    }
+
+    suspend fun saveUnitOfLength(unitOfLength: String) {
+        context.dataStore.edit { preferences ->
+            preferences[unitOfLengthKey] = unitOfLength
         }
     }
 

--- a/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
@@ -62,6 +62,14 @@ interface ChargeSummaryDao {
     """)
     suspend fun sumCostInRange(carId: Int, startDate: String, endDate: String): Double
 
+    @Query("""
+        SELECT COUNT(*) FROM charges_summary
+        WHERE carId = :carId
+        AND startDate >= :startDate AND startDate < :endDate
+        AND cost IS NOT NULL
+    """)
+    suspend fun countWithCostInRange(carId: Int, startDate: String, endDate: String): Int
+
     // Average cost per kWh
     @Query("""
         SELECT COALESCE(SUM(cost) / NULLIF(SUM(energyAdded), 0), 0)

--- a/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
@@ -130,6 +130,8 @@ class DataSyncWorker @AssistedInject constructor(
 
             return if (hasNetworkError) {
                 log("Sync incomplete due to network errors, scheduling retry")
+                // Summaries may still have landed — refresh trip widget before retrying details.
+                TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(applicationContext)
                 Result.retry()
             } else {
                 log("Sync complete for all cars")

--- a/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/DataSyncWorker.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit
 import com.matedroid.R
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.widget.TripSummaryWidgetUpdateWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -134,6 +135,7 @@ class DataSyncWorker @AssistedInject constructor(
                 log("Sync complete for all cars")
                 // Schedule background geocoding for location data
                 scheduleGeocoding()
+                TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(applicationContext)
                 Result.success()
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
@@ -10,6 +10,7 @@ import com.matedroid.data.api.models.ChargeData
 import com.matedroid.data.api.models.ChargeDetail
 import com.matedroid.data.api.models.DriveData
 import com.matedroid.data.api.models.DriveDetail
+import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.dao.DriveSummaryDao
@@ -41,7 +42,8 @@ class SyncRepository @Inject constructor(
     private val aggregateDao: AggregateDao,
     private val syncManager: SyncManager,
     private val logCollector: SyncLogCollector,
-    private val geocodingRepository: GeocodingRepository
+    private val geocodingRepository: GeocodingRepository,
+    private val settingsDataStore: SettingsDataStore,
 ) {
     companion object {
         private const val TAG = "SyncRepository"
@@ -159,7 +161,22 @@ class SyncRepository @Inject constructor(
             }
         }
 
+        // Cache the unit system that these summaries were converted into, so
+        // offline widgets/screens label Room values honestly.
+        cacheUnitOfLengthFromGlobalSettings()
+
         return true
+    }
+
+    private suspend fun cacheUnitOfLengthFromGlobalSettings() {
+        when (val result = teslamateRepository.getGlobalSettings()) {
+            is ApiResult.Success -> {
+                result.data.settings?.teslamateUnits?.unitOfLength
+                    ?.takeIf { it == "km" || it == "mi" }
+                    ?.let { settingsDataStore.saveUnitOfLength(it) }
+            }
+            is ApiResult.Error -> Unit
+        }
     }
 
     /**

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -179,6 +179,7 @@ fun NavGraph(
                     "mileage" -> Screen.Mileage(carId, exteriorColor)
                     "battery" -> Screen.Battery(carId, exteriorColor = exteriorColor)
                     "stats" -> Screen.Stats(carId, exteriorColor)
+                    "trips" -> Screen.Trips(carId, exteriorColor)
                     "countries_visited" -> Screen.CountriesVisited(carId, exteriorColor)
                     "updates" -> Screen.Updates(carId, exteriorColor)
                     "sentry_history" -> Screen.SentryHistory(carId, exteriorColor)

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -396,16 +396,20 @@ class DashboardViewModel @Inject constructor(
     }
 
     /**
-     * Fetches global settings from the API and caches the base_url.
+     * Fetches global settings from the API and caches settings used offline.
      * This runs silently - failures don't affect the user experience.
      */
     private fun fetchAndCacheGlobalSettings() {
         viewModelScope.launch {
             when (val result = repository.getGlobalSettings()) {
                 is ApiResult.Success -> {
-                    result.data.settings?.teslamateUrls?.baseUrl?.let { url ->
+                    val globalSettings = result.data.settings
+                    globalSettings?.teslamateUrls?.baseUrl?.let { url ->
                         settingsDataStore.saveTeslamateBaseUrl(url.trimEnd('/'))
                     }
+                    globalSettings?.teslamateUnits?.unitOfLength
+                        ?.takeIf { it == "km" || it == "mi" }
+                        ?.let { settingsDataStore.saveUnitOfLength(it) }
                 }
                 is ApiResult.Error -> {
                     // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -2,7 +2,6 @@ package com.matedroid.ui.screens.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import android.content.Context
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarExterior
 import com.matedroid.data.api.models.CarStatus
@@ -17,10 +16,8 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TeslamateRepository
-import com.matedroid.widget.TripSummaryWidgetUpdateWorker
 import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +73,6 @@ data class DashboardUiState(
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    @ApplicationContext private val appContext: Context,
     private val repository: TeslamateRepository,
     private val geocodingRepository: GeocodingRepository,
     private val settingsDataStore: SettingsDataStore,
@@ -413,10 +409,8 @@ class DashboardViewModel @Inject constructor(
                     }
                     globalSettings?.teslamateUnits?.unitOfLength
                         ?.takeIf { it == "km" || it == "mi" }
-                        ?.let {
-                            settingsDataStore.saveUnitOfLength(it)
-                            TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(appContext)
-                        }
+                        ?.let { settingsDataStore.saveUnitOfLength(it) }
+                    // Widget refresh waits for summary sync so labels match Room values.
                 }
                 is ApiResult.Error -> {
                     // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.content.Context
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarExterior
 import com.matedroid.data.api.models.CarStatus
@@ -16,8 +17,10 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.widget.TripSummaryWidgetUpdateWorker
 import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,6 +76,7 @@ data class DashboardUiState(
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val repository: TeslamateRepository,
     private val geocodingRepository: GeocodingRepository,
     private val settingsDataStore: SettingsDataStore,
@@ -409,7 +413,10 @@ class DashboardViewModel @Inject constructor(
                     }
                     globalSettings?.teslamateUnits?.unitOfLength
                         ?.takeIf { it == "km" || it == "mi" }
-                        ?.let { settingsDataStore.saveUnitOfLength(it) }
+                        ?.let {
+                            settingsDataStore.saveUnitOfLength(it)
+                            TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(appContext)
+                        }
                 }
                 is ApiResult.Error -> {
                     // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -267,10 +267,9 @@ class SettingsViewModel @Inject constructor(
                 }
                 globalSettings?.teslamateUnits?.unitOfLength
                     ?.takeIf { it == "km" || it == "mi" }
-                    ?.let {
-                        settingsDataStore.saveUnitOfLength(it)
-                        TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(context)
-                    }
+                    ?.let { settingsDataStore.saveUnitOfLength(it) }
+                // Do not refresh the trip widget here: Room summaries are still in the
+                // previous unit until the next sync. Currency changes refresh separately.
             }
             is ApiResult.Error -> {
                 // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ import com.matedroid.notification.SentryNotificationManager
 import com.matedroid.data.sync.DataSyncWorker
 import com.matedroid.data.sync.SyncManager
 import com.matedroid.data.sync.TpmsPressureWorker
+import com.matedroid.widget.TripSummaryWidgetUpdateWorker
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -170,6 +171,7 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(currencyCode = currencyCode)
         viewModelScope.launch {
             settingsDataStore.saveCurrency(currencyCode)
+            TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(context)
         }
     }
 
@@ -265,7 +267,10 @@ class SettingsViewModel @Inject constructor(
                 }
                 globalSettings?.teslamateUnits?.unitOfLength
                     ?.takeIf { it == "km" || it == "mi" }
-                    ?.let { settingsDataStore.saveUnitOfLength(it) }
+                    ?.let {
+                        settingsDataStore.saveUnitOfLength(it)
+                        TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(context)
+                    }
             }
             is ApiResult.Error -> {
                 // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -253,15 +253,19 @@ class SettingsViewModel @Inject constructor(
     }
 
     /**
-     * Fetches global settings from the API and caches the base_url.
+     * Fetches global settings from the API and caches settings used offline.
      * This runs silently - failures don't affect the user experience.
      */
     private suspend fun fetchAndCacheGlobalSettings() {
         when (val result = repository.getGlobalSettings()) {
             is ApiResult.Success -> {
-                result.data.settings?.teslamateUrls?.baseUrl?.let { url ->
+                val globalSettings = result.data.settings
+                globalSettings?.teslamateUrls?.baseUrl?.let { url ->
                     settingsDataStore.saveTeslamateBaseUrl(url.trimEnd('/'))
                 }
+                globalSettings?.teslamateUnits?.unitOfLength
+                    ?.takeIf { it == "km" || it == "mi" }
+                    ?.let { settingsDataStore.saveUnitOfLength(it) }
             }
             is ApiResult.Error -> {
                 // Silent fail - this is optional functionality

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
@@ -1,0 +1,415 @@
+package com.matedroid.widget
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.appWidgetBackground
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.state.GlanceStateDefinition
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.matedroid.MainActivity
+import com.matedroid.R
+
+private val TRIP_WIDGET_BACKGROUND = Color(0xFF101413)
+private val TRIP_WIDGET_PANEL = Color(0xFF18201E)
+private val TRIP_WIDGET_ACCENT = Color(0xFF58D68D)
+private val TRIP_WIDGET_SECONDARY = Color(0xFFFFC857)
+private val TRIP_WIDGET_TEXT = Color.White
+private val TRIP_WIDGET_MUTED = Color(0xB3FFFFFF)
+
+/**
+ * Read-only home screen widget focused on recent driving and charging summaries.
+ *
+ * All database work happens in [TripSummaryWidgetUpdateWorker]. Rendering uses
+ * preformatted values from Glance preferences so the widget itself never talks
+ * to TeslaMate or the car.
+ */
+class TripSummaryWidget : GlanceAppWidget() {
+
+    companion object {
+        val CAR_ID_KEY = intPreferencesKey("trip_summary_car_id")
+        val HAS_DATA_KEY = booleanPreferencesKey("trip_summary_has_data")
+        val HAS_DRIVES_KEY = booleanPreferencesKey("trip_summary_has_drives")
+        val CAR_NAME_KEY = stringPreferencesKey("trip_summary_car_name")
+        val DISTANCE_VALUE_KEY = stringPreferencesKey("trip_summary_distance_value")
+        val DRIVE_COUNT_VALUE_KEY = stringPreferencesKey("trip_summary_drive_count_value")
+        val DRIVING_DAYS_VALUE_KEY = stringPreferencesKey("trip_summary_driving_days_value")
+        val ENERGY_VALUE_KEY = stringPreferencesKey("trip_summary_energy_value")
+        val EFFICIENCY_VALUE_KEY = stringPreferencesKey("trip_summary_efficiency_value")
+        val COST_VALUE_KEY = stringPreferencesKey("trip_summary_cost_value")
+        val COST_PER_DISTANCE_VALUE_KEY = stringPreferencesKey("trip_summary_cost_per_distance_value")
+        val DISTANCE_UNIT_KEY = stringPreferencesKey("trip_summary_distance_unit")
+        val UPDATED_VALUE_KEY = stringPreferencesKey("trip_summary_updated_value")
+    }
+
+    override val stateDefinition: GlanceStateDefinition<*> = PreferencesGlanceStateDefinition
+
+    override val sizeMode: SizeMode = SizeMode.Exact
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent { WidgetContent() }
+    }
+
+    @Composable
+    internal fun WidgetContent() {
+        val prefs = currentState<Preferences>()
+        val carId = prefs[CAR_ID_KEY]
+        val hasData = prefs[HAS_DATA_KEY] ?: false
+        val context = LocalContext.current
+
+        GlanceTheme {
+            val cornerMod = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                GlanceModifier.cornerRadius(android.R.dimen.system_app_widget_background_radius)
+            } else {
+                GlanceModifier
+            }
+            val openTripsIntent = Intent(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra("EXTRA_NAVIGATE_TO", "trips")
+                .putExtra("EXTRA_SKIP_CAR_WIDGET_UPDATE", true)
+                .apply {
+                    if (carId != null) putExtra("EXTRA_CAR_ID", carId)
+                }
+
+            Box(
+                modifier = GlanceModifier
+                    .fillMaxSize()
+                    .appWidgetBackground()
+                    .then(cornerMod)
+                    .background(ColorProvider(TRIP_WIDGET_BACKGROUND))
+                    .clickable(actionStartActivity(openTripsIntent))
+            ) {
+                when {
+                    carId == null -> CenteredMessage(context.getString(R.string.widget_error_configure))
+                    !hasData -> CenteredMessage(context.getString(R.string.widget_loading))
+                    else -> SummaryContent(prefs)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun CenteredMessage(text: String) {
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(ColorProvider(TRIP_WIDGET_BACKGROUND))
+                .padding(12.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                style = TextStyle(
+                    color = ColorProvider(TRIP_WIDGET_MUTED),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium
+                ),
+                maxLines = 2
+            )
+        }
+    }
+
+    @Composable
+    private fun SummaryContent(prefs: Preferences) {
+        val context = LocalContext.current
+        val size = LocalSize.current
+        val compact = size.height.value < 115f || size.width.value < 190f
+
+        val carName = prefs[CAR_NAME_KEY].orEmpty()
+        val hasDrives = prefs[HAS_DRIVES_KEY] ?: false
+        val distance = prefs[DISTANCE_VALUE_KEY].orEmpty()
+        val drives = prefs[DRIVE_COUNT_VALUE_KEY].orEmpty()
+        val drivingDays = prefs[DRIVING_DAYS_VALUE_KEY].orEmpty()
+        val energy = prefs[ENERGY_VALUE_KEY].orEmpty()
+        val efficiency = prefs[EFFICIENCY_VALUE_KEY].orEmpty()
+        val cost = prefs[COST_VALUE_KEY].orEmpty()
+        val costPerDistance = prefs[COST_PER_DISTANCE_VALUE_KEY].orEmpty()
+        val distanceUnit = prefs[DISTANCE_UNIT_KEY].orEmpty()
+        val updated = prefs[UPDATED_VALUE_KEY].orEmpty()
+
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = if (compact) 10.dp else 14.dp,
+                    vertical = if (compact) 8.dp else 12.dp
+                )
+        ) {
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = GlanceModifier.defaultWeight()) {
+                    if (carName.isNotBlank()) {
+                        Text(
+                            text = carName,
+                            style = TextStyle(
+                                color = ColorProvider(TRIP_WIDGET_TEXT),
+                                fontSize = if (compact) 12.sp else 14.sp,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            maxLines = 1
+                        )
+                    }
+                    Text(
+                        text = context.getString(R.string.trip_widget_period_last_30_days),
+                        style = TextStyle(
+                            color = ColorProvider(TRIP_WIDGET_MUTED),
+                            fontSize = if (compact) 10.sp else 11.sp
+                        ),
+                        maxLines = 1
+                    )
+                }
+                if (!compact && updated.isNotBlank()) {
+                    Text(
+                        text = updated,
+                        style = TextStyle(
+                            color = ColorProvider(TRIP_WIDGET_MUTED),
+                            fontSize = 10.sp
+                        ),
+                        maxLines = 1
+                    )
+                }
+            }
+
+            Spacer(modifier = GlanceModifier.height(if (compact) 4.dp else 8.dp))
+
+            if (!hasDrives) {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .defaultWeight()
+                        .background(ColorProvider(TRIP_WIDGET_PANEL))
+                        .cornerRadius(8.dp)
+                        .padding(12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = context.getString(R.string.trip_widget_empty),
+                        style = TextStyle(
+                            color = ColorProvider(TRIP_WIDGET_MUTED),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Medium
+                        ),
+                        maxLines = 2
+                    )
+                }
+            } else {
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Column(modifier = GlanceModifier.defaultWeight()) {
+                        Text(
+                            text = distance,
+                            style = TextStyle(
+                                color = ColorProvider(TRIP_WIDGET_ACCENT),
+                                fontSize = if (compact) 22.sp else 30.sp,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            maxLines = 1
+                        )
+                        Text(
+                            text = context.getString(R.string.distance),
+                            style = TextStyle(
+                                color = ColorProvider(TRIP_WIDGET_MUTED),
+                                fontSize = 10.sp
+                            ),
+                            maxLines = 1
+                        )
+                    }
+                    Spacer(modifier = GlanceModifier.width(8.dp))
+                    Column(
+                        horizontalAlignment = Alignment.End
+                    ) {
+                        Text(
+                            text = drives,
+                            style = TextStyle(
+                                color = ColorProvider(TRIP_WIDGET_TEXT),
+                                fontSize = if (compact) 18.sp else 22.sp,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            maxLines = 1
+                        )
+                        Text(
+                            text = context.getString(R.string.nav_drives),
+                            style = TextStyle(
+                                color = ColorProvider(TRIP_WIDGET_MUTED),
+                                fontSize = 10.sp
+                            ),
+                            maxLines = 1
+                        )
+                    }
+                }
+
+                if (compact) {
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+                    CompactFooter(cost = cost, efficiency = efficiency)
+                } else {
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+
+                    Row(modifier = GlanceModifier.fillMaxWidth()) {
+                        MetricTile(
+                            label = context.getString(R.string.trip_widget_energy),
+                            value = energy,
+                            accent = TRIP_WIDGET_SECONDARY,
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                        Spacer(modifier = GlanceModifier.width(8.dp))
+                        MetricTile(
+                            label = context.getString(R.string.cost),
+                            value = cost,
+                            accent = TRIP_WIDGET_ACCENT,
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                    }
+
+                    Spacer(modifier = GlanceModifier.height(7.dp))
+
+                    Row(modifier = GlanceModifier.fillMaxWidth()) {
+                        MetricTile(
+                            label = context.getString(R.string.trip_widget_efficiency),
+                            value = efficiency,
+                            accent = TRIP_WIDGET_ACCENT,
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                        Spacer(modifier = GlanceModifier.width(8.dp))
+                        MetricTile(
+                            label = context.getString(R.string.trip_widget_cost_per_distance, distanceUnit),
+                            value = costPerDistance,
+                            accent = TRIP_WIDGET_SECONDARY,
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                        Spacer(modifier = GlanceModifier.width(8.dp))
+                        MetricTile(
+                            label = context.getString(R.string.trip_widget_driving_days),
+                            value = drivingDays,
+                            accent = TRIP_WIDGET_TEXT,
+                            modifier = GlanceModifier.defaultWeight()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun CompactFooter(cost: String, efficiency: String) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = cost,
+                style = TextStyle(
+                    color = ColorProvider(TRIP_WIDGET_TEXT),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium
+                ),
+                maxLines = 1
+            )
+            Spacer(modifier = GlanceModifier.defaultWeight())
+            Text(
+                text = efficiency,
+                style = TextStyle(
+                    color = ColorProvider(TRIP_WIDGET_MUTED),
+                    fontSize = 12.sp
+                ),
+                maxLines = 1
+            )
+        }
+    }
+
+    @Composable
+    private fun MetricTile(
+        label: String,
+        value: String,
+        accent: Color,
+        modifier: GlanceModifier = GlanceModifier
+    ) {
+        Column(
+            modifier = modifier
+                .background(ColorProvider(TRIP_WIDGET_PANEL))
+                .cornerRadius(8.dp)
+                .padding(horizontal = 8.dp, vertical = 7.dp)
+        ) {
+            Text(
+                text = value,
+                style = TextStyle(
+                    color = ColorProvider(accent),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                maxLines = 1
+            )
+            Text(
+                text = label,
+                style = TextStyle(
+                    color = ColorProvider(TRIP_WIDGET_MUTED),
+                    fontSize = 9.sp
+                ),
+                maxLines = 1
+            )
+        }
+    }
+
+    suspend fun updateWidget(
+        context: Context,
+        glanceId: GlanceId,
+        data: TripSummaryWidgetDisplayData
+    ) {
+        updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { prefs ->
+            prefs.toMutablePreferences().apply {
+                this[CAR_ID_KEY] = data.carId
+                this[HAS_DATA_KEY] = true
+                this[HAS_DRIVES_KEY] = data.hasDrives
+                this[CAR_NAME_KEY] = data.carName
+                this[DISTANCE_VALUE_KEY] = data.distanceValue
+                this[DRIVE_COUNT_VALUE_KEY] = data.driveCountValue
+                this[DRIVING_DAYS_VALUE_KEY] = data.drivingDaysValue
+                this[ENERGY_VALUE_KEY] = data.energyValue
+                this[EFFICIENCY_VALUE_KEY] = data.efficiencyValue
+                this[COST_VALUE_KEY] = data.costValue
+                this[COST_PER_DISTANCE_VALUE_KEY] = data.costPerDistanceValue
+                this[DISTANCE_UNIT_KEY] = data.distanceUnit
+                this[UPDATED_VALUE_KEY] = data.updatedValue
+            }
+        }
+        update(context, glanceId)
+    }
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
@@ -66,6 +66,8 @@ class TripSummaryWidget : GlanceAppWidget() {
         val HAS_DATA_KEY = booleanPreferencesKey("trip_summary_has_data")
         val HAS_DRIVES_KEY = booleanPreferencesKey("trip_summary_has_drives")
         val CAR_NAME_KEY = stringPreferencesKey("trip_summary_car_name")
+        val RANGE_DAYS_KEY = intPreferencesKey("trip_summary_range_days")
+        val PERIOD_LABEL_KEY = stringPreferencesKey("trip_summary_period_label")
         val DISTANCE_VALUE_KEY = stringPreferencesKey("trip_summary_distance_value")
         val DRIVE_COUNT_VALUE_KEY = stringPreferencesKey("trip_summary_drive_count_value")
         val DRIVING_DAYS_VALUE_KEY = stringPreferencesKey("trip_summary_driving_days_value")
@@ -151,6 +153,8 @@ class TripSummaryWidget : GlanceAppWidget() {
         val compact = size.height.value < 115f || size.width.value < 190f
 
         val carName = prefs[CAR_NAME_KEY].orEmpty()
+        val periodLabel = prefs[PERIOD_LABEL_KEY]
+            ?: context.getString(R.string.trip_widget_period_last_30_days)
         val hasDrives = prefs[HAS_DRIVES_KEY] ?: false
         val distance = prefs[DISTANCE_VALUE_KEY].orEmpty()
         val drives = prefs[DRIVE_COUNT_VALUE_KEY].orEmpty()
@@ -187,7 +191,7 @@ class TripSummaryWidget : GlanceAppWidget() {
                         )
                     }
                     Text(
-                        text = context.getString(R.string.trip_widget_period_last_30_days),
+                        text = periodLabel,
                         style = TextStyle(
                             color = ColorProvider(TRIP_WIDGET_MUTED),
                             fontSize = if (compact) 10.sp else 11.sp
@@ -400,6 +404,7 @@ class TripSummaryWidget : GlanceAppWidget() {
                 this[HAS_DATA_KEY] = true
                 this[HAS_DRIVES_KEY] = data.hasDrives
                 this[CAR_NAME_KEY] = data.carName
+                this[PERIOD_LABEL_KEY] = data.periodLabel
                 this[DISTANCE_VALUE_KEY] = data.distanceValue
                 this[DRIVE_COUNT_VALUE_KEY] = data.driveCountValue
                 this[DRIVING_DAYS_VALUE_KEY] = data.drivingDaysValue

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
@@ -305,7 +305,13 @@ class TripSummaryWidget : GlanceAppWidget() {
 
                 if (compact) {
                     Spacer(modifier = GlanceModifier.defaultWeight())
-                    CompactFooter(cost = cost, efficiency = efficiency)
+                    CompactFooter(
+                        cost = cost,
+                        efficiency = efficiency,
+                        costCoverage = costCoverage,
+                        chargesWithCost = chargesWithCost,
+                        chargeCount = chargeCount,
+                    )
                 } else {
                     Spacer(modifier = GlanceModifier.defaultWeight())
 
@@ -388,14 +394,36 @@ class TripSummaryWidget : GlanceAppWidget() {
     }
 
     @Composable
-    private fun CompactFooter(cost: String, efficiency: String) {
+    private fun CompactFooter(
+        cost: String,
+        efficiency: String,
+        costCoverage: TripSummaryWidgetCostCoverage,
+        chargesWithCost: Int,
+        chargeCount: Int,
+    ) {
         val context = LocalContext.current
+        val costLabel = when (costCoverage) {
+            TripSummaryWidgetCostCoverage.Partial -> context.getString(
+                R.string.trip_widget_compact_cost_partial,
+                cost,
+                chargesWithCost,
+                chargeCount,
+            )
+            TripSummaryWidgetCostCoverage.Missing -> context.getString(
+                R.string.trip_widget_cost_none_priced
+            )
+            TripSummaryWidgetCostCoverage.None,
+            TripSummaryWidgetCostCoverage.Complete -> context.getString(
+                R.string.trip_widget_compact_cost,
+                cost,
+            )
+        }
         Row(
             modifier = GlanceModifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = context.getString(R.string.trip_widget_compact_cost, cost),
+                text = costLabel,
                 style = TextStyle(
                     color = ColorProvider(TRIP_WIDGET_TEXT),
                     fontSize = 12.sp,

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
@@ -69,11 +69,16 @@ class TripSummaryWidget : GlanceAppWidget() {
         val RANGE_DAYS_KEY = intPreferencesKey("trip_summary_range_days")
         val PERIOD_LABEL_KEY = stringPreferencesKey("trip_summary_period_label")
         val DISTANCE_VALUE_KEY = stringPreferencesKey("trip_summary_distance_value")
+        val DISTANCE_TREND_KEY = stringPreferencesKey("trip_summary_distance_trend")
+        val DISTANCE_TREND_PERCENT_KEY = intPreferencesKey("trip_summary_distance_trend_percent")
         val DRIVE_COUNT_VALUE_KEY = stringPreferencesKey("trip_summary_drive_count_value")
         val DRIVING_DAYS_VALUE_KEY = stringPreferencesKey("trip_summary_driving_days_value")
         val ENERGY_VALUE_KEY = stringPreferencesKey("trip_summary_energy_value")
         val EFFICIENCY_VALUE_KEY = stringPreferencesKey("trip_summary_efficiency_value")
         val COST_VALUE_KEY = stringPreferencesKey("trip_summary_cost_value")
+        val COST_COVERAGE_KEY = stringPreferencesKey("trip_summary_cost_coverage")
+        val CHARGES_WITH_COST_KEY = intPreferencesKey("trip_summary_charges_with_cost")
+        val CHARGE_COUNT_KEY = intPreferencesKey("trip_summary_charge_count")
         val COST_PER_DISTANCE_VALUE_KEY = stringPreferencesKey("trip_summary_cost_per_distance_value")
         val DISTANCE_UNIT_KEY = stringPreferencesKey("trip_summary_distance_unit")
         val UPDATED_VALUE_KEY = stringPreferencesKey("trip_summary_updated_value")
@@ -157,11 +162,20 @@ class TripSummaryWidget : GlanceAppWidget() {
             ?: context.getString(R.string.trip_widget_period_last_30_days)
         val hasDrives = prefs[HAS_DRIVES_KEY] ?: false
         val distance = prefs[DISTANCE_VALUE_KEY].orEmpty()
+        val distanceTrend = TripSummaryWidgetTrend.values().firstOrNull {
+            it.name == prefs[DISTANCE_TREND_KEY]
+        } ?: TripSummaryWidgetTrend.None
+        val distanceTrendPercent = prefs[DISTANCE_TREND_PERCENT_KEY] ?: 0
         val drives = prefs[DRIVE_COUNT_VALUE_KEY].orEmpty()
         val drivingDays = prefs[DRIVING_DAYS_VALUE_KEY].orEmpty()
         val energy = prefs[ENERGY_VALUE_KEY].orEmpty()
         val efficiency = prefs[EFFICIENCY_VALUE_KEY].orEmpty()
         val cost = prefs[COST_VALUE_KEY].orEmpty()
+        val costCoverage = TripSummaryWidgetCostCoverage.values().firstOrNull {
+            it.name == prefs[COST_COVERAGE_KEY]
+        } ?: TripSummaryWidgetCostCoverage.None
+        val chargesWithCost = prefs[CHARGES_WITH_COST_KEY] ?: 0
+        val chargeCount = prefs[CHARGE_COUNT_KEY] ?: 0
         val costPerDistance = prefs[COST_PER_DISTANCE_VALUE_KEY].orEmpty()
         val distanceUnit = prefs[DISTANCE_UNIT_KEY].orEmpty()
         val updated = prefs[UPDATED_VALUE_KEY].orEmpty()
@@ -249,7 +263,15 @@ class TripSummaryWidget : GlanceAppWidget() {
                             maxLines = 1
                         )
                         Text(
-                            text = context.getString(R.string.distance),
+                            text = if (compact) {
+                                context.getString(R.string.distance)
+                            } else {
+                                distanceTrendLabel(
+                                    context = context,
+                                    trend = distanceTrend,
+                                    percent = distanceTrendPercent,
+                                )
+                            },
                             style = TextStyle(
                                 color = ColorProvider(TRIP_WIDGET_MUTED),
                                 fontSize = 10.sp
@@ -296,7 +318,12 @@ class TripSummaryWidget : GlanceAppWidget() {
                         )
                         Spacer(modifier = GlanceModifier.width(8.dp))
                         MetricTile(
-                            label = context.getString(R.string.cost),
+                            label = costCoverageLabel(
+                                context = context,
+                                coverage = costCoverage,
+                                chargesWithCost = chargesWithCost,
+                                chargeCount = chargeCount,
+                            ),
                             value = cost,
                             accent = TRIP_WIDGET_ACCENT,
                             modifier = GlanceModifier.defaultWeight()
@@ -330,6 +357,34 @@ class TripSummaryWidget : GlanceAppWidget() {
                 }
             }
         }
+    }
+
+    private fun distanceTrendLabel(
+        context: Context,
+        trend: TripSummaryWidgetTrend,
+        percent: Int,
+    ): String = when (trend) {
+        TripSummaryWidgetTrend.None -> context.getString(R.string.distance)
+        TripSummaryWidgetTrend.New -> context.getString(R.string.trip_widget_distance_trend_new)
+        TripSummaryWidgetTrend.Same -> context.getString(R.string.trip_widget_distance_trend_same)
+        TripSummaryWidgetTrend.Up -> context.getString(R.string.trip_widget_distance_trend_more, percent)
+        TripSummaryWidgetTrend.Down -> context.getString(R.string.trip_widget_distance_trend_less, percent)
+    }
+
+    private fun costCoverageLabel(
+        context: Context,
+        coverage: TripSummaryWidgetCostCoverage,
+        chargesWithCost: Int,
+        chargeCount: Int,
+    ): String = when (coverage) {
+        TripSummaryWidgetCostCoverage.None -> context.getString(R.string.cost)
+        TripSummaryWidgetCostCoverage.Missing -> context.getString(R.string.trip_widget_cost_none_priced)
+        TripSummaryWidgetCostCoverage.Partial -> context.getString(
+            R.string.trip_widget_cost_partially_priced,
+            chargesWithCost,
+            chargeCount,
+        )
+        TripSummaryWidgetCostCoverage.Complete -> context.getString(R.string.trip_widget_cost_all_priced)
     }
 
     @Composable
@@ -406,11 +461,16 @@ class TripSummaryWidget : GlanceAppWidget() {
                 this[CAR_NAME_KEY] = data.carName
                 this[PERIOD_LABEL_KEY] = data.periodLabel
                 this[DISTANCE_VALUE_KEY] = data.distanceValue
+                this[DISTANCE_TREND_KEY] = data.distanceTrend.name
+                this[DISTANCE_TREND_PERCENT_KEY] = data.distanceTrendPercent
                 this[DRIVE_COUNT_VALUE_KEY] = data.driveCountValue
                 this[DRIVING_DAYS_VALUE_KEY] = data.drivingDaysValue
                 this[ENERGY_VALUE_KEY] = data.energyValue
                 this[EFFICIENCY_VALUE_KEY] = data.efficiencyValue
                 this[COST_VALUE_KEY] = data.costValue
+                this[COST_COVERAGE_KEY] = data.costCoverage.name
+                this[CHARGES_WITH_COST_KEY] = data.chargesWithCost
+                this[CHARGE_COUNT_KEY] = data.chargeCount
                 this[COST_PER_DISTANCE_VALUE_KEY] = data.costPerDistanceValue
                 this[DISTANCE_UNIT_KEY] = data.distanceUnit
                 this[UPDATED_VALUE_KEY] = data.updatedValue

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidget.kt
@@ -330,12 +330,13 @@ class TripSummaryWidget : GlanceAppWidget() {
 
     @Composable
     private fun CompactFooter(cost: String, efficiency: String) {
+        val context = LocalContext.current
         Row(
             modifier = GlanceModifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = cost,
+                text = context.getString(R.string.trip_widget_compact_cost, cost),
                 style = TextStyle(
                     color = ColorProvider(TRIP_WIDGET_TEXT),
                     fontSize = 12.sp,
@@ -345,7 +346,7 @@ class TripSummaryWidget : GlanceAppWidget() {
             )
             Spacer(modifier = GlanceModifier.defaultWeight())
             Text(
-                text = efficiency,
+                text = context.getString(R.string.trip_widget_compact_efficiency, efficiency),
                 style = TextStyle(
                     color = ColorProvider(TRIP_WIDGET_MUTED),
                     fontSize = 12.sp

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
@@ -16,11 +16,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -35,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.lifecycle.lifecycleScope
@@ -78,8 +82,22 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
             MateDroidTheme {
                 var screenState by remember { mutableStateOf<ScreenState>(ScreenState.Loading) }
                 var selectedRange by remember { mutableStateOf(TripSummaryWidgetRange.DEFAULT) }
+                var selectedCarId by remember { mutableStateOf<Int?>(null) }
 
                 LaunchedEffect(Unit) {
+                    val glanceId = GlanceAppWidgetManager(this@TripSummaryWidgetConfigActivity)
+                        .getGlanceIdBy(appWidgetId)
+                    val prefs = getAppWidgetState(
+                        this@TripSummaryWidgetConfigActivity,
+                        PreferencesGlanceStateDefinition,
+                        glanceId,
+                    )
+                    selectedRange = TripSummaryWidgetRange.fromDays(
+                        prefs[TripSummaryWidget.RANGE_DAYS_KEY]
+                            ?: TripSummaryWidgetRange.DEFAULT.days
+                    )
+                    selectedCarId = prefs[TripSummaryWidget.CAR_ID_KEY]
+
                     when (val result = teslamateRepository.getCars()) {
                         is ApiResult.Success -> {
                             val cars = result.data
@@ -87,7 +105,12 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                                 cars.isEmpty() -> screenState = ScreenState.Error(
                                     getString(R.string.no_vehicles_found)
                                 )
-                                else -> screenState = ScreenState.Picker(cars)
+                                else -> {
+                                    if (selectedCarId == null && cars.size == 1) {
+                                        selectedCarId = cars.single().carId
+                                    }
+                                    screenState = ScreenState.Picker(cars)
+                                }
                             }
                         }
                         is ApiResult.Error -> screenState = ScreenState.Error(result.message)
@@ -99,8 +122,14 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                     is ScreenState.Picker -> PickerScreen(
                         cars = s.cars,
                         selectedRange = selectedRange,
+                        selectedCarId = selectedCarId,
                         onRangeSelected = { selectedRange = it },
-                        onCarSelected = { car -> confirmSelection(appWidgetId, car, selectedRange) }
+                        onCarSelected = { selectedCarId = it.carId },
+                        onConfirm = {
+                            s.cars.firstOrNull { it.carId == selectedCarId }?.let { car ->
+                                confirmSelection(appWidgetId, car, selectedRange)
+                            }
+                        },
                     )
                     is ScreenState.Error -> ErrorScreen(s.message)
                 }
@@ -146,12 +175,25 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
     private fun PickerScreen(
         cars: List<CarData>,
         selectedRange: TripSummaryWidgetRange,
+        selectedCarId: Int?,
         onRangeSelected: (TripSummaryWidgetRange) -> Unit,
         onCarSelected: (CarData) -> Unit,
+        onConfirm: () -> Unit,
     ) {
         Scaffold(
             topBar = {
                 TopAppBar(title = { Text(stringResource(R.string.widget_select_car_title)) })
+            },
+            bottomBar = {
+                Button(
+                    onClick = onConfirm,
+                    enabled = selectedCarId != null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                ) {
+                    Text(stringResource(R.string.widget_save))
+                }
             }
         ) { padding ->
             LazyColumn(
@@ -192,7 +234,14 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onCarSelected(car) }
+                            .clickable { onCarSelected(car) },
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (selectedCarId == car.carId) {
+                                MaterialTheme.colorScheme.primaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            }
+                        ),
                     ) {
                         Row(
                             modifier = Modifier
@@ -202,7 +251,12 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                         ) {
                             Text(
                                 text = car.displayName,
-                                style = MaterialTheme.typography.titleMedium
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.weight(1f),
+                            )
+                            RadioButton(
+                                selected = selectedCarId == car.carId,
+                                onClick = null,
                             )
                         }
                     }

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -76,6 +77,7 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
         setContent {
             MateDroidTheme {
                 var screenState by remember { mutableStateOf<ScreenState>(ScreenState.Loading) }
+                var selectedRange by remember { mutableStateOf(TripSummaryWidgetRange.DEFAULT) }
 
                 LaunchedEffect(Unit) {
                     when (val result = teslamateRepository.getCars()) {
@@ -85,7 +87,6 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                                 cars.isEmpty() -> screenState = ScreenState.Error(
                                     getString(R.string.no_vehicles_found)
                                 )
-                                cars.size == 1 -> confirmSelection(appWidgetId, cars.first())
                                 else -> screenState = ScreenState.Picker(cars)
                             }
                         }
@@ -95,9 +96,12 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
 
                 when (val s = screenState) {
                     is ScreenState.Loading -> LoadingScreen()
-                    is ScreenState.Picker -> PickerScreen(s.cars) { car ->
-                        confirmSelection(appWidgetId, car)
-                    }
+                    is ScreenState.Picker -> PickerScreen(
+                        cars = s.cars,
+                        selectedRange = selectedRange,
+                        onRangeSelected = { selectedRange = it },
+                        onCarSelected = { car -> confirmSelection(appWidgetId, car, selectedRange) }
+                    )
                     is ScreenState.Error -> ErrorScreen(s.message)
                 }
             }
@@ -139,7 +143,12 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
 
     @Composable
     @OptIn(ExperimentalMaterial3Api::class)
-    private fun PickerScreen(cars: List<CarData>, onCarSelected: (CarData) -> Unit) {
+    private fun PickerScreen(
+        cars: List<CarData>,
+        selectedRange: TripSummaryWidgetRange,
+        onRangeSelected: (TripSummaryWidgetRange) -> Unit,
+        onCarSelected: (CarData) -> Unit,
+    ) {
         Scaffold(
             topBar = {
                 TopAppBar(title = { Text(stringResource(R.string.widget_select_car_title)) })
@@ -152,6 +161,33 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.trip_widget_range_title),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            TripSummaryWidgetRange.values().forEach { range ->
+                                FilterChip(
+                                    selected = selectedRange == range,
+                                    onClick = { onRangeSelected(range) },
+                                    label = { Text(stringResource(range.labelRes)) }
+                                )
+                            }
+                        }
+                    }
+                }
+
                 items(cars) { car ->
                     Card(
                         modifier = Modifier
@@ -175,7 +211,11 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
         }
     }
 
-    private fun confirmSelection(appWidgetId: Int, car: CarData) {
+    private fun confirmSelection(
+        appWidgetId: Int,
+        car: CarData,
+        range: TripSummaryWidgetRange,
+    ) {
         lifecycleScope.launch {
             val glanceId = GlanceAppWidgetManager(this@TripSummaryWidgetConfigActivity)
                 .getGlanceIdBy(appWidgetId)
@@ -188,6 +228,8 @@ class TripSummaryWidgetConfigActivity : ComponentActivity() {
                 prefs.toMutablePreferences().apply {
                     this[TripSummaryWidget.CAR_ID_KEY] = car.carId
                     this[TripSummaryWidget.CAR_NAME_KEY] = car.displayName
+                    this[TripSummaryWidget.RANGE_DAYS_KEY] = range.days
+                    this[TripSummaryWidget.PERIOD_LABEL_KEY] = getString(range.labelRes)
                     this[TripSummaryWidget.HAS_DATA_KEY] = false
                 }
             }

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetConfigActivity.kt
@@ -1,0 +1,204 @@
+package com.matedroid.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.lifecycle.lifecycleScope
+import com.matedroid.R
+import com.matedroid.data.api.models.CarData
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.ui.theme.MateDroidTheme
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class TripSummaryWidgetConfigActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var teslamateRepository: TeslamateRepository
+
+    private sealed interface ScreenState {
+        data object Loading : ScreenState
+        data class Picker(val cars: List<CarData>) : ScreenState
+        data class Error(val message: String) : ScreenState
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setResult(RESULT_CANCELED)
+
+        val appWidgetId = intent.extras?.getInt(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        setContent {
+            MateDroidTheme {
+                var screenState by remember { mutableStateOf<ScreenState>(ScreenState.Loading) }
+
+                LaunchedEffect(Unit) {
+                    when (val result = teslamateRepository.getCars()) {
+                        is ApiResult.Success -> {
+                            val cars = result.data
+                            when {
+                                cars.isEmpty() -> screenState = ScreenState.Error(
+                                    getString(R.string.no_vehicles_found)
+                                )
+                                cars.size == 1 -> confirmSelection(appWidgetId, cars.first())
+                                else -> screenState = ScreenState.Picker(cars)
+                            }
+                        }
+                        is ApiResult.Error -> screenState = ScreenState.Error(result.message)
+                    }
+                }
+
+                when (val s = screenState) {
+                    is ScreenState.Loading -> LoadingScreen()
+                    is ScreenState.Picker -> PickerScreen(s.cars) { car ->
+                        confirmSelection(appWidgetId, car)
+                    }
+                    is ScreenState.Error -> ErrorScreen(s.message)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun LoadingScreen() {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+
+    @Composable
+    private fun ErrorScreen(message: String) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = stringResource(R.string.error_loading_data),
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+
+    @Composable
+    @OptIn(ExperimentalMaterial3Api::class)
+    private fun PickerScreen(cars: List<CarData>, onCarSelected: (CarData) -> Unit) {
+        Scaffold(
+            topBar = {
+                TopAppBar(title = { Text(stringResource(R.string.widget_select_car_title)) })
+            }
+        ) { padding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(cars) { car ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onCarSelected(car) }
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = car.displayName,
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun confirmSelection(appWidgetId: Int, car: CarData) {
+        lifecycleScope.launch {
+            val glanceId = GlanceAppWidgetManager(this@TripSummaryWidgetConfigActivity)
+                .getGlanceIdBy(appWidgetId)
+
+            updateAppWidgetState(
+                this@TripSummaryWidgetConfigActivity,
+                PreferencesGlanceStateDefinition,
+                glanceId
+            ) { prefs ->
+                prefs.toMutablePreferences().apply {
+                    this[TripSummaryWidget.CAR_ID_KEY] = car.carId
+                    this[TripSummaryWidget.CAR_NAME_KEY] = car.displayName
+                    this[TripSummaryWidget.HAS_DATA_KEY] = false
+                }
+            }
+
+            TripSummaryWidget().update(this@TripSummaryWidgetConfigActivity, glanceId)
+            TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(this@TripSummaryWidgetConfigActivity)
+
+            setResult(RESULT_OK, Intent().apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            })
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDateRange.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDateRange.kt
@@ -1,0 +1,19 @@
+package com.matedroid.widget
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object TripSummaryWidgetDateRange {
+    private val API_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+
+    fun lastDays(today: LocalDate = LocalDate.now(), days: Long = 30): Pair<String, String> {
+        require(days > 0) { "days must be positive" }
+
+        val start = today.minusDays(days - 1).atStartOfDay()
+        val end = today.plusDays(1).atStartOfDay()
+        return start.toApiDateString() to end.toApiDateString()
+    }
+
+    private fun LocalDateTime.toApiDateString(): String = format(API_DATE_FORMATTER)
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDateRange.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDateRange.kt
@@ -15,5 +15,29 @@ object TripSummaryWidgetDateRange {
         return start.toApiDateString() to end.toApiDateString()
     }
 
+    fun currentAndPreviousDays(
+        today: LocalDate = LocalDate.now(),
+        days: Long = 30,
+    ): TripSummaryWidgetDateRanges {
+        require(days > 0) { "days must be positive" }
+
+        val currentStart = today.minusDays(days - 1).atStartOfDay()
+        val currentEnd = today.plusDays(1).atStartOfDay()
+        val previousStart = currentStart.minusDays(days)
+        return TripSummaryWidgetDateRanges(
+            currentStart = currentStart.toApiDateString(),
+            currentEnd = currentEnd.toApiDateString(),
+            previousStart = previousStart.toApiDateString(),
+            previousEnd = currentStart.toApiDateString(),
+        )
+    }
+
     private fun LocalDateTime.toApiDateString(): String = format(API_DATE_FORMATTER)
 }
+
+data class TripSummaryWidgetDateRanges(
+    val currentStart: String,
+    val currentEnd: String,
+    val previousStart: String,
+    val previousEnd: String,
+)

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
@@ -12,12 +12,32 @@ data class TripSummaryWidgetDisplayData(
     val periodLabel: String,
     val hasDrives: Boolean,
     val distanceValue: String,
+    val distanceTrend: TripSummaryWidgetTrend,
+    val distanceTrendPercent: Int,
     val driveCountValue: String,
     val drivingDaysValue: String,
     val energyValue: String,
     val efficiencyValue: String,
     val costValue: String,
+    val costCoverage: TripSummaryWidgetCostCoverage,
+    val chargesWithCost: Int,
+    val chargeCount: Int,
     val costPerDistanceValue: String,
     val distanceUnit: String,
     val updatedValue: String,
 )
+
+enum class TripSummaryWidgetTrend {
+    None,
+    New,
+    Same,
+    Up,
+    Down,
+}
+
+enum class TripSummaryWidgetCostCoverage {
+    None,
+    Missing,
+    Partial,
+    Complete,
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
@@ -9,6 +9,7 @@ package com.matedroid.widget
 data class TripSummaryWidgetDisplayData(
     val carId: Int,
     val carName: String,
+    val periodLabel: String,
     val hasDrives: Boolean,
     val distanceValue: String,
     val driveCountValue: String,

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetDisplayData.kt
@@ -1,0 +1,22 @@
+package com.matedroid.widget
+
+/**
+ * Persisted display snapshot for the read-only trip summary widget.
+ *
+ * The widget renderer reads only these preformatted values from Glance
+ * preferences. The worker owns all database access and formatting.
+ */
+data class TripSummaryWidgetDisplayData(
+    val carId: Int,
+    val carName: String,
+    val hasDrives: Boolean,
+    val distanceValue: String,
+    val driveCountValue: String,
+    val drivingDaysValue: String,
+    val energyValue: String,
+    val efficiencyValue: String,
+    val costValue: String,
+    val costPerDistanceValue: String,
+    val distanceUnit: String,
+    val updatedValue: String,
+)

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
@@ -2,6 +2,8 @@ package com.matedroid.widget
 
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.UnitFormatter
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 data class TripSummaryWidgetMetrics(
     val driveCount: Int,
@@ -11,6 +13,8 @@ data class TripSummaryWidgetMetrics(
     val avgEfficiency: Double,
     val totalCost: Double,
     val chargesWithCost: Int,
+    val chargeCount: Int,
+    val previousDistance: Double,
 )
 
 object TripSummaryWidgetFormatter {
@@ -41,6 +45,29 @@ object TripSummaryWidgetFormatter {
         } else {
             noValue
         }
+        val distanceTrend = when {
+            metrics.driveCount <= 0 -> TripSummaryWidgetTrend.None
+            metrics.previousDistance <= 0 -> TripSummaryWidgetTrend.New
+            else -> {
+                val percent = ((metrics.totalDistance / metrics.previousDistance) - 1.0) * 100.0
+                when (percent.roundToInt()) {
+                    0 -> TripSummaryWidgetTrend.Same
+                    in 1..Int.MAX_VALUE -> TripSummaryWidgetTrend.Up
+                    else -> TripSummaryWidgetTrend.Down
+                }
+            }
+        }
+        val distanceTrendPercent = if (metrics.previousDistance > 0) {
+            abs((((metrics.totalDistance / metrics.previousDistance) - 1.0) * 100.0).roundToInt())
+        } else {
+            0
+        }
+        val costCoverage = when {
+            metrics.chargeCount <= 0 -> TripSummaryWidgetCostCoverage.None
+            metrics.chargesWithCost <= 0 -> TripSummaryWidgetCostCoverage.Missing
+            metrics.chargesWithCost < metrics.chargeCount -> TripSummaryWidgetCostCoverage.Partial
+            else -> TripSummaryWidgetCostCoverage.Complete
+        }
 
         return TripSummaryWidgetDisplayData(
             carId = carId,
@@ -48,11 +75,16 @@ object TripSummaryWidgetFormatter {
             periodLabel = periodLabel,
             hasDrives = metrics.driveCount > 0,
             distanceValue = UnitFormatter.formatDistance(metrics.totalDistance, units = units, decimals = 0),
+            distanceTrend = distanceTrend,
+            distanceTrendPercent = distanceTrendPercent,
             driveCountValue = "%,d".format(metrics.driveCount),
             drivingDaysValue = "%,d".format(metrics.drivingDays),
             energyValue = UnitFormatter.formatEnergy(metrics.totalEnergy),
             efficiencyValue = efficiencyValue,
             costValue = costValue,
+            costCoverage = costCoverage,
+            chargesWithCost = metrics.chargesWithCost,
+            chargeCount = metrics.chargeCount,
             costPerDistanceValue = costPerDistance,
             distanceUnit = UnitFormatter.getDistanceUnit(units),
             updatedValue = updatedValue,

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
@@ -1,0 +1,59 @@
+package com.matedroid.widget
+
+import com.matedroid.data.api.models.Units
+import com.matedroid.domain.model.UnitFormatter
+
+data class TripSummaryWidgetMetrics(
+    val driveCount: Int,
+    val drivingDays: Int,
+    val totalDistance: Double,
+    val totalEnergy: Double,
+    val avgEfficiency: Double,
+    val totalCost: Double,
+    val chargesWithCost: Int,
+)
+
+object TripSummaryWidgetFormatter {
+
+    fun format(
+        carId: Int,
+        carName: String,
+        metrics: TripSummaryWidgetMetrics,
+        currencySymbol: String,
+        noValue: String,
+        updatedValue: String,
+        units: Units? = null,
+    ): TripSummaryWidgetDisplayData {
+        val hasCostData = metrics.chargesWithCost > 0
+        val costValue = if (hasCostData) {
+            UnitFormatter.formatCost(metrics.totalCost, currencySymbol)
+        } else {
+            noValue
+        }
+        val costPerDistance = if (hasCostData && metrics.totalDistance > 0) {
+            UnitFormatter.formatCost((metrics.totalCost / metrics.totalDistance) * 100, currencySymbol)
+        } else {
+            noValue
+        }
+        val efficiencyValue = if (metrics.avgEfficiency > 0) {
+            UnitFormatter.formatEfficiency(metrics.avgEfficiency, units = units, decimals = 0)
+        } else {
+            noValue
+        }
+
+        return TripSummaryWidgetDisplayData(
+            carId = carId,
+            carName = carName,
+            hasDrives = metrics.driveCount > 0,
+            distanceValue = UnitFormatter.formatDistance(metrics.totalDistance, units = units, decimals = 0),
+            driveCountValue = "%,d".format(metrics.driveCount),
+            drivingDaysValue = "%,d".format(metrics.drivingDays),
+            energyValue = UnitFormatter.formatEnergy(metrics.totalEnergy),
+            efficiencyValue = efficiencyValue,
+            costValue = costValue,
+            costPerDistanceValue = costPerDistance,
+            distanceUnit = UnitFormatter.getDistanceUnit(units),
+            updatedValue = updatedValue,
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
@@ -29,13 +29,16 @@ object TripSummaryWidgetFormatter {
         updatedValue: String,
         units: Units? = null,
     ): TripSummaryWidgetDisplayData {
-        val hasCostData = metrics.chargesWithCost > 0
-        val costValue = if (hasCostData) {
+        val hasCompleteCostData = metrics.chargeCount > 0 &&
+            metrics.chargesWithCost == metrics.chargeCount
+        val hasAnyCostData = metrics.chargesWithCost > 0
+        val costValue = if (hasAnyCostData) {
             UnitFormatter.formatCost(metrics.totalCost, currencySymbol)
         } else {
             noValue
         }
-        val costPerDistance = if (hasCostData && metrics.totalDistance > 0) {
+        // Cost/100 is only honest when every charge in the range is priced.
+        val costPerDistance = if (hasCompleteCostData && metrics.totalDistance > 0) {
             UnitFormatter.formatCost((metrics.totalCost / metrics.totalDistance) * 100, currencySymbol)
         } else {
             noValue

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetFormatter.kt
@@ -18,6 +18,7 @@ object TripSummaryWidgetFormatter {
     fun format(
         carId: Int,
         carName: String,
+        periodLabel: String,
         metrics: TripSummaryWidgetMetrics,
         currencySymbol: String,
         noValue: String,
@@ -44,6 +45,7 @@ object TripSummaryWidgetFormatter {
         return TripSummaryWidgetDisplayData(
             carId = carId,
             carName = carName,
+            periodLabel = periodLabel,
             hasDrives = metrics.driveCount > 0,
             distanceValue = UnitFormatter.formatDistance(metrics.totalDistance, units = units, decimals = 0),
             driveCountValue = "%,d".format(metrics.driveCount),

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetRange.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetRange.kt
@@ -1,0 +1,21 @@
+package com.matedroid.widget
+
+import androidx.annotation.StringRes
+import com.matedroid.R
+
+enum class TripSummaryWidgetRange(
+    val days: Int,
+    @StringRes val labelRes: Int,
+) {
+    SevenDays(7, R.string.trip_widget_period_last_7_days),
+    ThirtyDays(30, R.string.trip_widget_period_last_30_days),
+    NinetyDays(90, R.string.trip_widget_period_last_90_days);
+
+    companion object {
+        val DEFAULT = ThirtyDays
+
+        fun fromDays(days: Int): TripSummaryWidgetRange {
+            return values().firstOrNull { it.days == days } ?: DEFAULT
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetReceiver.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetReceiver.kt
@@ -1,0 +1,32 @@
+package com.matedroid.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.os.Bundle
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class TripSummaryWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget: GlanceAppWidget = TripSummaryWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        TripSummaryWidgetUpdateWorker.scheduleWork(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        TripSummaryWidgetUpdateWorker.cancelWork(context)
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle
+    ) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+        TripSummaryWidgetUpdateWorker.scheduleImmediateUpdate(context)
+    }
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
@@ -40,7 +40,6 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
         const val WORK_NAME = "trip_summary_widget_update"
         const val PERIODIC_WORK_NAME = "trip_summary_widget_update_periodic"
         private const val PERIODIC_INTERVAL_HOURS = 6L
-        private const val RANGE_DAYS = 30L
 
         fun scheduleImmediateUpdate(context: Context) {
             val request = OneTimeWorkRequestBuilder<TripSummaryWidgetUpdateWorker>()
@@ -92,7 +91,6 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
         val settings = settingsDataStore.settings.firstOrNull()
         val currency = Currency.findByCode(settings?.currencyCode ?: Currency.DEFAULT.code)
         val units = Units(unitOfLength = settings?.unitOfLength ?: "km")
-        val (startDate, endDate) = TripSummaryWidgetDateRange.lastDays(days = RANGE_DAYS)
 
         for (glanceId in glanceIds) {
             try {
@@ -100,10 +98,15 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
                 val carId = prefs[TripSummaryWidget.CAR_ID_KEY] ?: continue
                 val carName = prefs[TripSummaryWidget.CAR_NAME_KEY]
                     ?: appContext.getString(R.string.app_name)
+                val range = TripSummaryWidgetRange.fromDays(
+                    prefs[TripSummaryWidget.RANGE_DAYS_KEY] ?: TripSummaryWidgetRange.DEFAULT.days
+                )
+                val (startDate, endDate) = TripSummaryWidgetDateRange.lastDays(days = range.days.toLong())
 
                 val displayData = buildDisplayData(
                     carId = carId,
                     carName = carName,
+                    periodLabel = appContext.getString(range.labelRes),
                     currencySymbol = currency.symbol,
                     units = units,
                     startDate = startDate,
@@ -122,6 +125,7 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
     private suspend fun buildDisplayData(
         carId: Int,
         carName: String,
+        periodLabel: String,
         currencySymbol: String,
         units: Units,
         startDate: String,
@@ -140,6 +144,7 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
         return TripSummaryWidgetFormatter.format(
             carId = carId,
             carName = carName,
+            periodLabel = periodLabel,
             metrics = metrics,
             currencySymbol = currencySymbol,
             noValue = noValue,

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
@@ -19,8 +19,6 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.model.Currency
-import com.matedroid.data.repository.ApiResult
-import com.matedroid.data.repository.TeslamateRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.firstOrNull
@@ -35,7 +33,6 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
     private val driveSummaryDao: DriveSummaryDao,
     private val chargeSummaryDao: ChargeSummaryDao,
     private val settingsDataStore: SettingsDataStore,
-    private val teslamateRepository: TeslamateRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -93,7 +90,11 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
 
         val settings = settingsDataStore.settings.firstOrNull()
         val currency = Currency.findByCode(settings?.currencyCode ?: Currency.DEFAULT.code)
-        val units = resolveUnits(settings?.unitOfLength)
+        // Use only the cached unit stored with the last summary sync so Room
+        // values and labels stay aligned (never live-fetch settings here).
+        val units = Units(
+            unitOfLength = settings?.unitOfLength?.takeIf { it == "km" || it == "mi" } ?: "km"
+        )
 
         for (glanceId in glanceIds) {
             try {
@@ -163,26 +164,5 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
             ),
             units = units,
         )
-    }
-
-    /**
-     * Prefer a freshly cached TeslaMate unit-of-length so Room values are labeled
-     * honestly. Falls back to the DataStore cache, then km only as a last resort.
-     * Hits TeslamateApi settings only — never the vehicle.
-     */
-    private suspend fun resolveUnits(cachedUnitOfLength: String?): Units {
-        when (val result = teslamateRepository.getGlobalSettings()) {
-            is ApiResult.Success -> {
-                val unit = result.data.settings?.teslamateUnits?.unitOfLength
-                    ?.takeIf { it == "km" || it == "mi" }
-                if (unit != null) {
-                    settingsDataStore.saveUnitOfLength(unit)
-                    return Units(unitOfLength = unit)
-                }
-            }
-            is ApiResult.Error -> Unit
-        }
-        val fallback = cachedUnitOfLength?.takeIf { it == "km" || it == "mi" } ?: "km"
-        return Units(unitOfLength = fallback)
     }
 }

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
@@ -1,0 +1,154 @@
+package com.matedroid.widget
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.matedroid.R
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.data.local.dao.ChargeSummaryDao
+import com.matedroid.data.local.dao.DriveSummaryDao
+import com.matedroid.data.model.Currency
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.firstOrNull
+import java.text.DateFormat
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val driveSummaryDao: DriveSummaryDao,
+    private val chargeSummaryDao: ChargeSummaryDao,
+    private val settingsDataStore: SettingsDataStore,
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        private const val TAG = "TripSummaryWidgetWorker"
+        const val WORK_NAME = "trip_summary_widget_update"
+        const val PERIODIC_WORK_NAME = "trip_summary_widget_update_periodic"
+        private const val PERIODIC_INTERVAL_HOURS = 6L
+        private const val RANGE_DAYS = 30L
+
+        fun scheduleImmediateUpdate(context: Context) {
+            val request = OneTimeWorkRequestBuilder<TripSummaryWidgetUpdateWorker>()
+                .addTag(TAG)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+            Log.d(TAG, "Scheduled immediate trip summary widget update")
+        }
+
+        fun scheduleWork(context: Context) {
+            val periodicRequest = PeriodicWorkRequestBuilder<TripSummaryWidgetUpdateWorker>(
+                PERIODIC_INTERVAL_HOURS,
+                TimeUnit.HOURS
+            )
+                .addTag("$TAG-periodic")
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                PERIODIC_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                periodicRequest
+            )
+            Log.d(TAG, "Scheduled trip summary widget update every ${PERIODIC_INTERVAL_HOURS}h")
+        }
+
+        fun cancelWork(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_WORK_NAME)
+            Log.d(TAG, "Cancelled trip summary widget update work")
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "Starting trip summary widget update")
+
+        val manager = GlanceAppWidgetManager(appContext)
+        val glanceIds = manager.getGlanceIds(TripSummaryWidget::class.java)
+
+        if (glanceIds.isEmpty()) {
+            Log.d(TAG, "No active trip summary widgets, skipping update")
+            return Result.success()
+        }
+
+        val settings = settingsDataStore.settings.firstOrNull()
+        val currency = Currency.findByCode(settings?.currencyCode ?: Currency.DEFAULT.code)
+        val units = Units(unitOfLength = settings?.unitOfLength ?: "km")
+        val (startDate, endDate) = TripSummaryWidgetDateRange.lastDays(days = RANGE_DAYS)
+
+        for (glanceId in glanceIds) {
+            try {
+                val prefs = getAppWidgetState(appContext, PreferencesGlanceStateDefinition, glanceId)
+                val carId = prefs[TripSummaryWidget.CAR_ID_KEY] ?: continue
+                val carName = prefs[TripSummaryWidget.CAR_NAME_KEY]
+                    ?: appContext.getString(R.string.app_name)
+
+                val displayData = buildDisplayData(
+                    carId = carId,
+                    carName = carName,
+                    currencySymbol = currency.symbol,
+                    units = units,
+                    startDate = startDate,
+                    endDate = endDate
+                )
+                TripSummaryWidget().updateWidget(appContext, glanceId, displayData)
+                Log.d(TAG, "Updated trip summary widget for car $carId")
+            } catch (e: Exception) {
+                Log.e(TAG, "Error updating trip summary widget $glanceId", e)
+            }
+        }
+
+        return Result.success()
+    }
+
+    private suspend fun buildDisplayData(
+        carId: Int,
+        carName: String,
+        currencySymbol: String,
+        units: Units,
+        startDate: String,
+        endDate: String,
+    ): TripSummaryWidgetDisplayData {
+        val metrics = TripSummaryWidgetMetrics(
+            driveCount = driveSummaryDao.countInRange(carId, startDate, endDate),
+            drivingDays = driveSummaryDao.countDrivingDaysInRange(carId, startDate, endDate),
+            totalDistance = driveSummaryDao.sumDistanceInRange(carId, startDate, endDate),
+            totalEnergy = driveSummaryDao.sumEnergyConsumedInRange(carId, startDate, endDate),
+            avgEfficiency = driveSummaryDao.avgEfficiencyInRange(carId, startDate, endDate),
+            totalCost = chargeSummaryDao.sumCostInRange(carId, startDate, endDate),
+            chargesWithCost = chargeSummaryDao.countWithCostInRange(carId, startDate, endDate),
+        )
+        val noValue = appContext.getString(R.string.trip_widget_no_value)
+        return TripSummaryWidgetFormatter.format(
+            carId = carId,
+            carName = carName,
+            metrics = metrics,
+            currencySymbol = currencySymbol,
+            noValue = noValue,
+            updatedValue = appContext.getString(
+                R.string.trip_widget_updated,
+                DateFormat.getTimeInstance(DateFormat.SHORT).format(Date())
+            ),
+            units = units,
+        )
+    }
+
+}

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
@@ -19,6 +19,8 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.model.Currency
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.TeslamateRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.firstOrNull
@@ -33,6 +35,7 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
     private val driveSummaryDao: DriveSummaryDao,
     private val chargeSummaryDao: ChargeSummaryDao,
     private val settingsDataStore: SettingsDataStore,
+    private val teslamateRepository: TeslamateRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -90,7 +93,7 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
 
         val settings = settingsDataStore.settings.firstOrNull()
         val currency = Currency.findByCode(settings?.currencyCode ?: Currency.DEFAULT.code)
-        val units = Units(unitOfLength = settings?.unitOfLength ?: "km")
+        val units = resolveUnits(settings?.unitOfLength)
 
         for (glanceId in glanceIds) {
             try {
@@ -162,4 +165,24 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
         )
     }
 
+    /**
+     * Prefer a freshly cached TeslaMate unit-of-length so Room values are labeled
+     * honestly. Falls back to the DataStore cache, then km only as a last resort.
+     * Hits TeslamateApi settings only — never the vehicle.
+     */
+    private suspend fun resolveUnits(cachedUnitOfLength: String?): Units {
+        when (val result = teslamateRepository.getGlobalSettings()) {
+            is ApiResult.Success -> {
+                val unit = result.data.settings?.teslamateUnits?.unitOfLength
+                    ?.takeIf { it == "km" || it == "mi" }
+                if (unit != null) {
+                    settingsDataStore.saveUnitOfLength(unit)
+                    return Units(unitOfLength = unit)
+                }
+            }
+            is ApiResult.Error -> Unit
+        }
+        val fallback = cachedUnitOfLength?.takeIf { it == "km" || it == "mi" } ?: "km"
+        return Units(unitOfLength = fallback)
+    }
 }

--- a/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/TripSummaryWidgetUpdateWorker.kt
@@ -101,7 +101,9 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
                 val range = TripSummaryWidgetRange.fromDays(
                     prefs[TripSummaryWidget.RANGE_DAYS_KEY] ?: TripSummaryWidgetRange.DEFAULT.days
                 )
-                val (startDate, endDate) = TripSummaryWidgetDateRange.lastDays(days = range.days.toLong())
+                val ranges = TripSummaryWidgetDateRange.currentAndPreviousDays(
+                    days = range.days.toLong()
+                )
 
                 val displayData = buildDisplayData(
                     carId = carId,
@@ -109,8 +111,7 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
                     periodLabel = appContext.getString(range.labelRes),
                     currencySymbol = currency.symbol,
                     units = units,
-                    startDate = startDate,
-                    endDate = endDate
+                    ranges = ranges,
                 )
                 TripSummaryWidget().updateWidget(appContext, glanceId, displayData)
                 Log.d(TAG, "Updated trip summary widget for car $carId")
@@ -128,17 +129,22 @@ class TripSummaryWidgetUpdateWorker @AssistedInject constructor(
         periodLabel: String,
         currencySymbol: String,
         units: Units,
-        startDate: String,
-        endDate: String,
+        ranges: TripSummaryWidgetDateRanges,
     ): TripSummaryWidgetDisplayData {
         val metrics = TripSummaryWidgetMetrics(
-            driveCount = driveSummaryDao.countInRange(carId, startDate, endDate),
-            drivingDays = driveSummaryDao.countDrivingDaysInRange(carId, startDate, endDate),
-            totalDistance = driveSummaryDao.sumDistanceInRange(carId, startDate, endDate),
-            totalEnergy = driveSummaryDao.sumEnergyConsumedInRange(carId, startDate, endDate),
-            avgEfficiency = driveSummaryDao.avgEfficiencyInRange(carId, startDate, endDate),
-            totalCost = chargeSummaryDao.sumCostInRange(carId, startDate, endDate),
-            chargesWithCost = chargeSummaryDao.countWithCostInRange(carId, startDate, endDate),
+            driveCount = driveSummaryDao.countInRange(carId, ranges.currentStart, ranges.currentEnd),
+            drivingDays = driveSummaryDao.countDrivingDaysInRange(carId, ranges.currentStart, ranges.currentEnd),
+            totalDistance = driveSummaryDao.sumDistanceInRange(carId, ranges.currentStart, ranges.currentEnd),
+            totalEnergy = driveSummaryDao.sumEnergyConsumedInRange(carId, ranges.currentStart, ranges.currentEnd),
+            avgEfficiency = driveSummaryDao.avgEfficiencyInRange(carId, ranges.currentStart, ranges.currentEnd),
+            totalCost = chargeSummaryDao.sumCostInRange(carId, ranges.currentStart, ranges.currentEnd),
+            chargesWithCost = chargeSummaryDao.countWithCostInRange(carId, ranges.currentStart, ranges.currentEnd),
+            chargeCount = chargeSummaryDao.countInRange(carId, ranges.currentStart, ranges.currentEnd),
+            previousDistance = driveSummaryDao.sumDistanceInRange(
+                carId,
+                ranges.previousStart,
+                ranges.previousEnd,
+            ),
         )
         val noValue = appContext.getString(R.string.trip_widget_no_value)
         return TripSummaryWidgetFormatter.format(

--- a/app/src/main/res/layout/trip_summary_widget_preview.xml
+++ b/app/src/main/res/layout/trip_summary_widget_preview.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Static placeholder shown in the system widget picker before the widget is configured -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#101413"
+    android:gravity="center_vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/trip_widget_title"
+        android:textColor="#FFFFFFFF"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/trip_widget_description"
+        android:textColor="#B3FFFFFF"
+        android:textSize="13sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1198,6 +1198,16 @@
 
     <!-- ==================== Estri a la pantalla d'inici ==================== -->
     <string name="widget_description">Estat de bateria del teu Tesla</string>
+    <string name="trip_widget_title">Resum de viatges</string>
+    <string name="trip_widget_description">Els darrers 30 dies de trajectes, energia i costos de càrrega</string>
+    <string name="trip_widget_period_last_30_days">Darrers 30 dies</string>
+    <string name="trip_widget_empty">Cap trajecte en els darrers 30 dies</string>
+    <string name="trip_widget_driving_days">Dies</string>
+    <string name="trip_widget_energy">Energia</string>
+    <string name="trip_widget_efficiency">Eficiència</string>
+    <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
+    <string name="trip_widget_no_value">N/D</string>
+    <string name="trip_widget_updated">Actualitzat %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehicle per a l\'estri</string>
     <string name="widget_loading">Carregant…</string>
     <string name="widget_error_configure">Toca per configurar</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1208,12 +1208,20 @@
     <string name="trip_widget_driving_days">Dies</string>
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Eficiència</string>
+    <string name="trip_widget_distance_trend_new">Distància · nova</string>
+    <string name="trip_widget_distance_trend_same">Distància · sense canvis</string>
+    <string name="trip_widget_distance_trend_more">Distància · %1$d%% més</string>
+    <string name="trip_widget_distance_trend_less">Distància · %1$d%% menys</string>
+    <string name="trip_widget_cost_none_priced">Cost · cap preu</string>
+    <string name="trip_widget_cost_partially_priced">Cost · %1$d/%2$d amb preu</string>
+    <string name="trip_widget_cost_all_priced">Cost · complet</string>
     <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
     <string name="trip_widget_compact_cost">Cost %1$s</string>
     <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualitzat %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehicle per a l\'estri</string>
+    <string name="widget_save">Desa l\'estri</string>
     <string name="widget_loading">Carregant…</string>
     <string name="widget_error_configure">Toca per configurar</string>
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1206,6 +1206,8 @@
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Eficiència</string>
     <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
+    <string name="trip_widget_compact_cost">Cost %1$s</string>
+    <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualitzat %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehicle per a l\'estri</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1199,9 +1199,12 @@
     <!-- ==================== Estri a la pantalla d'inici ==================== -->
     <string name="widget_description">Estat de bateria del teu Tesla</string>
     <string name="trip_widget_title">Resum de viatges</string>
-    <string name="trip_widget_description">Els darrers 30 dies de trajectes, energia i costos de càrrega</string>
+    <string name="trip_widget_description">Trajectes, energia i costos de càrrega per interval</string>
+    <string name="trip_widget_period_last_7_days">Darrers 7 dies</string>
     <string name="trip_widget_period_last_30_days">Darrers 30 dies</string>
-    <string name="trip_widget_empty">Cap trajecte en els darrers 30 dies</string>
+    <string name="trip_widget_period_last_90_days">Darrers 90 dies</string>
+    <string name="trip_widget_range_title">Interval del resum</string>
+    <string name="trip_widget_empty">Cap trajecte en aquest interval</string>
     <string name="trip_widget_driving_days">Dies</string>
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Eficiència</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1217,6 +1217,7 @@
     <string name="trip_widget_cost_all_priced">Cost · complet</string>
     <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
     <string name="trip_widget_compact_cost">Cost %1$s</string>
+    <string name="trip_widget_compact_cost_partial">Cost %1$s · %2$d/%3$d amb preu</string>
     <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualitzat %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1296,6 +1296,13 @@
     <string name="trip_widget_driving_days">Tage</string>
     <string name="trip_widget_energy">Energie</string>
     <string name="trip_widget_efficiency">Effizienz</string>
+    <string name="trip_widget_distance_trend_new">Strecke · neu</string>
+    <string name="trip_widget_distance_trend_same">Strecke · unverändert</string>
+    <string name="trip_widget_distance_trend_more">Strecke · %1$d%% mehr</string>
+    <string name="trip_widget_distance_trend_less">Strecke · %1$d%% weniger</string>
+    <string name="trip_widget_cost_none_priced">Kosten · keine Preise</string>
+    <string name="trip_widget_cost_partially_priced">Kosten · %1$d/%2$d bepreist</string>
+    <string name="trip_widget_cost_all_priced">Kosten · vollständig</string>
     <string name="trip_widget_cost_per_distance">Kosten/100 %1$s</string>
     <string name="trip_widget_compact_cost">Kosten %1$s</string>
     <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
@@ -1304,6 +1311,7 @@
 
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">Fahrzeug für das Widget auswählen</string>
+    <string name="widget_save">Widget speichern</string>
 
     <!-- Shown on the widget while data is being loaded for the first time -->
     <string name="widget_loading">Wird geladen…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1305,6 +1305,7 @@
     <string name="trip_widget_cost_all_priced">Kosten · vollständig</string>
     <string name="trip_widget_cost_per_distance">Kosten/100 %1$s</string>
     <string name="trip_widget_compact_cost">Kosten %1$s</string>
+    <string name="trip_widget_compact_cost_partial">Kosten %1$s · %2$d/%3$d bepreist</string>
     <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
     <string name="trip_widget_no_value">k. A.</string>
     <string name="trip_widget_updated">Aktualisiert %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1287,9 +1287,12 @@
     <!-- Widget description shown in the system widget picker -->
     <string name="widget_description">Batteriestatus für deinen Tesla</string>
     <string name="trip_widget_title">Trip-Zusammenfassung</string>
-    <string name="trip_widget_description">Die letzten 30 Tage mit Fahrten, Energie und Ladekosten</string>
+    <string name="trip_widget_description">Fahrten, Energie und Ladekosten nach Zeitraum</string>
+    <string name="trip_widget_period_last_7_days">Letzte 7 Tage</string>
     <string name="trip_widget_period_last_30_days">Letzte 30 Tage</string>
-    <string name="trip_widget_empty">Keine Fahrten in den letzten 30 Tagen</string>
+    <string name="trip_widget_period_last_90_days">Letzte 90 Tage</string>
+    <string name="trip_widget_range_title">Zusammenfassungszeitraum</string>
+    <string name="trip_widget_empty">Keine Fahrten in diesem Zeitraum</string>
     <string name="trip_widget_driving_days">Tage</string>
     <string name="trip_widget_energy">Energie</string>
     <string name="trip_widget_efficiency">Effizienz</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1286,6 +1286,16 @@
     <!-- ==================== Home Screen Widget ==================== -->
     <!-- Widget description shown in the system widget picker -->
     <string name="widget_description">Batteriestatus für deinen Tesla</string>
+    <string name="trip_widget_title">Trip-Zusammenfassung</string>
+    <string name="trip_widget_description">Die letzten 30 Tage mit Fahrten, Energie und Ladekosten</string>
+    <string name="trip_widget_period_last_30_days">Letzte 30 Tage</string>
+    <string name="trip_widget_empty">Keine Fahrten in den letzten 30 Tagen</string>
+    <string name="trip_widget_driving_days">Tage</string>
+    <string name="trip_widget_energy">Energie</string>
+    <string name="trip_widget_efficiency">Effizienz</string>
+    <string name="trip_widget_cost_per_distance">Kosten/100 %1$s</string>
+    <string name="trip_widget_no_value">k. A.</string>
+    <string name="trip_widget_updated">Aktualisiert %1$s</string>
 
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">Fahrzeug für das Widget auswählen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1294,6 +1294,8 @@
     <string name="trip_widget_energy">Energie</string>
     <string name="trip_widget_efficiency">Effizienz</string>
     <string name="trip_widget_cost_per_distance">Kosten/100 %1$s</string>
+    <string name="trip_widget_compact_cost">Kosten %1$s</string>
+    <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
     <string name="trip_widget_no_value">k. A.</string>
     <string name="trip_widget_updated">Aktualisiert %1$s</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1198,6 +1198,16 @@
 
     <!-- ==================== Widget en la pantalla de inicio ==================== -->
     <string name="widget_description">Estado de batería de tu Tesla</string>
+    <string name="trip_widget_title">Resumen de viajes</string>
+    <string name="trip_widget_description">Últimos 30 días de recorridos, energía y costes de carga</string>
+    <string name="trip_widget_period_last_30_days">Últimos 30 días</string>
+    <string name="trip_widget_empty">No hay recorridos en los últimos 30 días</string>
+    <string name="trip_widget_driving_days">Días</string>
+    <string name="trip_widget_energy">Energía</string>
+    <string name="trip_widget_efficiency">Eficiencia</string>
+    <string name="trip_widget_cost_per_distance">Coste/100 %1$s</string>
+    <string name="trip_widget_no_value">N/D</string>
+    <string name="trip_widget_updated">Actualizado %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehículo para el widget</string>
     <string name="widget_loading">Cargando…</string>
     <string name="widget_error_configure">Toca para configurar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1217,6 +1217,7 @@
     <string name="trip_widget_cost_all_priced">Coste · completo</string>
     <string name="trip_widget_cost_per_distance">Coste/100 %1$s</string>
     <string name="trip_widget_compact_cost">Coste %1$s</string>
+    <string name="trip_widget_compact_cost_partial">Coste %1$s · %2$d/%3$d con precio</string>
     <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualizado %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1206,6 +1206,8 @@
     <string name="trip_widget_energy">Energía</string>
     <string name="trip_widget_efficiency">Eficiencia</string>
     <string name="trip_widget_cost_per_distance">Coste/100 %1$s</string>
+    <string name="trip_widget_compact_cost">Coste %1$s</string>
+    <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualizado %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehículo para el widget</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1199,9 +1199,12 @@
     <!-- ==================== Widget en la pantalla de inicio ==================== -->
     <string name="widget_description">Estado de batería de tu Tesla</string>
     <string name="trip_widget_title">Resumen de viajes</string>
-    <string name="trip_widget_description">Últimos 30 días de recorridos, energía y costes de carga</string>
+    <string name="trip_widget_description">Recorridos, energía y costes de carga por intervalo</string>
+    <string name="trip_widget_period_last_7_days">Últimos 7 días</string>
     <string name="trip_widget_period_last_30_days">Últimos 30 días</string>
-    <string name="trip_widget_empty">No hay recorridos en los últimos 30 días</string>
+    <string name="trip_widget_period_last_90_days">Últimos 90 días</string>
+    <string name="trip_widget_range_title">Intervalo del resumen</string>
+    <string name="trip_widget_empty">No hay recorridos en este intervalo</string>
     <string name="trip_widget_driving_days">Días</string>
     <string name="trip_widget_energy">Energía</string>
     <string name="trip_widget_efficiency">Eficiencia</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1208,12 +1208,20 @@
     <string name="trip_widget_driving_days">Días</string>
     <string name="trip_widget_energy">Energía</string>
     <string name="trip_widget_efficiency">Eficiencia</string>
+    <string name="trip_widget_distance_trend_new">Distancia · nueva</string>
+    <string name="trip_widget_distance_trend_same">Distancia · sin cambios</string>
+    <string name="trip_widget_distance_trend_more">Distancia · %1$d%% más</string>
+    <string name="trip_widget_distance_trend_less">Distancia · %1$d%% menos</string>
+    <string name="trip_widget_cost_none_priced">Coste · sin precios</string>
+    <string name="trip_widget_cost_partially_priced">Coste · %1$d/%2$d con precio</string>
+    <string name="trip_widget_cost_all_priced">Coste · completo</string>
     <string name="trip_widget_cost_per_distance">Coste/100 %1$s</string>
     <string name="trip_widget_compact_cost">Coste %1$s</string>
     <string name="trip_widget_compact_efficiency">Ef. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Actualizado %1$s</string>
     <string name="widget_select_car_title">Selecciona un vehículo para el widget</string>
+    <string name="widget_save">Guardar widget</string>
     <string name="widget_loading">Cargando…</string>
     <string name="widget_error_configure">Toca para configurar</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1206,6 +1206,8 @@
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Efficienza</string>
     <string name="trip_widget_cost_per_distance">Costo/100 %1$s</string>
+    <string name="trip_widget_compact_cost">Costo %1$s</string>
+    <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Aggiornato %1$s</string>
     <string name="widget_select_car_title">Seleziona un veicolo per il widget</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1208,12 +1208,20 @@
     <string name="trip_widget_driving_days">Giorni</string>
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Efficienza</string>
+    <string name="trip_widget_distance_trend_new">Distanza · nuova</string>
+    <string name="trip_widget_distance_trend_same">Distanza · invariata</string>
+    <string name="trip_widget_distance_trend_more">Distanza · %1$d%% in più</string>
+    <string name="trip_widget_distance_trend_less">Distanza · %1$d%% in meno</string>
+    <string name="trip_widget_cost_none_priced">Costo · nessun prezzo</string>
+    <string name="trip_widget_cost_partially_priced">Costo · %1$d/%2$d con prezzo</string>
+    <string name="trip_widget_cost_all_priced">Costo · completo</string>
     <string name="trip_widget_cost_per_distance">Costo/100 %1$s</string>
     <string name="trip_widget_compact_cost">Costo %1$s</string>
     <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Aggiornato %1$s</string>
     <string name="widget_select_car_title">Seleziona un veicolo per il widget</string>
+    <string name="widget_save">Salva widget</string>
     <string name="widget_loading">Caricamento…</string>
     <string name="widget_error_configure">Tocca per configurare</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1198,6 +1198,16 @@
 
     <!-- ==================== Widget nella schermata principale ==================== -->
     <string name="widget_description">Stato batteria per la tua Tesla</string>
+    <string name="trip_widget_title">Riepilogo viaggi</string>
+    <string name="trip_widget_description">Ultimi 30 giorni di percorsi, energia e costi di ricarica</string>
+    <string name="trip_widget_period_last_30_days">Ultimi 30 giorni</string>
+    <string name="trip_widget_empty">Nessun percorso negli ultimi 30 giorni</string>
+    <string name="trip_widget_driving_days">Giorni</string>
+    <string name="trip_widget_energy">Energia</string>
+    <string name="trip_widget_efficiency">Efficienza</string>
+    <string name="trip_widget_cost_per_distance">Costo/100 %1$s</string>
+    <string name="trip_widget_no_value">N/D</string>
+    <string name="trip_widget_updated">Aggiornato %1$s</string>
     <string name="widget_select_car_title">Seleziona un veicolo per il widget</string>
     <string name="widget_loading">Caricamento…</string>
     <string name="widget_error_configure">Tocca per configurare</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1217,6 +1217,7 @@
     <string name="trip_widget_cost_all_priced">Costo · completo</string>
     <string name="trip_widget_cost_per_distance">Costo/100 %1$s</string>
     <string name="trip_widget_compact_cost">Costo %1$s</string>
+    <string name="trip_widget_compact_cost_partial">Costo %1$s · %2$d/%3$d con prezzo</string>
     <string name="trip_widget_compact_efficiency">Eff. %1$s</string>
     <string name="trip_widget_no_value">N/D</string>
     <string name="trip_widget_updated">Aggiornato %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1199,9 +1199,12 @@
     <!-- ==================== Widget nella schermata principale ==================== -->
     <string name="widget_description">Stato batteria per la tua Tesla</string>
     <string name="trip_widget_title">Riepilogo viaggi</string>
-    <string name="trip_widget_description">Ultimi 30 giorni di percorsi, energia e costi di ricarica</string>
+    <string name="trip_widget_description">Percorsi, energia e costi di ricarica per intervallo</string>
+    <string name="trip_widget_period_last_7_days">Ultimi 7 giorni</string>
     <string name="trip_widget_period_last_30_days">Ultimi 30 giorni</string>
-    <string name="trip_widget_empty">Nessun percorso negli ultimi 30 giorni</string>
+    <string name="trip_widget_period_last_90_days">Ultimi 90 giorni</string>
+    <string name="trip_widget_range_title">Intervallo riepilogo</string>
+    <string name="trip_widget_empty">Nessun percorso in questo intervallo</string>
     <string name="trip_widget_driving_days">Giorni</string>
     <string name="trip_widget_energy">Energia</string>
     <string name="trip_widget_efficiency">Efficienza</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1202,9 +1202,12 @@
     <!-- Widget description shown in the system widget picker -->
     <string name="widget_description">Tesla 电池状态小组件</string>
     <string name="trip_widget_title">行程摘要</string>
-    <string name="trip_widget_description">最近 30 天的行驶、能耗和充电成本</string>
+    <string name="trip_widget_description">按范围显示行驶、能耗和充电成本</string>
+    <string name="trip_widget_period_last_7_days">最近 7 天</string>
     <string name="trip_widget_period_last_30_days">最近 30 天</string>
-    <string name="trip_widget_empty">最近 30 天没有行驶记录</string>
+    <string name="trip_widget_period_last_90_days">最近 90 天</string>
+    <string name="trip_widget_range_title">摘要范围</string>
+    <string name="trip_widget_empty">此范围内没有行驶记录</string>
     <string name="trip_widget_driving_days">天数</string>
     <string name="trip_widget_energy">能耗</string>
     <string name="trip_widget_efficiency">效率</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1220,6 +1220,7 @@
     <string name="trip_widget_cost_all_priced">费用 · 全部已计价</string>
     <string name="trip_widget_cost_per_distance">费用/100 %1$s</string>
     <string name="trip_widget_compact_cost">费用 %1$s</string>
+    <string name="trip_widget_compact_cost_partial">费用 %1$s · %2$d/%3$d 已计价</string>
     <string name="trip_widget_compact_efficiency">效率 %1$s</string>
     <string name="trip_widget_no_value">暂无</string>
     <string name="trip_widget_updated">已更新 %1$s</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1209,6 +1209,8 @@
     <string name="trip_widget_energy">能耗</string>
     <string name="trip_widget_efficiency">效率</string>
     <string name="trip_widget_cost_per_distance">费用/100 %1$s</string>
+    <string name="trip_widget_compact_cost">费用 %1$s</string>
+    <string name="trip_widget_compact_efficiency">效率 %1$s</string>
     <string name="trip_widget_no_value">暂无</string>
     <string name="trip_widget_updated">已更新 %1$s</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1211,6 +1211,13 @@
     <string name="trip_widget_driving_days">天数</string>
     <string name="trip_widget_energy">能耗</string>
     <string name="trip_widget_efficiency">效率</string>
+    <string name="trip_widget_distance_trend_new">里程 · 本期新增</string>
+    <string name="trip_widget_distance_trend_same">里程 · 与上期相同</string>
+    <string name="trip_widget_distance_trend_more">里程 · 增加 %1$d%%</string>
+    <string name="trip_widget_distance_trend_less">里程 · 减少 %1$d%%</string>
+    <string name="trip_widget_cost_none_priced">费用 · 均未计价</string>
+    <string name="trip_widget_cost_partially_priced">费用 · %1$d/%2$d 已计价</string>
+    <string name="trip_widget_cost_all_priced">费用 · 全部已计价</string>
     <string name="trip_widget_cost_per_distance">费用/100 %1$s</string>
     <string name="trip_widget_compact_cost">费用 %1$s</string>
     <string name="trip_widget_compact_efficiency">效率 %1$s</string>
@@ -1219,6 +1226,7 @@
 
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">为小组件选择一辆车</string>
+    <string name="widget_save">保存小组件</string>
 
     <!-- Shown on the widget while data is being loaded for the first time -->
     <string name="widget_loading">加载中…</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1201,6 +1201,16 @@
     <!-- ==================== Home Screen Widget ==================== -->
     <!-- Widget description shown in the system widget picker -->
     <string name="widget_description">Tesla 电池状态小组件</string>
+    <string name="trip_widget_title">行程摘要</string>
+    <string name="trip_widget_description">最近 30 天的行驶、能耗和充电成本</string>
+    <string name="trip_widget_period_last_30_days">最近 30 天</string>
+    <string name="trip_widget_empty">最近 30 天没有行驶记录</string>
+    <string name="trip_widget_driving_days">天数</string>
+    <string name="trip_widget_energy">能耗</string>
+    <string name="trip_widget_efficiency">效率</string>
+    <string name="trip_widget_cost_per_distance">费用/100 %1$s</string>
+    <string name="trip_widget_no_value">暂无</string>
+    <string name="trip_widget_updated">已更新 %1$s</string>
 
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">为小组件选择一辆车</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1318,6 +1318,17 @@
     <!-- Compact metric label for average driving efficiency in the selected range -->
     <string name="trip_widget_efficiency">Efficiency</string>
 
+    <!-- Distance comparison with the immediately preceding range of the same length -->
+    <string name="trip_widget_distance_trend_new">Distance · new this period</string>
+    <string name="trip_widget_distance_trend_same">Distance · unchanged</string>
+    <string name="trip_widget_distance_trend_more">Distance · %1$d%% more</string>
+    <string name="trip_widget_distance_trend_less">Distance · %1$d%% less</string>
+
+    <!-- Charging-cost coverage labels keep partial cost totals honest -->
+    <string name="trip_widget_cost_none_priced">Cost · none priced</string>
+    <string name="trip_widget_cost_partially_priced">Cost · %1$d/%2$d priced</string>
+    <string name="trip_widget_cost_all_priced">Cost · all priced</string>
+
     <!-- Compact metric label for charging cost per 100 distance units. %1$s is the distance unit (km or mi). -->
     <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
 
@@ -1335,6 +1346,7 @@
 
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">Select a vehicle for the widget</string>
+    <string name="widget_save">Save widget</string>
 
     <!-- Shown on the widget while data is being loaded for the first time -->
     <string name="widget_loading">Loading…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1334,6 +1334,8 @@
 
     <!-- Compact footer value for total charging cost. %1$s is the formatted cost or unavailable value. -->
     <string name="trip_widget_compact_cost">Cost %1$s</string>
+    <!-- Compact footer when only some charges in the range are priced. %1$s cost, %2$d priced, %3$d total. -->
+    <string name="trip_widget_compact_cost_partial">Cost %1$s · %2$d/%3$d priced</string>
 
     <!-- Compact footer value for average driving efficiency. %1$s is the formatted efficiency or unavailable value. -->
     <string name="trip_widget_compact_efficiency">Eff %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1292,6 +1292,36 @@
     <!-- Widget description shown in the system widget picker -->
     <string name="widget_description">Battery status for your Tesla</string>
 
+    <!-- Widget title shown in the system widget picker for trip summaries -->
+    <string name="trip_widget_title">Trip summary</string>
+
+    <!-- Widget description shown in the system widget picker for trip summaries -->
+    <string name="trip_widget_description">Last 30 days of drives, energy, and charging costs</string>
+
+    <!-- Period label shown on the trip summary widget -->
+    <string name="trip_widget_period_last_30_days">Last 30 days</string>
+
+    <!-- Empty state shown on the trip summary widget when no drives are available in the selected range -->
+    <string name="trip_widget_empty">No drives in the last 30 days</string>
+
+    <!-- Metric label for unique days with at least one drive in the selected range -->
+    <string name="trip_widget_driving_days">Days</string>
+
+    <!-- Compact metric label for total energy used in the selected range -->
+    <string name="trip_widget_energy">Energy</string>
+
+    <!-- Compact metric label for average driving efficiency in the selected range -->
+    <string name="trip_widget_efficiency">Efficiency</string>
+
+    <!-- Compact metric label for charging cost per 100 distance units. %1$s is the distance unit (km or mi). -->
+    <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
+
+    <!-- Placeholder for unavailable metric values on the trip summary widget -->
+    <string name="trip_widget_no_value">N/A</string>
+
+    <!-- Last update timestamp on the trip summary widget. %1$s is a localized short time. -->
+    <string name="trip_widget_updated">Updated %1$s</string>
+
     <!-- Title of the car selection screen shown when configuring the widget -->
     <string name="widget_select_car_title">Select a vehicle for the widget</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1296,13 +1296,18 @@
     <string name="trip_widget_title">Trip summary</string>
 
     <!-- Widget description shown in the system widget picker for trip summaries -->
-    <string name="trip_widget_description">Last 30 days of drives, energy, and charging costs</string>
+    <string name="trip_widget_description">Drives, energy, and charging costs by range</string>
 
     <!-- Period label shown on the trip summary widget -->
+    <string name="trip_widget_period_last_7_days">Last 7 days</string>
     <string name="trip_widget_period_last_30_days">Last 30 days</string>
+    <string name="trip_widget_period_last_90_days">Last 90 days</string>
+
+    <!-- Range selector title shown while configuring the trip summary widget -->
+    <string name="trip_widget_range_title">Summary range</string>
 
     <!-- Empty state shown on the trip summary widget when no drives are available in the selected range -->
-    <string name="trip_widget_empty">No drives in the last 30 days</string>
+    <string name="trip_widget_empty">No drives in this range</string>
 
     <!-- Metric label for unique days with at least one drive in the selected range -->
     <string name="trip_widget_driving_days">Days</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1316,6 +1316,12 @@
     <!-- Compact metric label for charging cost per 100 distance units. %1$s is the distance unit (km or mi). -->
     <string name="trip_widget_cost_per_distance">Cost/100 %1$s</string>
 
+    <!-- Compact footer value for total charging cost. %1$s is the formatted cost or unavailable value. -->
+    <string name="trip_widget_compact_cost">Cost %1$s</string>
+
+    <!-- Compact footer value for average driving efficiency. %1$s is the formatted efficiency or unavailable value. -->
+    <string name="trip_widget_compact_efficiency">Eff %1$s</string>
+
     <!-- Placeholder for unavailable metric values on the trip summary widget -->
     <string name="trip_widget_no_value">N/A</string>
 

--- a/app/src/main/res/xml/trip_summary_widget_info.xml
+++ b/app/src/main/res/xml/trip_summary_widget_info.xml
@@ -10,4 +10,5 @@
     android:updatePeriodMillis="0"
     android:configure="com.matedroid.widget.TripSummaryWidgetConfigActivity"
     android:description="@string/trip_widget_description"
+    android:previewLayout="@layout/trip_summary_widget_preview"
     android:initialLayout="@layout/trip_summary_widget_preview" />

--- a/app/src/main/res/xml/trip_summary_widget_info.xml
+++ b/app/src/main/res/xml/trip_summary_widget_info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="140dp"
+    android:minHeight="90dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="70dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:configure="com.matedroid.widget.TripSummaryWidgetConfigActivity"
+    android:description="@string/trip_widget_description"
+    android:initialLayout="@layout/trip_summary_widget_preview" />

--- a/app/src/main/res/xml/trip_summary_widget_info.xml
+++ b/app/src/main/res/xml/trip_summary_widget_info.xml
@@ -9,6 +9,7 @@
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:configure="com.matedroid.widget.TripSummaryWidgetConfigActivity"
+    android:widgetFeatures="reconfigurable"
     android:description="@string/trip_widget_description"
     android:previewLayout="@layout/trip_summary_widget_preview"
     android:initialLayout="@layout/trip_summary_widget_preview" />

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.matedroid.ui.screens.dashboard
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
 import com.matedroid.data.api.models.BatteryDetails
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarStatus
@@ -24,6 +27,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
@@ -48,6 +54,8 @@ class DashboardViewModelTest {
     private lateinit var geocodingRepository: GeocodingRepository
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var sentryStateRepository: SentryStateRepository
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
     private var viewModel: DashboardViewModel? = null
 
     private val testCar = CarData(
@@ -81,6 +89,8 @@ class DashboardViewModelTest {
         geocodingRepository = mockk()
         settingsDataStore = mockk()
         sentryStateRepository = mockk()
+        context = mockk(relaxed = true)
+        workManager = mockk(relaxed = true)
         coEvery { sentryStateRepository.getEventCount(any()) } returns 0
         // Default: no previously selected car
         every { settingsDataStore.settings } returns flowOf(AppSettings())
@@ -91,6 +101,12 @@ class DashboardViewModelTest {
             GlobalSettingsData(settings = GlobalSettings(teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com")))
         )
         coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit
+        mockkObject(WorkManager.Companion)
+        every { WorkManager.getInstance(any()) } returns workManager
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>(), any()) } returns 0
     }
 
     @After
@@ -98,12 +114,12 @@ class DashboardViewModelTest {
         cancelViewModelCoroutines()
         viewModel = null
         Dispatchers.resetMain()
-        clearAllMocks()
+        unmockkAll()
     }
 
     private fun createViewModel(): DashboardViewModel {
         return DashboardViewModel(
-            repository, geocodingRepository, settingsDataStore, sentryStateRepository,
+            context, repository, geocodingRepository, settingsDataStore, sentryStateRepository,
             mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -9,6 +9,7 @@ import com.matedroid.data.api.models.ChargingDetails
 import com.matedroid.data.api.models.GlobalSettings
 import com.matedroid.data.api.models.GlobalSettingsData
 import com.matedroid.data.api.models.TeslamateUrls
+import com.matedroid.data.api.models.TeslamateUnits
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.AppSettings
 import com.matedroid.data.local.SettingsDataStore
@@ -131,6 +132,27 @@ class DashboardViewModelTest {
         assertEquals(1, viewModel!!.uiState.value.cars.size)
         assertEquals(1, viewModel!!.uiState.value.selectedCarId)
         assertEquals(testStatus, viewModel!!.uiState.value.carStatus)
+    }
+
+    @Test
+    fun `loadCars caches unit of length from global settings`() = runTest {
+        coEvery { repository.getCars() } returns ApiResult.Success(listOf(testCar))
+        coEvery { repository.getCarStatus(1) } returns ApiResult.Success(testStatusWithUnits)
+        coEvery { repository.getGlobalSettings() } returns ApiResult.Success(
+            GlobalSettingsData(
+                settings = GlobalSettings(
+                    teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com"),
+                    teslamateUnits = TeslamateUnits(unitOfLength = "mi")
+                )
+            )
+        )
+        coEvery { settingsDataStore.saveUnitOfLength(any()) } returns Unit
+
+        viewModel = createViewModel()
+        runCurrent()
+        cancelViewModelCoroutines()
+
+        coVerify { settingsDataStore.saveUnitOfLength("mi") }
     }
 
     @Test

--- a/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/dashboard/DashboardViewModelTest.kt
@@ -1,9 +1,6 @@
 package com.matedroid.ui.screens.dashboard
 
-import android.content.Context
-import android.util.Log
 import androidx.lifecycle.viewModelScope
-import androidx.work.WorkManager
 import com.matedroid.data.api.models.BatteryDetails
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarStatus
@@ -27,9 +24,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
@@ -54,8 +48,6 @@ class DashboardViewModelTest {
     private lateinit var geocodingRepository: GeocodingRepository
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var sentryStateRepository: SentryStateRepository
-    private lateinit var context: Context
-    private lateinit var workManager: WorkManager
     private var viewModel: DashboardViewModel? = null
 
     private val testCar = CarData(
@@ -89,8 +81,6 @@ class DashboardViewModelTest {
         geocodingRepository = mockk()
         settingsDataStore = mockk()
         sentryStateRepository = mockk()
-        context = mockk(relaxed = true)
-        workManager = mockk(relaxed = true)
         coEvery { sentryStateRepository.getEventCount(any()) } returns 0
         // Default: no previously selected car
         every { settingsDataStore.settings } returns flowOf(AppSettings())
@@ -101,12 +91,6 @@ class DashboardViewModelTest {
             GlobalSettingsData(settings = GlobalSettings(teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com")))
         )
         coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit
-        mockkObject(WorkManager.Companion)
-        every { WorkManager.getInstance(any()) } returns workManager
-        mockkStatic(Log::class)
-        every { Log.d(any(), any()) } returns 0
-        every { Log.e(any(), any<String>()) } returns 0
-        every { Log.e(any(), any<String>(), any()) } returns 0
     }
 
     @After
@@ -114,12 +98,12 @@ class DashboardViewModelTest {
         cancelViewModelCoroutines()
         viewModel = null
         Dispatchers.resetMain()
-        unmockkAll()
+        clearAllMocks()
     }
 
     private fun createViewModel(): DashboardViewModel {
         return DashboardViewModel(
-            context, repository, geocodingRepository, settingsDataStore, sentryStateRepository,
+            repository, geocodingRepository, settingsDataStore, sentryStateRepository,
             mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.work.WorkManager
 import com.matedroid.data.api.models.GlobalSettings
 import com.matedroid.data.api.models.GlobalSettingsData
 import com.matedroid.data.api.models.TeslamateUrls
+import com.matedroid.data.api.models.TeslamateUnits
 import com.matedroid.data.local.AppSettings
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.repository.ApiResult
@@ -177,6 +178,30 @@ class SettingsViewModelTest {
         assertNotNull(result)
         assertTrue(result!!.primaryResult is ServerTestResult.Success)
         assertNull(result.secondaryResult) // No secondary URL configured
+    }
+
+    @Test
+    fun `testConnection caches unit of length from global settings`() = runTest {
+        coEvery { repository.testConnection(any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.getGlobalSettings() } returns ApiResult.Success(
+            GlobalSettingsData(
+                settings = GlobalSettings(
+                    teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com"),
+                    teslamateUnits = TeslamateUnits(unitOfLength = "mi")
+                )
+            )
+        )
+        coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit
+        coEvery { settingsDataStore.saveUnitOfLength(any()) } returns Unit
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.updateServerUrl("https://valid.com")
+        viewModel.testConnection()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsDataStore.saveUnitOfLength("mi") }
     }
 
     @Test

--- a/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.matedroid.ui.screens.settings
 
 import android.content.Context
+import android.util.Log
 import androidx.work.WorkManager
 import com.matedroid.data.api.models.GlobalSettings
 import com.matedroid.data.api.models.GlobalSettingsData
@@ -19,6 +20,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -68,6 +70,10 @@ class SettingsViewModelTest {
         // removed @JvmStatic, so mockkStatic(WorkManager::class) no longer intercepts).
         mockkObject(WorkManager.Companion)
         every { WorkManager.getInstance(any()) } returns workManager
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>(), any()) } returns 0
     }
 
     @After

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
@@ -19,6 +19,33 @@ class TripSummaryWidgetDateRangeTest {
     }
 
     @Test
+    fun lastDaysSupportsShortAndLongWidgetRanges() {
+        val today = LocalDate.of(2026, 7, 8)
+
+        val (sevenDayStart, sevenDayEnd) = TripSummaryWidgetDateRange.lastDays(
+            today = today,
+            days = 7
+        )
+        val (ninetyDayStart, ninetyDayEnd) = TripSummaryWidgetDateRange.lastDays(
+            today = today,
+            days = 90
+        )
+
+        assertEquals("2026-07-02T00:00:00", sevenDayStart)
+        assertEquals("2026-07-09T00:00:00", sevenDayEnd)
+        assertEquals("2026-04-10T00:00:00", ninetyDayStart)
+        assertEquals("2026-07-09T00:00:00", ninetyDayEnd)
+    }
+
+    @Test
+    fun rangeFallsBackToDefaultWhenStoredPreferenceIsUnsupported() {
+        assertEquals(TripSummaryWidgetRange.SevenDays, TripSummaryWidgetRange.fromDays(7))
+        assertEquals(TripSummaryWidgetRange.ThirtyDays, TripSummaryWidgetRange.fromDays(30))
+        assertEquals(TripSummaryWidgetRange.NinetyDays, TripSummaryWidgetRange.fromDays(90))
+        assertEquals(TripSummaryWidgetRange.DEFAULT, TripSummaryWidgetRange.fromDays(42))
+    }
+
+    @Test
     fun lastDaysRejectsNonPositiveRanges() {
         assertThrows(IllegalArgumentException::class.java) {
             TripSummaryWidgetDateRange.lastDays(days = 0)

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
@@ -38,6 +38,19 @@ class TripSummaryWidgetDateRangeTest {
     }
 
     @Test
+    fun comparisonRangeImmediatelyPrecedesCurrentRange() {
+        val ranges = TripSummaryWidgetDateRange.currentAndPreviousDays(
+            today = LocalDate.of(2026, 7, 8),
+            days = 30,
+        )
+
+        assertEquals("2026-06-09T00:00:00", ranges.currentStart)
+        assertEquals("2026-07-09T00:00:00", ranges.currentEnd)
+        assertEquals("2026-05-10T00:00:00", ranges.previousStart)
+        assertEquals("2026-06-09T00:00:00", ranges.previousEnd)
+    }
+
+    @Test
     fun rangeFallsBackToDefaultWhenStoredPreferenceIsUnsupported() {
         assertEquals(TripSummaryWidgetRange.SevenDays, TripSummaryWidgetRange.fromDays(7))
         assertEquals(TripSummaryWidgetRange.ThirtyDays, TripSummaryWidgetRange.fromDays(30))

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetDateRangeTest.kt
@@ -1,0 +1,27 @@
+package com.matedroid.widget
+
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class TripSummaryWidgetDateRangeTest {
+
+    @Test
+    fun lastDaysIncludesTodayAndPreviousDays() {
+        val (startDate, endDate) = TripSummaryWidgetDateRange.lastDays(
+            today = LocalDate.of(2026, 7, 8),
+            days = 30
+        )
+
+        assertEquals("2026-06-09T00:00:00", startDate)
+        assertEquals("2026-07-09T00:00:00", endDate)
+    }
+
+    @Test
+    fun lastDaysRejectsNonPositiveRanges() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TripSummaryWidgetDateRange.lastDays(days = 0)
+        }
+    }
+}

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
@@ -1,0 +1,132 @@
+package com.matedroid.widget
+
+import com.matedroid.data.api.models.Units
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TripSummaryWidgetFormatterTest {
+
+    private lateinit var previousLocale: Locale
+
+    @Before
+    fun setUp() {
+        previousLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(previousLocale)
+    }
+
+    @Test
+    fun formatShowsNoValueWhenNoChargeCostWasRecorded() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model Y",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 4,
+                drivingDays = 3,
+                totalDistance = 300.0,
+                totalEnergy = 48.0,
+                avgEfficiency = 160.0,
+                totalCost = 0.0,
+                chargesWithCost = 0,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+        )
+
+        assertTrue(data.hasDrives)
+        assertEquals("300 km", data.distanceValue)
+        assertEquals("4", data.driveCountValue)
+        assertEquals("3", data.drivingDaysValue)
+        assertEquals("48 kWh", data.energyValue)
+        assertEquals("160 Wh/km", data.efficiencyValue)
+        assertEquals("N/A", data.costValue)
+        assertEquals("N/A", data.costPerDistanceValue)
+        assertEquals("km", data.distanceUnit)
+        assertEquals("Updated 9:00", data.updatedValue)
+    }
+
+    @Test
+    fun formatShowsZeroCostWhenAZeroCostChargeWasRecorded() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model Y",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 3,
+                drivingDays = 2,
+                totalDistance = 250.0,
+                totalEnergy = 40.0,
+                avgEfficiency = 160.0,
+                totalCost = 0.0,
+                chargesWithCost = 1,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+        )
+
+        assertEquals("0.00 \$", data.costValue)
+        assertEquals("0.00 \$", data.costPerDistanceValue)
+    }
+
+    @Test
+    fun formatUsesImperialLabelsWhenUnitsAreImperial() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model 3",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 2,
+                drivingDays = 2,
+                totalDistance = 120.0,
+                totalEnergy = 30.0,
+                avgEfficiency = 250.0,
+                totalCost = 12.0,
+                chargesWithCost = 1,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+            units = Units(unitOfLength = "mi"),
+        )
+
+        assertEquals("120 mi", data.distanceValue)
+        assertEquals("250 Wh/mi", data.efficiencyValue)
+        assertEquals("10.00 \$", data.costPerDistanceValue)
+        assertEquals("mi", data.distanceUnit)
+    }
+
+    @Test
+    fun formatMarksEmptyDriveRange() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model S",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 0,
+                drivingDays = 0,
+                totalDistance = 0.0,
+                totalEnergy = 0.0,
+                avgEfficiency = 0.0,
+                totalCost = 0.0,
+                chargesWithCost = 0,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+        )
+
+        assertFalse(data.hasDrives)
+        assertEquals("0 km", data.distanceValue)
+        assertEquals("0", data.drivingDaysValue)
+        assertEquals("N/A", data.efficiencyValue)
+        assertEquals("N/A", data.costValue)
+    }
+}

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
@@ -115,11 +115,39 @@ class TripSummaryWidgetFormatterTest {
 
         assertEquals("120 mi", data.distanceValue)
         assertEquals("250 Wh/mi", data.efficiencyValue)
-        assertEquals("10.00 \$", data.costPerDistanceValue)
+        assertEquals("N/A", data.costPerDistanceValue)
+        assertEquals("12.00 \$", data.costValue)
         assertEquals("mi", data.distanceUnit)
         assertEquals(TripSummaryWidgetTrend.Down, data.distanceTrend)
         assertEquals(20, data.distanceTrendPercent)
         assertEquals(TripSummaryWidgetCostCoverage.Partial, data.costCoverage)
+    }
+
+    @Test
+    fun formatShowsCostPerDistanceOnlyWhenEveryChargeIsPriced() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model Y",
+            periodLabel = "Last 30 days",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 4,
+                drivingDays = 3,
+                totalDistance = 200.0,
+                totalEnergy = 32.0,
+                avgEfficiency = 160.0,
+                totalCost = 20.0,
+                chargesWithCost = 2,
+                chargeCount = 2,
+                previousDistance = 180.0,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+        )
+
+        assertEquals("20.00 \$", data.costValue)
+        assertEquals("10.00 \$", data.costPerDistanceValue)
+        assertEquals(TripSummaryWidgetCostCoverage.Complete, data.costCoverage)
     }
 
     @Test

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
@@ -38,6 +38,8 @@ class TripSummaryWidgetFormatterTest {
                 avgEfficiency = 160.0,
                 totalCost = 0.0,
                 chargesWithCost = 0,
+                chargeCount = 2,
+                previousDistance = 250.0,
             ),
             currencySymbol = "\$",
             noValue = "N/A",
@@ -53,6 +55,9 @@ class TripSummaryWidgetFormatterTest {
         assertEquals("160 Wh/km", data.efficiencyValue)
         assertEquals("N/A", data.costValue)
         assertEquals("N/A", data.costPerDistanceValue)
+        assertEquals(TripSummaryWidgetTrend.Up, data.distanceTrend)
+        assertEquals(20, data.distanceTrendPercent)
+        assertEquals(TripSummaryWidgetCostCoverage.Missing, data.costCoverage)
         assertEquals("km", data.distanceUnit)
         assertEquals("Updated 9:00", data.updatedValue)
     }
@@ -71,6 +76,8 @@ class TripSummaryWidgetFormatterTest {
                 avgEfficiency = 160.0,
                 totalCost = 0.0,
                 chargesWithCost = 1,
+                chargeCount = 1,
+                previousDistance = 250.0,
             ),
             currencySymbol = "\$",
             noValue = "N/A",
@@ -79,6 +86,8 @@ class TripSummaryWidgetFormatterTest {
 
         assertEquals("0.00 \$", data.costValue)
         assertEquals("0.00 \$", data.costPerDistanceValue)
+        assertEquals(TripSummaryWidgetTrend.Same, data.distanceTrend)
+        assertEquals(TripSummaryWidgetCostCoverage.Complete, data.costCoverage)
     }
 
     @Test
@@ -95,6 +104,8 @@ class TripSummaryWidgetFormatterTest {
                 avgEfficiency = 250.0,
                 totalCost = 12.0,
                 chargesWithCost = 1,
+                chargeCount = 2,
+                previousDistance = 150.0,
             ),
             currencySymbol = "\$",
             noValue = "N/A",
@@ -106,6 +117,9 @@ class TripSummaryWidgetFormatterTest {
         assertEquals("250 Wh/mi", data.efficiencyValue)
         assertEquals("10.00 \$", data.costPerDistanceValue)
         assertEquals("mi", data.distanceUnit)
+        assertEquals(TripSummaryWidgetTrend.Down, data.distanceTrend)
+        assertEquals(20, data.distanceTrendPercent)
+        assertEquals(TripSummaryWidgetCostCoverage.Partial, data.costCoverage)
     }
 
     @Test
@@ -122,6 +136,8 @@ class TripSummaryWidgetFormatterTest {
                 avgEfficiency = 0.0,
                 totalCost = 0.0,
                 chargesWithCost = 0,
+                chargeCount = 0,
+                previousDistance = 200.0,
             ),
             currencySymbol = "\$",
             noValue = "N/A",
@@ -133,5 +149,33 @@ class TripSummaryWidgetFormatterTest {
         assertEquals("0", data.drivingDaysValue)
         assertEquals("N/A", data.efficiencyValue)
         assertEquals("N/A", data.costValue)
+        assertEquals(TripSummaryWidgetTrend.None, data.distanceTrend)
+        assertEquals(TripSummaryWidgetCostCoverage.None, data.costCoverage)
+    }
+
+    @Test
+    fun formatMarksDistanceAsNewWhenPreviousRangeWasEmpty() {
+        val data = TripSummaryWidgetFormatter.format(
+            carId = 7,
+            carName = "Model 3",
+            periodLabel = "Last 7 days",
+            metrics = TripSummaryWidgetMetrics(
+                driveCount = 1,
+                drivingDays = 1,
+                totalDistance = 42.0,
+                totalEnergy = 7.0,
+                avgEfficiency = 167.0,
+                totalCost = 0.0,
+                chargesWithCost = 0,
+                chargeCount = 0,
+                previousDistance = 0.0,
+            ),
+            currencySymbol = "\$",
+            noValue = "N/A",
+            updatedValue = "Updated 9:00",
+        )
+
+        assertEquals(TripSummaryWidgetTrend.New, data.distanceTrend)
+        assertEquals(0, data.distanceTrendPercent)
     }
 }

--- a/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
+++ b/app/src/test/java/com/matedroid/widget/TripSummaryWidgetFormatterTest.kt
@@ -29,6 +29,7 @@ class TripSummaryWidgetFormatterTest {
         val data = TripSummaryWidgetFormatter.format(
             carId = 7,
             carName = "Model Y",
+            periodLabel = "Last 30 days",
             metrics = TripSummaryWidgetMetrics(
                 driveCount = 4,
                 drivingDays = 3,
@@ -44,6 +45,7 @@ class TripSummaryWidgetFormatterTest {
         )
 
         assertTrue(data.hasDrives)
+        assertEquals("Last 30 days", data.periodLabel)
         assertEquals("300 km", data.distanceValue)
         assertEquals("4", data.driveCountValue)
         assertEquals("3", data.drivingDaysValue)
@@ -60,6 +62,7 @@ class TripSummaryWidgetFormatterTest {
         val data = TripSummaryWidgetFormatter.format(
             carId = 7,
             carName = "Model Y",
+            periodLabel = "Last 7 days",
             metrics = TripSummaryWidgetMetrics(
                 driveCount = 3,
                 drivingDays = 2,
@@ -83,6 +86,7 @@ class TripSummaryWidgetFormatterTest {
         val data = TripSummaryWidgetFormatter.format(
             carId = 7,
             carName = "Model 3",
+            periodLabel = "Last 90 days",
             metrics = TripSummaryWidgetMetrics(
                 driveCount = 2,
                 drivingDays = 2,
@@ -109,6 +113,7 @@ class TripSummaryWidgetFormatterTest {
         val data = TripSummaryWidgetFormatter.format(
             carId = 7,
             carName = "Model S",
+            periodLabel = "Last 30 days",
             metrics = TripSummaryWidgetMetrics(
                 driveCount = 0,
                 drivingDays = 0,


### PR DESCRIPTION
Adds a read-only home screen Trip summary widget backed entirely by cached Room summaries. It never sends vehicle commands or polls the car.

Highlights:
- Vehicle selection with reconfigurable 7/30/90-day ranges
- Distance, drives, driving days, energy, efficiency, charging cost, and cost per 100 distance units
- Same-length previous-period distance comparison
- Honest charging-cost coverage labels for missing, partial, and complete price data
- Periodic/offline updates plus refresh after successful data sync
- Trips deep-linking without live car polling
- Cached TeslaMate unit and currency handling
- Localized widget copy in English, Catalan, German, Spanish, Italian, and Chinese
- Formatter and date-range unit coverage

Local verification:
- git diff --check
- ./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleDebug

Local setup note: Android SDK, Gradle cache, and build output are backed by an APFS sparsebundle on the external SSD to avoid internal disk pressure.