### PR TITLE
Fix unit-system bugs for imperial users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.
+- **Drive comparison curves are correct again for miles/imperial users** — the compare-drives overlay was applying a km→miles conversion to speeds the API had already converted (curves plotted ~40% low), and its energy estimate mixed km distances with mph speeds, skewing the consumption ranking.
+- **Distances in the trip editing sheets now respect the unit setting** — the add-leg, create-trip and merge-trip sheets showed a hardcoded "km" label on values that are miles for imperial users.
+- **"Where was I" shows the temperature in °F for imperial users** instead of always °C.
+- **Charge charts now classify AC vs DC the same way as the list** — recent DC charges whose details hadn't synced yet were counted in the AC segment of the energy/cost/count charts while showing a DC badge in the list.
+- **Trip detection and the short-drive filter now behave the same for miles/imperial users** — the "at least 300 km" road-trip rule and the "under 1 km" short-drive rule were being read as 300 mi / 1 mi; the thresholds are now scaled to the unit system.
 
 ## [1.10.0] - 2026-07-01
 

--- a/app/src/main/java/com/matedroid/MateDroidApp.kt
+++ b/app/src/main/java/com/matedroid/MateDroidApp.kt
@@ -13,12 +13,19 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
+import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.sync.ChargingNotificationWorker
 import com.matedroid.data.sync.DataSyncWorker
 import com.matedroid.data.sync.TpmsPressureWorker
