### PR TITLE
Expand Trips summary with energy, efficiency, and cost metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Richer Trips summary** — the Trips list summary now includes energy used, average efficiency, energy charged, charging cost, and cost per 100 km/mi. Known costs stay visible when only some sessions are priced, with an honest coverage note; cost/100 only appears when every charge in range is priced.
+
 ### Changed
 - **Snappier throughout** — smoother list scrolling, lighter chart rendering, the Stats and Trips screens do their heavy work off the UI thread, and the dashboard stops polling for status while it's off screen (less background battery use). No change to how anything looks.
 - **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.

--- a/app/src/main/java/com/matedroid/domain/TripsSummaryCalculator.kt
+++ b/app/src/main/java/com/matedroid/domain/TripsSummaryCalculator.kt
@@ -1,0 +1,59 @@
+package com.matedroid.domain
+
+import com.matedroid.domain.model.Trip
+
+enum class TripCostCoverage {
+    None,
+    Partial,
+    Complete,
+}
+
+data class TripsSummaryMetrics(
+    val tripCount: Int = 0,
+    val totalDistance: Double = 0.0,
+    val totalDrivingMinutes: Int = 0,
+    val totalEnergyConsumed: Double = 0.0,
+    val totalEnergyCharged: Double = 0.0,
+    val averageEfficiency: Double? = null,
+    val totalChargeCost: Double? = null,
+    val costPer100Distance: Double? = null,
+    val pricedChargeCount: Int = 0,
+    val chargeCount: Int = 0,
+    val costCoverage: TripCostCoverage = TripCostCoverage.None,
+)
+
+object TripsSummaryCalculator {
+
+    fun calculate(trips: List<Trip>): TripsSummaryMetrics {
+        val totalDistance = trips.sumOf { it.totalDistance }
+        val totalEnergyConsumed = trips.sumOf { it.totalEnergyConsumed }
+        val charges = trips.flatMap { it.charges }
+        val chargeCosts = charges.mapNotNull { it.cost }
+        val totalChargeCost = chargeCosts
+            .takeIf { it.isNotEmpty() }
+            ?.sum()
+        val costCoverage = when {
+            charges.isEmpty() || chargeCosts.isEmpty() -> TripCostCoverage.None
+            chargeCosts.size < charges.size -> TripCostCoverage.Partial
+            else -> TripCostCoverage.Complete
+        }
+
+        return TripsSummaryMetrics(
+            tripCount = trips.size,
+            totalDistance = totalDistance,
+            totalDrivingMinutes = trips.sumOf { it.totalDrivingDurationMin },
+            totalEnergyConsumed = totalEnergyConsumed,
+            totalEnergyCharged = trips.sumOf { it.totalEnergyCharged },
+            averageEfficiency = totalDistance
+                .takeIf { it > 0.0 }
+                ?.let { totalEnergyConsumed * 1000.0 / it },
+            totalChargeCost = totalChargeCost,
+            costPer100Distance = totalChargeCost
+                ?.takeIf { totalDistance > 0.0 }
+                ?.let { it * 100.0 / totalDistance },
+            pricedChargeCount = chargeCosts.size,
+            chargeCount = charges.size,
+            costCoverage = costCoverage,
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/domain/TripsSummaryCalculator.kt
+++ b/app/src/main/java/com/matedroid/domain/TripsSummaryCalculator.kt
@@ -48,8 +48,10 @@ object TripsSummaryCalculator {
                 .takeIf { it > 0.0 }
                 ?.let { totalEnergyConsumed * 1000.0 / it },
             totalChargeCost = totalChargeCost,
+            // Cost / 100 distance is only honest when every charge in range is priced.
+            // Known totals still surface under Partial; the rate stays unavailable.
             costPer100Distance = totalChargeCost
-                ?.takeIf { totalDistance > 0.0 }
+                ?.takeIf { costCoverage == TripCostCoverage.Complete && totalDistance > 0.0 }
                 ?.let { it * 100.0 / totalDistance },
             pricedChargeCount = chargeCosts.size,
             chargeCount = charges.size,

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -442,31 +442,54 @@ private fun SummaryCard(
                     modifier = Modifier.weight(0.8f)
                 )
             }
-            if (summary.costCoverage == TripCostCoverage.Partial) {
-                Spacer(modifier = Modifier.height(10.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Info,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = palette.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
+            when (summary.costCoverage) {
+                TripCostCoverage.Partial -> {
+                    Spacer(modifier = Modifier.height(10.dp))
+                    CostCoverageNote(
                         text = stringResource(
                             R.string.trip_cost_coverage_partial,
                             summary.pricedChargeCount,
                             summary.chargeCount,
                         ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = palette.onSurfaceVariant,
+                        palette = palette,
                     )
                 }
+                TripCostCoverage.None -> {
+                    if (summary.chargeCount > 0) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        CostCoverageNote(
+                            text = stringResource(R.string.trip_cost_coverage_none),
+                            palette = palette,
+                        )
+                    }
+                }
+                TripCostCoverage.Complete -> Unit
             }
         }
+    }
+}
+
+@Composable
+private fun CostCoverageNote(
+    text: String,
+    palette: CarColorPalette,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Info,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = palette.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = palette.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsScreen.kt
@@ -25,17 +25,22 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.BatteryChargingFull
+import androidx.compose.material.icons.filled.EnergySavingsLeaf
 import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Paid
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Straighten
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -56,6 +61,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -66,6 +72,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.domain.isSignificant
+import com.matedroid.domain.TripCostCoverage
+import com.matedroid.domain.TripsSummaryMetrics
 import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.DateRangePickerDialog
@@ -204,9 +212,7 @@ fun TripsScreen(
                 Box(modifier = Modifier.padding(padding)) {
                     TripsContent(
                         trips = uiState.trips,
-                        totalDistance = uiState.totalDistance,
-                        totalDrivingMin = uiState.totalDrivingMin,
-                        totalEnergyCharged = uiState.totalEnergyCharged,
+                        summary = uiState.summary,
                         availableYears = uiState.availableYears,
                         selectedYear = uiState.selectedYear,
                         isCustomDateFilter = uiState.isCustomDateFilter,
@@ -215,6 +221,7 @@ fun TripsScreen(
                         onYearSelected = { viewModel.setYear(it) },
                         onCustomRangeSelected = { start, end -> viewModel.setCustomDateRange(start, end) },
                         units = uiState.units,
+                        currencySymbol = uiState.currencySymbol,
                         palette = palette,
                         dcChargeIds = uiState.dcChargeIds,
                         showShortDrivesCharges = uiState.showShortDrivesCharges,
@@ -232,9 +239,7 @@ fun TripsScreen(
 @Composable
 private fun TripsContent(
     trips: List<Trip>,
-    totalDistance: Double,
-    totalDrivingMin: Int,
-    totalEnergyCharged: Double,
+    summary: TripsSummaryMetrics,
     availableYears: List<Int>,
     selectedYear: Int?,
     isCustomDateFilter: Boolean,
@@ -243,6 +248,7 @@ private fun TripsContent(
     onYearSelected: (Int?) -> Unit,
     onCustomRangeSelected: (LocalDate, LocalDate) -> Unit,
     units: Units?,
+    currencySymbol: String,
     palette: CarColorPalette,
     dcChargeIds: Set<Int>,
     showShortDrivesCharges: Boolean,
@@ -278,11 +284,9 @@ private fun TripsContent(
         // Summary card
         item {
             SummaryCard(
-                tripCount = trips.size,
-                totalDistance = totalDistance,
-                totalDrivingMin = totalDrivingMin,
-                totalEnergyCharged = totalEnergyCharged,
+                summary = summary,
                 units = units,
+                currencySymbol = currencySymbol,
                 palette = palette
             )
         }
@@ -337,13 +341,22 @@ private fun TripsContent(
 
 @Composable
 private fun SummaryCard(
-    tripCount: Int,
-    totalDistance: Double,
-    totalDrivingMin: Int,
-    totalEnergyCharged: Double,
+    summary: TripsSummaryMetrics,
     units: Units?,
+    currencySymbol: String,
     palette: CarColorPalette
 ) {
+    val unavailable = "—"
+    val efficiency = summary.averageEfficiency?.let {
+        UnitFormatter.formatEfficiency(it, units, decimals = 0)
+    } ?: unavailable
+    val chargeCost = summary.totalChargeCost?.let {
+        UnitFormatter.formatCost(it, currencySymbol)
+    } ?: unavailable
+    val costPerDistance = summary.costPer100Distance?.let {
+        UnitFormatter.formatCost(it, currencySymbol)
+    } ?: unavailable
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = palette.surface)
@@ -360,14 +373,14 @@ private fun SummaryCard(
                 SummaryItem(
                     icon = Icons.Filled.Route,
                     label = stringResource(R.string.trips_title),
-                    value = "%,d".format(tripCount),
+                    value = "%,d".format(summary.tripCount),
                     palette = palette,
                     modifier = Modifier.weight(1.2f)
                 )
                 SummaryItem(
-                    icon = Icons.Filled.Speed,
+                    icon = Icons.Filled.Straighten,
                     label = stringResource(R.string.total_distance),
-                    value = UnitFormatter.formatDistance(totalDistance, units, decimals = 0),
+                    value = UnitFormatter.formatDistance(summary.totalDistance, units, decimals = 0),
                     palette = palette,
                     modifier = Modifier.weight(0.8f)
                 )
@@ -377,17 +390,81 @@ private fun SummaryCard(
                 SummaryItem(
                     icon = Icons.Filled.Schedule,
                     label = stringResource(R.string.trip_driving_time),
-                    value = formatDuration(LocalContext.current.resources, totalDrivingMin),
+                    value = formatDuration(
+                        LocalContext.current.resources,
+                        summary.totalDrivingMinutes,
+                    ),
                     palette = palette,
                     modifier = Modifier.weight(1.2f)
                 )
                 SummaryItem(
                     icon = Icons.Filled.ElectricBolt,
-                    label = stringResource(R.string.trip_energy_charged),
-                    value = "%,.0f kWh".format(totalEnergyCharged),
+                    label = stringResource(R.string.stats_energy_used),
+                    value = UnitFormatter.formatEnergy(summary.totalEnergyConsumed),
                     palette = palette,
                     modifier = Modifier.weight(0.8f)
                 )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                SummaryItem(
+                    icon = Icons.Filled.EnergySavingsLeaf,
+                    label = stringResource(R.string.stats_avg_efficiency),
+                    value = efficiency,
+                    palette = palette,
+                    modifier = Modifier.weight(1.2f)
+                )
+                SummaryItem(
+                    icon = Icons.Filled.BatteryChargingFull,
+                    label = stringResource(R.string.trip_energy_charged),
+                    value = UnitFormatter.formatEnergy(summary.totalEnergyCharged),
+                    palette = palette,
+                    modifier = Modifier.weight(0.8f)
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                SummaryItem(
+                    icon = Icons.Filled.Paid,
+                    label = stringResource(R.string.trip_charge_cost),
+                    value = chargeCost,
+                    palette = palette,
+                    modifier = Modifier.weight(1.2f)
+                )
+                SummaryItem(
+                    icon = Icons.Filled.AttachMoney,
+                    label = stringResource(
+                        R.string.trip_cost_per_100,
+                        UnitFormatter.getDistanceUnit(units),
+                    ),
+                    value = costPerDistance,
+                    palette = palette,
+                    modifier = Modifier.weight(0.8f)
+                )
+            }
+            if (summary.costCoverage == TripCostCoverage.Partial) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = palette.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.trip_cost_coverage_partial,
+                            summary.pricedChargeCount,
+                            summary.chargeCount,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = palette.onSurfaceVariant,
+                    )
+                }
             }
         }
     }
@@ -663,4 +740,3 @@ internal fun Trip.displayName(): String {
  *  1w–~1mo → "Xw Yd"
  *  ≥30d → "Xmo Yw"
  */
-

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripsViewModel.kt
@@ -5,10 +5,14 @@ import androidx.lifecycle.viewModelScope
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.dao.AggregateDao
+import com.matedroid.data.model.Currency
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.TripRepository
+import com.matedroid.domain.TripsSummaryCalculator
+import com.matedroid.domain.TripsSummaryMetrics
 import com.matedroid.domain.model.Trip
+import com.matedroid.util.parseIsoDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,22 +20,20 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import com.matedroid.util.parseIsoDate
 import java.time.LocalDate
 import javax.inject.Inject
 
 data class TripsUiState(
     val isLoading: Boolean = true,
     val trips: List<Trip> = emptyList(),
-    val totalDistance: Double = 0.0,
-    val totalDrivingMin: Int = 0,
-    val totalEnergyCharged: Double = 0.0,
+    val summary: TripsSummaryMetrics = TripsSummaryMetrics(),
     val availableYears: List<Int> = emptyList(),
     val selectedYear: Int? = null,
     val isCustomDateFilter: Boolean = false,
     val customStartDate: LocalDate? = null,
     val customEndDate: LocalDate? = null,
     val units: Units? = null,
+    val currencySymbol: String = Currency.DEFAULT.symbol,
     val dcChargeIds: Set<Int> = emptySet(),
     val showShortDrivesCharges: Boolean = false
 )
@@ -119,8 +121,14 @@ class TripsViewModel @Inject constructor(
     private fun loadTrips(carId: Int) {
         viewModelScope.launch {
             // Read on each load so toggling the setting is reflected when the screen reloads.
-            val showShort = settingsDataStore.showShortDrivesCharges.first()
-            _uiState.update { it.copy(showShortDrivesCharges = showShort) }
+            val settings = settingsDataStore.settings.first()
+            val currencySymbol = Currency.findByCode(settings.currencyCode).symbol
+            _uiState.update {
+                it.copy(
+                    showShortDrivesCharges = settings.showShortDrivesCharges,
+                    currencySymbol = currencySymbol,
+                )
+            }
 
             allTrips = tripRepository.getTrips(carId)
 
@@ -149,9 +157,7 @@ class TripsViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 trips = filtered,
-                totalDistance = filtered.sumOf { t -> t.totalDistance },
-                totalDrivingMin = filtered.sumOf { t -> t.totalDrivingDurationMin },
-                totalEnergyCharged = filtered.sumOf { t -> t.totalEnergyCharged }
+                summary = TripsSummaryCalculator.calculate(filtered),
             )
         }
     }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1100,6 +1100,7 @@
     <string name="trip_driving_time">Temps de conducció</string>
     <string name="trip_energy_charged">Energia carregada</string>
     <string name="trip_charge_cost">Cost de càrrega</string>
+    <string name="trip_cost_coverage_partial">Els costos inclouen %1$d de %2$d sessions de càrrega</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consum</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1101,6 +1101,8 @@
     <string name="trip_energy_charged">Energia carregada</string>
     <string name="trip_charge_cost">Cost de càrrega</string>
     <string name="trip_cost_coverage_partial">Els costos inclouen %1$d de %2$d sessions de càrrega</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">No hi ha costos de càrrega registrats per a aquests viatges</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consum</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1129,6 +1129,8 @@
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Ladekosten</string>
     <string name="trip_cost_coverage_partial">Kosten enthalten %1$d von %2$d Ladevorgängen</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">Für diese Fahrten sind keine Ladekosten erfasst</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Verbrauch</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1128,6 +1128,7 @@
     <string name="trip_energy_charged">Geladene Energie</string>
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Ladekosten</string>
+    <string name="trip_cost_coverage_partial">Kosten enthalten %1$d von %2$d Ladevorgängen</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Verbrauch</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1101,6 +1101,8 @@
     <string name="trip_energy_charged">Energía cargada</string>
     <string name="trip_charge_cost">Coste de carga</string>
     <string name="trip_cost_coverage_partial">Los costes incluyen %1$d de %2$d sesiones de carga</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">No hay costes de carga registrados para estos viajes</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumo</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1100,6 +1100,7 @@
     <string name="trip_driving_time">Tiempo de conducción</string>
     <string name="trip_energy_charged">Energía cargada</string>
     <string name="trip_charge_cost">Coste de carga</string>
+    <string name="trip_cost_coverage_partial">Los costes incluyen %1$d de %2$d sesiones de carga</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumo</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1101,6 +1101,8 @@
     <string name="trip_energy_charged">Energia ricaricata</string>
     <string name="trip_charge_cost">Costo ricarica</string>
     <string name="trip_cost_coverage_partial">I costi includono %1$d di %2$d sessioni di ricarica</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">Nessun costo di ricarica registrato per questi viaggi</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumo</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1100,6 +1100,7 @@
     <string name="trip_driving_time">Tempo di guida</string>
     <string name="trip_energy_charged">Energia ricaricata</string>
     <string name="trip_charge_cost">Costo ricarica</string>
+    <string name="trip_cost_coverage_partial">I costi includono %1$d di %2$d sessioni di ricarica</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumo</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1101,6 +1101,7 @@
     <string name="trip_driving_time">驾驶时间</string>
     <string name="trip_energy_charged">充入能量</string>
     <string name="trip_charge_cost">充电费用</string>
+    <string name="trip_cost_coverage_partial">费用包含 %1$d/%2$d 次充电记录</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">能耗</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1102,6 +1102,8 @@
     <string name="trip_energy_charged">充入能量</string>
     <string name="trip_charge_cost">充电费用</string>
     <string name="trip_cost_coverage_partial">费用包含 %1$d/%2$d 次充电记录</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">这些行程没有记录充电费用</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">能耗</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1133,6 +1133,8 @@
     <string name="trip_charge_cost">Charge cost</string>
     <!-- Shown when only some charging sessions in the selected trips have recorded costs -->
     <string name="trip_cost_coverage_partial">Costs include %1$d of %2$d charging sessions</string>
+    <!-- Shown when trips have charging sessions but none have a recorded cost -->
+    <string name="trip_cost_coverage_none">No charging costs recorded for these trips</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumption</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1131,6 +1131,8 @@
     <string name="trip_energy_charged">Energy charged</string>
     <!-- Charge cost label -->
     <string name="trip_charge_cost">Charge cost</string>
+    <!-- Shown when only some charging sessions in the selected trips have recorded costs -->
+    <string name="trip_cost_coverage_partial">Costs include %1$d of %2$d charging sessions</string>
     <!-- Average consumption tile label on trip detail (value shown in Wh/km or Wh/mi) -->
     <string name="consumption">Consumption</string>
     <!-- Cost-per-distance tile label on trip detail; %1$s is the distance unit (km or mi) -->

--- a/app/src/test/java/com/matedroid/domain/TripsSummaryCalculatorTest.kt
+++ b/app/src/test/java/com/matedroid/domain/TripsSummaryCalculatorTest.kt
@@ -1,0 +1,120 @@
+package com.matedroid.domain
+
+import com.matedroid.data.local.entity.ChargeSummary
+import com.matedroid.data.local.entity.DriveSummary
+import com.matedroid.domain.model.Trip
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TripsSummaryCalculatorTest {
+
+    @Test
+    fun `calculate aggregates trip energy efficiency and complete costs`() {
+        val summary = TripsSummaryCalculator.calculate(
+            listOf(
+                trip(id = 1, distance = 300.0, energyConsumed = 45.0, chargeCosts = listOf(12.0)),
+                trip(id = 2, distance = 200.0, energyConsumed = 35.0, chargeCosts = listOf(8.0)),
+            )
+        )
+
+        assertEquals(2, summary.tripCount)
+        assertEquals(500.0, summary.totalDistance, 0.001)
+        assertEquals(480, summary.totalDrivingMinutes)
+        assertEquals(80.0, summary.totalEnergyConsumed, 0.001)
+        assertEquals(60.0, summary.totalEnergyCharged, 0.001)
+        assertEquals(160.0, summary.averageEfficiency ?: 0.0, 0.001)
+        assertEquals(20.0, summary.totalChargeCost ?: 0.0, 0.001)
+        assertEquals(4.0, summary.costPer100Distance ?: 0.0, 0.001)
+        assertEquals(2, summary.pricedChargeCount)
+        assertEquals(2, summary.chargeCount)
+        assertEquals(TripCostCoverage.Complete, summary.costCoverage)
+    }
+
+    @Test
+    fun `calculate exposes partial cost coverage without discarding known costs`() {
+        val summary = TripsSummaryCalculator.calculate(
+            listOf(
+                trip(
+                    id = 1,
+                    distance = 400.0,
+                    energyConsumed = 64.0,
+                    chargeCosts = listOf(10.0, null),
+                )
+            )
+        )
+
+        assertEquals(10.0, summary.totalChargeCost ?: 0.0, 0.001)
+        assertEquals(2.5, summary.costPer100Distance ?: 0.0, 0.001)
+        assertEquals(1, summary.pricedChargeCount)
+        assertEquals(2, summary.chargeCount)
+        assertEquals(TripCostCoverage.Partial, summary.costCoverage)
+    }
+
+    @Test
+    fun `calculate leaves costs unavailable when no charge has a price`() {
+        val summary = TripsSummaryCalculator.calculate(
+            listOf(
+                trip(id = 1, distance = 300.0, energyConsumed = 45.0, chargeCosts = listOf(null))
+            )
+        )
+
+        assertNull(summary.totalChargeCost)
+        assertNull(summary.costPer100Distance)
+        assertEquals(TripCostCoverage.None, summary.costCoverage)
+    }
+
+    @Test
+    fun `calculate returns empty metrics for an empty range`() {
+        assertEquals(TripsSummaryMetrics(), TripsSummaryCalculator.calculate(emptyList()))
+    }
+
+    private fun trip(
+        id: Int,
+        distance: Double,
+        energyConsumed: Double,
+        chargeCosts: List<Double?>,
+    ): Trip {
+        val drive = DriveSummary(
+            driveId = id,
+            carId = 1,
+            startDate = "2026-07-0${id}T08:00:00",
+            endDate = "2026-07-0${id}T12:00:00",
+            durationMin = 240,
+            startAddress = "Start",
+            endAddress = "End",
+            distance = distance,
+            speedMax = 120,
+            speedAvg = 80,
+            powerMax = 150,
+            powerMin = -50,
+            startBatteryLevel = 90,
+            endBatteryLevel = 20,
+            outsideTempAvg = 20.0,
+            insideTempAvg = 21.0,
+            energyConsumed = energyConsumed,
+            efficiency = energyConsumed * 1000.0 / distance,
+        )
+        val charges = chargeCosts.mapIndexed { index, cost ->
+            ChargeSummary(
+                chargeId = id * 10 + index,
+                carId = 1,
+                startDate = "2026-07-0${id}T12:10:00",
+                endDate = "2026-07-0${id}T12:40:00",
+                durationMin = 30,
+                address = "Charger",
+                latitude = 0.0,
+                longitude = 0.0,
+                energyAdded = 30.0,
+                energyUsed = null,
+                cost = cost,
+                startBatteryLevel = 20,
+                endBatteryLevel = 70,
+                outsideTempAvg = 20.0,
+                odometer = 10_000.0,
+            )
+        }
+
+        return TripAggregator.buildTrip(listOf(drive), charges)!!
+    }
+}

--- a/app/src/test/java/com/matedroid/domain/TripsSummaryCalculatorTest.kt
+++ b/app/src/test/java/com/matedroid/domain/TripsSummaryCalculatorTest.kt
@@ -32,7 +32,7 @@ class TripsSummaryCalculatorTest {
     }
 
     @Test
-    fun `calculate exposes partial cost coverage without discarding known costs`() {
+    fun `calculate exposes partial cost coverage without inventing a complete rate`() {
         val summary = TripsSummaryCalculator.calculate(
             listOf(
                 trip(
@@ -45,7 +45,7 @@ class TripsSummaryCalculatorTest {
         )
 
         assertEquals(10.0, summary.totalChargeCost ?: 0.0, 0.001)
-        assertEquals(2.5, summary.costPer100Distance ?: 0.0, 0.001)
+        assertNull(summary.costPer100Distance)
         assertEquals(1, summary.pricedChargeCount)
         assertEquals(2, summary.chargeCount)
         assertEquals(TripCostCoverage.Partial, summary.costCoverage)
@@ -62,6 +62,21 @@ class TripsSummaryCalculatorTest {
         assertNull(summary.totalChargeCost)
         assertNull(summary.costPer100Distance)
         assertEquals(TripCostCoverage.None, summary.costCoverage)
+    }
+
+    @Test
+    fun `calculate treats zero-cost charges as priced and complete`() {
+        val summary = TripsSummaryCalculator.calculate(
+            listOf(
+                trip(id = 1, distance = 200.0, energyConsumed = 30.0, chargeCosts = listOf(0.0))
+            )
+        )
+
+        assertEquals(0.0, summary.totalChargeCost ?: -1.0, 0.001)
+        assertEquals(0.0, summary.costPer100Distance ?: -1.0, 0.001)
+        assertEquals(1, summary.pricedChargeCount)
+        assertEquals(1, summary.chargeCount)
+        assertEquals(TripCostCoverage.Complete, summary.costCoverage)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- expand the Trips summary card with energy used, average efficiency, energy charged, charging cost, and cost per 100 distance units
- calculate filtered-range totals in a small pure `TripsSummaryCalculator`
- keep known charging costs visible while clearly labeling partial cost coverage
- use the configured currency and existing metric/imperial unit labels
- localize the partial-cost note in all supported languages

This is fully read-only. It uses trip data already loaded by the app and adds no vehicle commands, polling, API calls, or persistence changes.

## Verification

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`
- `./gradlew :app:assembleDebug`

All pass locally.