+import com.matedroid.domain.UnitSystem
 import com.matedroid.notification.SentryNotificationManager
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 @HiltAndroidApp
 class MateDroidApp : Application(), Configuration.Provider {
@@ -29,6 +36,11 @@ class MateDroidApp : Application(), Configuration.Provider {
     @Inject
     lateinit var sentryNotificationManager: SentryNotificationManager
 
+    @Inject
+    lateinit var settingsDataStore: SettingsDataStore
+
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -37,6 +49,11 @@ class MateDroidApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Restore the last known unit system before any trip detection / filtering runs.
+        appScope.launch {
+            UnitSystem.isImperial = settingsDataStore.isImperial.first()
+        }
 
         // Configure OSMDroid tile cache (shared across all map screens)
         org.osmdroid.config.Configuration.getInstance().apply {

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -79,6 +79,18 @@ class SettingsDataStore @Inject constructor(
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
     private val notificationPermissionAskedKey = booleanPreferencesKey("notification_permission_asked")
+    private val isImperialKey = booleanPreferencesKey("is_imperial")
+
+    /** Last known TeslamateAPI unit system; used to restore [com.matedroid.domain.UnitSystem] at app start. */
+    val isImperial: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[isImperialKey] ?: false
+    }
+
+    suspend fun saveIsImperial(value: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[isImperialKey] = value
+        }
+    }
 
     val notificationPermissionAsked: Flow<Boolean> = context.dataStore.data.map { preferences ->
         preferences[notificationPermissionAskedKey] ?: false

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -15,6 +15,7 @@ import com.matedroid.data.api.models.UpdateData
 import com.matedroid.data.local.AppSettings
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.di.TeslamateApiFactory
+import com.matedroid.domain.UnitSystem
 import kotlinx.coroutines.flow.first
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
@@ -241,12 +242,29 @@ class TeslamateRepository @Inject constructor(
     suspend fun getCar(carId: Int): ApiResult<CarData> =
         executeWithFallback { api -> api.getCar(carId).toResult("car") { it?.data?.cars?.firstOrNull() } }
 
-    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> =
-        executeWithFallback { api ->
+    suspend fun getCarStatus(carId: Int): ApiResult<CarStatusWithUnits> {
+        val result = executeWithFallback { api ->
             api.getCarStatus(carId).toResult("status") { body ->
                 body?.data?.let { data -> data.status?.let { CarStatusWithUnits(it, data.units ?: Units()) } }
             }
         }
+        if (result is ApiResult.Success) {
+            updateUnitSystem(result.data.units.isImperial)
+        }
+        return result
+    }
+
+    // Tracks what we last persisted so the DataStore write happens at most once per change.
+    private var lastPersistedImperial: Boolean? = null
+
+    /** Keep [UnitSystem] (and its persisted copy) in sync with the server's unit setting. */
+    private suspend fun updateUnitSystem(imperial: Boolean) {
+        UnitSystem.isImperial = imperial
+        if (lastPersistedImperial != imperial) {
+            lastPersistedImperial = imperial
+            settingsDataStore.saveIsImperial(imperial)
+        }
+    }
 
     suspend fun getCharges(
         carId: Int,

--- a/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
+++ b/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
@@ -24,16 +24,19 @@ object ShortEntryFilter {
     /** A drive shorter than this many minutes is "short". */
     const val MIN_DRIVE_DURATION_MIN = 1
 
-    /** A drive shorter than this many km is "short". */
+    /**
+     * A drive shorter than this many km is "short". API distances arrive pre-converted
+     * (km or mi), so the comparison scales this through [UnitSystem.thresholdKmToUserUnits].
+     */
     const val MIN_DRIVE_DISTANCE_KM = 1.0
 
     /** A charge that added this much energy (kWh) or less is "short". */
     const val MIN_CHARGE_ENERGY_KWH = 0.1
 
     /** True when a drive is significant enough to show in lists. */
-    fun isSignificantDrive(durationMin: Int?, distanceKm: Double?): Boolean =
+    fun isSignificantDrive(durationMin: Int?, distance: Double?): Boolean =
         (durationMin ?: 0) >= MIN_DRIVE_DURATION_MIN &&
-            (distanceKm ?: 0.0) >= MIN_DRIVE_DISTANCE_KM
+            (distance ?: 0.0) >= UnitSystem.thresholdKmToUserUnits(MIN_DRIVE_DISTANCE_KM)
 
     /** True when a charge is significant enough to show in lists. */
     fun isSignificantCharge(energyKwh: Double?): Boolean =

--- a/app/src/main/java/com/matedroid/domain/TripDetector.kt
+++ b/app/src/main/java/com/matedroid/domain/TripDetector.kt
@@ -28,6 +28,8 @@ import javax.inject.Singleton
 class TripDetector @Inject constructor() {
 
     companion object {
+        // Physical thresholds defined in km; API distances arrive pre-converted (km or mi),
+        // so comparisons scale these through UnitSystem.thresholdKmToUserUnits.
         private const val MICRO_DRIVE_THRESHOLD_KM = 1.0
         private const val MIN_TRIP_DISTANCE_KM = 300.0
         private const val MAX_DRIVE_TO_CHARGE_GAP_MIN = 15L
@@ -44,7 +46,7 @@ class TripDetector @Inject constructor() {
         drives: List<DriveSummary>,
         dcCharges: List<ChargeSummary>
     ): List<Trip> {
-        val realDrives = drives.filter { it.distance >= MICRO_DRIVE_THRESHOLD_KM }
+        val realDrives = drives.filter { it.distance >= UnitSystem.thresholdKmToUserUnits(MICRO_DRIVE_THRESHOLD_KM) }
 
         val events = mutableListOf<Event>()
         realDrives.forEach { events.add(Event.Drive(it)) }
@@ -122,7 +124,7 @@ class TripDetector @Inject constructor() {
     ) {
         if (drives.size < 2 || charges.isEmpty()) return
         val totalDistance = drives.sumOf { it.distance }
-        if (totalDistance < MIN_TRIP_DISTANCE_KM) return
+        if (totalDistance < UnitSystem.thresholdKmToUserUnits(MIN_TRIP_DISTANCE_KM)) return
         TripAggregator.buildTrip(drives, charges)?.let { trips.add(it) }
     }
 

--- a/app/src/main/java/com/matedroid/domain/UnitSystem.kt
+++ b/app/src/main/java/com/matedroid/domain/UnitSystem.kt
@@ -1,0 +1,24 @@
+package com.matedroid.domain
+
+/**
+ * Process-wide mirror of TeslamateAPI's unit-system setting.
+ *
+ * TeslamateAPI pre-converts every value to the user's preferred unit system, so distances
+ * stored in Room are already km OR mi. Our own physical threshold constants (defined in km,
+ * e.g. "hide drives under 1 km", "a trip is at least 300 km") must therefore be scaled into
+ * the user's unit before comparing — otherwise imperial users get 1 mi / 300 mi thresholds.
+ *
+ * The flag is restored from preferences at app start ([com.matedroid.MateDroidApp]) and kept
+ * fresh by [com.matedroid.data.repository.TeslamateRepository] whenever a car status arrives.
+ *
+ * This is ONLY for scaling our own constants — never use it to convert API values.
+ */
+object UnitSystem {
+    private const val KM_TO_MI = 0.621371
+
+    @Volatile
+    var isImperial: Boolean = false
+
+    /** Scale a threshold defined in km into the user's distance unit. */
+    fun thresholdKmToUserUnits(km: Double): Double = if (isImperial) km * KM_TO_MI else km
+}

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -418,7 +418,7 @@ class ChargesViewModel @Inject constructor(
 
         // Calculate summary and chart data from filtered charges
         val summary = calculateSummary(chargesForStatsFiltered)
-        val chartData = calculateChartData(chargesForStatsFiltered, granularity, state.startDate)
+        val chartData = calculateChartData(chargesForStatsFiltered, granularity, state.startDate, ::isDc)
 
         _uiState.update {
             it.copy(
@@ -443,7 +443,12 @@ class ChargesViewModel @Inject constructor(
         }
     }
 
-    private fun calculateChartData(charges: List<ChargeData>, granularity: ChartGranularity, startDate: LocalDate?): List<ChargeChartData> =
+    private fun calculateChartData(
+        charges: List<ChargeData>,
+        granularity: ChartGranularity,
+        startDate: LocalDate?,
+        isDc: (ChargeData) -> Boolean
+    ): List<ChargeChartData> =
         buildTimeSeries(
             items = charges,
             granularity = granularity,
@@ -455,18 +460,19 @@ class ChargesViewModel @Inject constructor(
                 label = label,
                 sortKey = sortKey,
                 charges = bucket,
-                dcChargeIds = _uiState.value.dcChargeIds
+                isDc = isDc
             )
         }
 
-    // Helper function to centralize chart data creation
+    // Helper function to centralize chart data creation.
+    // Uses the same AC/DC classifier as the list badges so charts and list agree.
     private fun createChargeChartPoint(
         label: String,
         sortKey: Long,
         charges: List<ChargeData>,
-        dcChargeIds: Set<Int>
+        isDc: (ChargeData) -> Boolean
     ): ChargeChartData {
-        val dcCharges = charges.filter { it.chargeId in dcChargeIds }
+        val dcCharges = charges.filter(isDc)
         val energyDc = dcCharges.sumOf { it.chargeEnergyAdded ?: 0.0 }
         val energyTotal = charges.sumOf { it.chargeEnergyAdded ?: 0.0 }
         val costDc = dcCharges.sumOf { it.cost ?: 0.0 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveComparisonViewModel.kt
@@ -187,17 +187,19 @@ class DriveComparisonViewModel @Inject constructor(
                 val pLat = prevLat
                 val pLon = prevLon
                 if (pLat != null && pLon != null) {
-                    val segKm = haversineMeters(pLat, pLon, lat, lon) / 1000.0
-                    cumDistanceDisplay += (segKm * toDisplay).toFloat()
+                    // Haversine over raw GPS is always km; convert the segment to the display unit
+                    // so it matches the API speed, which arrives pre-converted (km/h or mph).
+                    val segDisplay = haversineMeters(pLat, pLon, lat, lon) / 1000.0 * toDisplay
+                    cumDistanceDisplay += segDisplay.toFloat()
                     val power = position.power
                     if (speed != null && speed > 0 && power != null) {
-                        cumEnergyKwh += power.toDouble() * (segKm / speed.toDouble()) // kW × h
+                        cumEnergyKwh += power.toDouble() * (segDisplay / speed.toDouble()) // kW × h
                     }
                 }
                 prevLat = lat
                 prevLon = lon
                 if (speed != null) {
-                    samples.add(DriveCurveSample(cumDistanceDisplay, speed.toFloat() * toDisplay, cumEnergyKwh.toFloat()))
+                    samples.add(DriveCurveSample(cumDistanceDisplay, speed.toFloat(), cumEnergyKwh.toFloat()))
                 }
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -45,11 +45,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.matedroid.R
+import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveSummary
 import com.matedroid.data.local.entity.SavedTripLeg
 import com.matedroid.domain.EligibleLegs
 import com.matedroid.domain.LegRef
+import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.util.formatDuration
@@ -63,6 +65,7 @@ import java.util.Locale
 fun AddLegSheet(
     eligible: EligibleLegs,
     dcChargeIds: Set<Int>,
+    units: Units?,
     palette: CarColorPalette,
     onPickLegs: (List<LegRef>) -> Unit,
     onDismiss: () -> Unit,
@@ -124,6 +127,7 @@ fun AddLegSheet(
                         val ref = candidate.toRef()
                         CandidateRow(
                             candidate = candidate,
+                            units = units,
                             palette = palette,
                             isDc = candidate is Candidate.Charge && candidate.charge.chargeId in dcChargeIds,
                             multiMode = multiMode,
@@ -217,6 +221,7 @@ private fun buildCandidateList(eligible: EligibleLegs): List<Candidate> {
 @Composable
 private fun CandidateRow(
     candidate: Candidate,
+    units: Units?,
     palette: CarColorPalette,
     isDc: Boolean,
     multiMode: Boolean,
@@ -274,7 +279,7 @@ private fun CandidateRow(
                 }
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
-                        text = "%.1f km".format(candidate.drive.distance),
+                        text = "%.1f %s".format(candidate.drive.distance, UnitFormatter.getDistanceUnit(units)),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Bold
                     )

--- a/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/CreateTripScreen.kt
@@ -138,6 +138,7 @@ fun CreateTripScreen(
                     drives = uiState.drives,
                     charges = uiState.charges,
                     dcChargeIds = uiState.dcChargeIds,
+                    units = uiState.units,
                     palette = palette,
                     onRemove = viewModel::removeLeg
                 )
@@ -166,6 +167,7 @@ fun CreateTripScreen(
         AddLegSheet(
             eligible = uiState.eligibleLegs!!,
             dcChargeIds = uiState.dcChargeIds,
+            units = uiState.units,
             palette = palette,
             startInMultiSelect = true,
             onPickLegs = viewModel::pickLegs,
@@ -262,6 +264,7 @@ private fun LegList(
     drives: List<DriveSummary>,
     charges: List<ChargeSummary>,
     dcChargeIds: Set<Int>,
+    units: com.matedroid.data.api.models.Units?,
     palette: CarColorPalette,
     onRemove: (LegRef) -> Unit
 ) {
@@ -299,8 +302,9 @@ private fun LegList(
                                 overflow = TextOverflow.Ellipsis
                             )
                             Text(
-                                text = "%.1f km · %s".format(
+                                text = "%.1f %s · %s".format(
                                     d.distance,
+                                    UnitFormatter.getDistanceUnit(units),
                                     formatDuration(context.resources, d.durationMin)
                                 ),
                                 style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -33,7 +33,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.matedroid.R
+import com.matedroid.data.api.models.Units
 import com.matedroid.domain.model.Trip
+import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.util.formatMediumNoYear
 import com.matedroid.util.parseIsoDateTime
@@ -43,6 +45,7 @@ import java.util.Locale
 @Composable
 fun MergeTripSheet(
     adjacentTrips: List<Pair<Long, Trip>>,
+    units: Units?,
     palette: CarColorPalette,
     onPick: (tripId: Long, trip: Trip) -> Unit,
     onDismiss: () -> Unit
@@ -85,6 +88,7 @@ fun MergeTripSheet(
                     items(adjacentTrips) { (id, trip) ->
                         AdjacentTripRow(
                             trip = trip,
+                            units = units,
                             palette = palette,
                             onClick = { onPick(id, trip) }
                         )
@@ -98,6 +102,7 @@ fun MergeTripSheet(
 @Composable
 private fun AdjacentTripRow(
     trip: Trip,
+    units: Units?,
     palette: CarColorPalette,
     onClick: () -> Unit
 ) {
@@ -133,7 +138,7 @@ private fun AdjacentTripRow(
         }
         Column(horizontalAlignment = Alignment.End) {
             Text(
-                text = "%.0f km".format(trip.totalDistance),
+                text = "%.0f %s".format(trip.totalDistance, UnitFormatter.getDistanceUnit(units)),
                 style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.Bold
             )

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -258,6 +258,7 @@ fun TripDetailScreen(
         AddLegSheet(
             eligible = uiState.eligibleLegs!!,
             dcChargeIds = uiState.dcChargeIds,
+            units = uiState.units,
             palette = palette,
             onPickLegs = viewModel::pickLegs,
             onDismiss = viewModel::closeAddLegSheet
@@ -266,6 +267,7 @@ fun TripDetailScreen(
     if (uiState.showMergeSheet) {
         MergeTripSheet(
             adjacentTrips = uiState.adjacentTrips,
+            units = uiState.units,
             palette = palette,
             onPick = viewModel::pickMergeTarget,
             onDismiss = viewModel::closeMergeSheet

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -493,8 +493,15 @@ fun WhereWasIScreen(
                                     tint = weatherIconColor(state.weatherCondition!!)
                                 )
                                 Spacer(modifier = Modifier.width(12.dp))
+                                // Open-meteo always returns \u00B0C (external data, not TeslamateAPI),
+                                // so converting for \u00B0F users is legitimate here.
+                                val displayTemp = if (state.units?.unitOfTemperature == "F") {
+                                    state.weatherTemperature!! * 1.8 + 32
+                                } else {
+                                    state.weatherTemperature!!
+                                }
                                 Text(
-                                    text = "%.1f\u00B0C".format(state.weatherTemperature),
+                                    text = UnitFormatter.formatTemperature(displayTemp, state.units, decimals = 1),
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Bold,
                                     color = palette.onSurface


### PR DESCRIPTION
Fixes from the full-repo code review — the unit-correctness cluster.

- **Drive comparison curves**: speed was multiplied by 0.621371 even though the API pre-converts to the user's unit, plotting imperial curves ~40% low; the energy integral also divided km distances by mph speeds, corrupting the consumption ranking. Both now use the display-unit segment distance.
- **Trip editing sheets** (add leg / create trip / merge trip) hardcoded a "km" label on distances that are miles for imperial users; they now use `UnitFormatter.getDistanceUnit`.
- **Where was I** printed the open-meteo temperature as °C for everyone; it now converts (external data, not TeslamateAPI) and labels per the unit setting.
- **Charge charts** classified DC by synced-detail IDs only, while the list also uses the average-power heuristic from #313 — recent DC charges counted as AC in the charts. Both now share the same classifier.
- **Trip detection & short-drive thresholds**: `MIN_TRIP_DISTANCE_KM = 300` etc. compared against pre-converted distances, effectively 300 mi / 1 mi for imperial users. A new `UnitSystem` holder (persisted, refreshed from every car-status response) scales our own km-defined constants — it is never used to convert API values.

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)