### PR TITLE
Fix charging service, worker and data-layer bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"Where was I" shows the temperature in °F for imperial users** instead of always °C.
 - **Charge charts now classify AC vs DC the same way as the list** — recent DC charges whose details hadn't synced yet were counted in the AC segment of the energy/cost/count charts while showing a DC badge in the list.
 - **Trip detection and the short-drive filter now behave the same for miles/imperial users** — the "at least 300 km" road-trip rule and the "under 1 km" short-drive rule were being read as 300 mi / 1 mi; the thresholds are now scaled to the unit system.
+- **With two cars, the charging notification no longer flickers** — the background check stopped the shared monitor whenever *any* car was idle, so the other car's charging notification was killed and recreated every 30 seconds.
+- **Editing trips (merge, add or remove legs) is now crash-safe** — the database writes happen atomically, so an interruption mid-edit can no longer leave a merged trip coexisting with its originals.
+- **A brief network hiccup no longer disables the live charging view for the rest of the session** — only a definitive "endpoint not available" answer from the server is remembered; transient errors are retried.
+- **Configuring both HTTP basic auth and an API token no longer sends two Authorization headers** (which some reverse proxies reject) — the API token takes precedence.
+- **A missed database migration can no longer silently wipe synced data in release builds** — that recovery path is now debug-only.
+- **The widget no longer keeps a stale colour or car model** if the server stops reporting a field.
 
 ## [1.10.0] - 2026-07-01
 

--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -87,9 +87,10 @@ class TeslamateRepository @Inject constructor(
 
     /**
      * Check whether the current charge endpoint is available for the given car.
-     * Makes a dedicated HTTP call and checks only the status code: 200 means the endpoint exists,
-     * anything else (e.g. 404 on old TM versions) means it doesn't.
-     * Result is cached for the app session since the API version doesn't change at runtime.
+     * Makes a dedicated HTTP call and checks only the status code: 200 means the endpoint
+     * exists, 404 means an old TM version without it. Only those two definitive answers are
+     * cached for the app session — a transient failure (timeout, DNS, 5xx) must not disable
+     * the live-charge UI until process death, so it leaves the cache unset and is retried.
      */
     suspend fun isCurrentChargeAvailable(carId: Int): Boolean {
         currentChargeApiAvailable[carId]?.let { return it }
@@ -98,9 +99,17 @@ class TeslamateRepository @Inject constructor(
             if (response.code() == 200) ApiResult.Success(true)
             else ApiResult.Error("Not available", response.code())
         }
-        val available = result is ApiResult.Success
-        currentChargeApiAvailable[carId] = available
-        return available
+        return when {
+            result is ApiResult.Success -> {
+                currentChargeApiAvailable[carId] = true
+                true
+            }
+            result is ApiResult.Error && result.code == 404 -> {
+                currentChargeApiAvailable[carId] = false
+                false
+            }
+            else -> false // transient — don't cache, probe again next time
+        }
     }
 
     private suspend fun getSettings(): AppSettings = settingsDataStore.settings.first()

--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -15,6 +15,7 @@ import androidx.work.WorkerParameters
 import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.api.models.CarData
+import com.matedroid.data.api.models.CarStatus
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.SentryEvent
 import com.matedroid.data.repository.SentryStateRepository
@@ -154,13 +155,48 @@ class ChargingNotificationWorker @AssistedInject constructor(
 
             Log.d(TAG, "Checking status for ${cars.size} cars")
 
-            // Check each car
+            // Check each car, collecting which ones need the shared monitor service.
+            // The start/stop decision must aggregate across ALL cars: stopping inside the
+            // per-car loop made any idle car kill the service (and every charging
+            // notification with it) 30 s after another car's iteration started it.
+            val needMonitor = mutableListOf<Pair<CarData, CarStatus>>()
+            var anyCheckFailed = false
             for (car in cars) {
-                try {
+                val outcome = try {
                     checkCarStatus(car)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error checking car ${car.carId}", e)
+                    CheckOutcome.Failed
                 }
+                when (outcome) {
+                    is CheckOutcome.NeedsMonitor -> needMonitor.add(car to outcome.status)
+                    CheckOutcome.Failed -> anyCheckFailed = true
+                    CheckOutcome.Idle -> { /* nothing to do */ }
+                }
+            }
+
+            if (needMonitor.isNotEmpty()) {
+                try {
+                    ChargingMonitorService.start(appContext)
+                } catch (e: Exception) {
+                    // On Android 12+, can't start foreground service from background.
+                    // Fall back to showing notifications directly (won't update in real-time).
+                    Log.w(TAG, "Cannot start foreground service, showing notifications directly: ${e.message}")
+                    for ((car, status) in needMonitor) {
+                        if (status.isCharging) {
+                            val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(car.carId)
+                            chargingNotificationManager.showChargingNotification(
+                                car, status, liveChargeAvailable,
+                                chronometerBaseMs = status.stateSinceEpochMs
+                            )
+                        }
+                    }
+                }
+            } else if (!anyCheckFailed) {
+                // Only stop when we positively know no car is charging — a failed check
+                // (transient network error) shouldn't tear down an active monitor.
+                Log.d(TAG, "No car needs monitoring, stopping monitor service")
+                ChargingMonitorService.stop(appContext)
             }
 
             Log.d(TAG, "Check complete")
@@ -174,7 +210,22 @@ class ChargingNotificationWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun checkCarStatus(car: CarData) {
+    /** Result of a per-car check; the caller aggregates these into one service start/stop decision. */
+    private sealed interface CheckOutcome {
+        /** Car is charging (or DC-finished-but-plugged) — the monitor service must run. */
+        data class NeedsMonitor(val status: CarStatus) : CheckOutcome
+        /** Car positively does not need monitoring. */
+        data object Idle : CheckOutcome
+        /** Status unknown (fetch failed) — must not count as idle. */
+        data object Failed : CheckOutcome
+    }
+
+    /**
+     * Per-car check: persists the DC-session flag, handles sentry events, and cancels the
+     * charging notification for idle cars. Starting or stopping the shared monitor service
+     * is the caller's job — it must aggregate across all cars.
+     */
+    private suspend fun checkCarStatus(car: CarData): CheckOutcome {
         // The car object is already in hand from doWork()'s getCars() — no refetch.
         val carId = car.carId
 
@@ -183,7 +234,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
             is ApiResult.Success -> statusResult.data
             is ApiResult.Error -> {
                 Log.e(TAG, "Failed to fetch status for car $carId: ${statusResult.message}")
-                return
+                return CheckOutcome.Failed
             }
         }
 
@@ -201,32 +252,17 @@ class ChargingNotificationWorker @AssistedInject constructor(
             chargeSessionStateDataStore.wasLastSessionDc(carId)
 
         // --- Charging ---
-        if (status.isCharging) {
+        val chargingOutcome = if (status.isCharging) {
             Log.d(TAG, "Car $carId is charging at ${status.batteryLevel}%")
-            try {
-                ChargingMonitorService.start(appContext)
-            } catch (e: Exception) {
-                // On Android 12+, can't start foreground service from background
-                // Fall back to showing notification directly (won't update in real-time)
-                Log.w(TAG, "Cannot start foreground service, showing notification directly: ${e.message}")
-                val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(carId)
-                chargingNotificationManager.showChargingNotification(
-                    car, status, liveChargeAvailable,
-                    chronometerBaseMs = status.stateSinceEpochMs
-                )
-            }
+            CheckOutcome.NeedsMonitor(status)
         } else if (dcFinishedPluggedIn) {
             // DC charge finished but cable still plugged — keep service alive
             Log.d(TAG, "Car $carId DC charge finished but still plugged in")
-            try {
-                ChargingMonitorService.start(appContext)
-            } catch (e: Exception) {
-                Log.w(TAG, "Cannot start foreground service for DC-finished state: ${e.message}")
-            }
+            CheckOutcome.NeedsMonitor(status)
         } else {
-            Log.d(TAG, "Car $carId is not charging, stopping monitor service")
-            ChargingMonitorService.stop(appContext)
+            Log.d(TAG, "Car $carId is not charging")
             chargingNotificationManager.cancelNotification(carId)
+            CheckOutcome.Idle
         }
 
         // --- Sentry ---
@@ -250,6 +286,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
             }
             null -> { /* no event */ }
         }
+
+        return chargingOutcome
     }
 
     /**

--- a/app/src/main/java/com/matedroid/di/DatabaseModule.kt
+++ b/app/src/main/java/com/matedroid/di/DatabaseModule.kt
@@ -2,6 +2,7 @@ package com.matedroid.di
 
 import android.content.Context
 import androidx.room.Room
+import com.matedroid.BuildConfig
 import com.matedroid.data.local.StatsDatabase
 import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.local.dao.ChargeSummaryDao
@@ -36,7 +37,14 @@ object DatabaseModule {
             StatsDatabase.DATABASE_NAME
         )
             .addMigrations(*StatsDatabase.ALL_MIGRATIONS)
-            .fallbackToDestructiveMigration(dropAllTables = false)  // Fallback for development
+            .apply {
+                // Debug convenience only. In release a missed migration must crash loudly
+                // instead of silently wiping all synced data (including the geocode cache,
+                // which takes hours to rebuild at Nominatim's 1 req/s).
+                if (BuildConfig.DEBUG) {
+                    fallbackToDestructiveMigration(dropAllTables = false)
+                }
+            }
             .build()
     }
 

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -173,12 +173,15 @@ class TeslamateApiFactory(
             .addInterceptor { chain ->
                 val requestBuilder = chain.request().newBuilder()
                     .header("User-Agent", "MateDroid/${BuildConfig.VERSION_NAME}")
-                if (basicAuthUsername.isNotBlank() && basicAuthPassword.isNotBlank()) {
-                    requestBuilder.addHeader("Authorization",
-                        okhttp3.Credentials.basic(basicAuthUsername, basicAuthPassword))
-                }
+                // A request must carry a single Authorization header — addHeader() appends,
+                // and duplicate Authorization headers get rejected/mishandled by many
+                // proxies and servers. When both credentials are configured the API token
+                // wins, as it's the credential TeslamateApi itself validates.
                 if (apiToken.isNotBlank()) {
-                    requestBuilder.addHeader("Authorization", "Bearer $apiToken")
+                    requestBuilder.header("Authorization", "Bearer $apiToken")
+                } else if (basicAuthUsername.isNotBlank() && basicAuthPassword.isNotBlank()) {
+                    requestBuilder.header("Authorization",
+                        okhttp3.Credentials.basic(basicAuthUsername, basicAuthPassword))
                 }
                 chain.proceed(requestBuilder.build())
             }

--- a/app/src/main/java/com/matedroid/domain/TripRepository.kt
+++ b/app/src/main/java/com/matedroid/domain/TripRepository.kt
@@ -1,5 +1,7 @@
 package com.matedroid.domain
 
+import androidx.room.withTransaction
+import com.matedroid.data.local.StatsDatabase
 import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.local.dao.ChargeSummaryDao
 import com.matedroid.data.local.dao.DriveSummaryDao
@@ -36,6 +38,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class TripRepository @Inject constructor(
+    private val database: StatsDatabase,
     private val driveSummaryDao: DriveSummaryDao,
     private val chargeSummaryDao: ChargeSummaryDao,
     private val aggregateDao: AggregateDao,
@@ -144,16 +147,19 @@ class TripRepository @Inject constructor(
         }
 
         val now = System.currentTimeMillis()
-        if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
-            val priorFingerprint = computeFingerprint(existing.driveIds())
-            savedTripDao.insertConsumedFingerprints(
-                listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
-            )
-            savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, now)
-        } else {
-            savedTripDao.updateSource(tripId, existing.trip.source, now)
+        // Atomic: a crash between these writes must not leave a half-edited trip.
+        database.withTransaction {
+            if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
+                val priorFingerprint = computeFingerprint(existing.driveIds())
+                savedTripDao.insertConsumedFingerprints(
+                    listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
+                )
+                savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, now)
+            } else {
+                savedTripDao.updateSource(tripId, existing.trip.source, now)
+            }
+            savedTripDao.replaceLegs(tripId, legsToWrite)
         }
-        savedTripDao.replaceLegs(tripId, legsToWrite)
     }
 
     /**
@@ -210,26 +216,31 @@ class TripRepository @Inject constructor(
         // Inherit the kept trip's custom name; fall back to the consumed trip's name if only the
         // consumed one had been renamed. Either way, user-chosen names don't disappear at merge.
         val inheritedName = kept.trip.name ?: consumed.trip.name
-        val newId = savedTripDao.insertTripWithLegs(
-            trip = SavedTrip(
-                carId = carId,
-                name = inheritedName,
-                source = SavedTrip.SOURCE_USER_MERGED,
-                createdAt = now,
-                updatedAt = now
-            ),
-            legs = { tripId ->
-                allRefs.mapIndexed { index, ref ->
-                    SavedTripLeg(tripId = tripId, position = index, legType = ref.type, legId = ref.id)
+        // Atomic: a crash mid-merge would otherwise leave the merged trip coexisting with the
+        // originals — duplicates that share legs but not a fingerprint, which the duplicate
+        // healer in cleanupDuplicateSavedTrips can't detect.
+        return database.withTransaction {
+            val newId = savedTripDao.insertTripWithLegs(
+                trip = SavedTrip(
+                    carId = carId,
+                    name = inheritedName,
+                    source = SavedTrip.SOURCE_USER_MERGED,
+                    createdAt = now,
+                    updatedAt = now
+                ),
+                legs = { tripId ->
+                    allRefs.mapIndexed { index, ref ->
+                        SavedTripLeg(tripId = tripId, position = index, legType = ref.type, legId = ref.id)
+                    }
                 }
-            }
-        )
-        savedTripDao.insertConsumedFingerprints(
-            inheritedFingerprints.map { SavedTripConsumedFingerprint(savedTripId = newId, fingerprint = it) }
-        )
-        savedTripDao.deleteTrip(keptTripId)
-        savedTripDao.deleteTrip(consumedTripId)
-        return newId
+            )
+            savedTripDao.insertConsumedFingerprints(
+                inheritedFingerprints.map { SavedTripConsumedFingerprint(savedTripId = newId, fingerprint = it) }
+            )
+            savedTripDao.deleteTrip(keptTripId)
+            savedTripDao.deleteTrip(consumedTripId)
+            newId
+        }
     }
 
     /** Trips for [carId] whose date range is within [windowDays] of [tripId]'s range, excluding [tripId] itself. */
@@ -537,16 +548,19 @@ class TripRepository @Inject constructor(
             return
         }
 
-        if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
-            val priorFingerprint = computeFingerprint(existing.driveIds())
-            savedTripDao.insertConsumedFingerprints(
-                listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
-            )
-            savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, System.currentTimeMillis())
-        } else {
-            savedTripDao.updateSource(tripId, existing.trip.source, System.currentTimeMillis())
+        // Atomic: a crash between these writes must not leave a half-edited trip.
+        database.withTransaction {
+            if (existing.trip.source == SavedTrip.SOURCE_AUTO_DETECTED) {
+                val priorFingerprint = computeFingerprint(existing.driveIds())
+                savedTripDao.insertConsumedFingerprints(
+                    listOf(SavedTripConsumedFingerprint(savedTripId = tripId, fingerprint = priorFingerprint))
+                )
+                savedTripDao.updateSource(tripId, SavedTrip.SOURCE_USER_EDITED, System.currentTimeMillis())
+            } else {
+                savedTripDao.updateSource(tripId, existing.trip.source, System.currentTimeMillis())
+            }
+            savedTripDao.replaceLegs(tripId, remaining)
         }
-        savedTripDao.replaceLegs(tripId, remaining)
     }
 }
 

--- a/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
+++ b/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
@@ -65,6 +65,11 @@ class ChargingMonitorService : Service() {
     private var isMonitoring = false
     private val activeNotificationCarIds = mutableSetOf<Int>()
 
+    // Last successfully posted foreground notification, so a redundant start command can
+    // satisfy the system's startForeground() deadline without flashing the placeholder.
+    private var lastForegroundId = INITIAL_NOTIFICATION_ID
+    private var lastForegroundNotification: Notification? = null
+
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "Service created")
@@ -72,7 +77,17 @@ class ChargingMonitorService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (isMonitoring) {
-            Log.d(TAG, "Service already monitoring, ignoring start command")
+            // Every startForegroundService() call (the worker sends one per 30 s poll while
+            // charging) re-arms the system's "must call startForeground()" deadline, so we
+            // must satisfy it even when already monitoring — waiting up to 30 s for the
+            // monitor loop risks a ForegroundServiceDidNotStartInTimeException.
+            Log.d(TAG, "Service already monitoring, re-posting foreground notification")
+            val current = lastForegroundNotification
+            if (current != null) {
+                postForeground(lastForegroundId, current)
+            } else {
+                startForegroundImmediately()
+            }
             return START_STICKY
         }
 
@@ -126,20 +141,31 @@ class ChargingMonitorService : Service() {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
 
-        try {
+        if (postForeground(INITIAL_NOTIFICATION_ID, notification)) {
+            Log.d(TAG, "Started foreground with placeholder notification")
+        } else {
+            stopSelf()
+        }
+    }
+
+    /** SDK-gated startForeground wrapper; remembers the last posted notification on success. */
+    private fun postForeground(notificationId: Int, notification: Notification): Boolean {
+        return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 startForeground(
-                    INITIAL_NOTIFICATION_ID,
+                    notificationId,
                     notification,
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
                 )
             } else {
-                startForeground(INITIAL_NOTIFICATION_ID, notification)
+                startForeground(notificationId, notification)
             }
-            Log.d(TAG, "Started foreground with placeholder notification")
+            lastForegroundId = notificationId
+            lastForegroundNotification = notification
+            true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to start foreground", e)
-            stopSelf()
+            Log.e(TAG, "startForeground failed", e)
+            false
         }
     }
 
@@ -191,18 +217,7 @@ class ChargingMonitorService : Service() {
         status: com.matedroid.data.api.models.CarStatus,
         liveChargeAvailable: Boolean
     ) {
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                startForeground(
-                    notificationId,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-                )
-            } else {
-                startForeground(notificationId, notification)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to update foreground notification", e)
+        if (!postForeground(notificationId, notification)) {
             chargingNotificationManager.showChargingNotification(
                 car, status, liveChargeAvailable,
                 chronometerBaseMs = status.stateSinceEpochMs

--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -594,11 +594,14 @@ class CarWidget : GlanceAppWidget() {
                 this[CAR_ID_KEY] = data.carId
                 this[HAS_DATA_KEY] = true
                 this[CAR_NAME_KEY] = data.carName
-                data.exteriorColor?.let { this[EXTERIOR_COLOR_KEY] = it }
-                data.model?.let { this[MODEL_KEY] = it }
-                data.trimBadging?.let { this[TRIM_BADGING_KEY] = it }
-                data.wheelType?.let { this[WHEEL_TYPE_KEY] = it }
-                data.state?.let { this[STATE_KEY] = it }
+                // Remove keys on null instead of skipping the write (like imageOverride /
+                // locationText below) — otherwise a field the API stops returning keeps
+                // rendering its stale value (wrong palette / car image) indefinitely.
+                if (data.exteriorColor != null) this[EXTERIOR_COLOR_KEY] = data.exteriorColor else remove(EXTERIOR_COLOR_KEY)
+                if (data.model != null) this[MODEL_KEY] = data.model else remove(MODEL_KEY)
+                if (data.trimBadging != null) this[TRIM_BADGING_KEY] = data.trimBadging else remove(TRIM_BADGING_KEY)
+                if (data.wheelType != null) this[WHEEL_TYPE_KEY] = data.wheelType else remove(WHEEL_TYPE_KEY)
+                if (data.state != null) this[STATE_KEY] = data.state else remove(STATE_KEY)
                 this[IS_LOCKED_KEY] = data.isLocked
                 this[SENTRY_MODE_KEY] = data.sentryModeActive
                 this[PLUGGED_IN_KEY] = data.pluggedIn


### PR DESCRIPTION
Second cluster from the full-repo code review — service/worker and data-layer correctness.

- **Multi-car notification flap**: the worker's per-car loop called the process-wide `ChargingMonitorService.stop()` whenever *that* car was idle, so with one car charging and one parked the foreground service and the charging notification were killed and restarted every 30 s. The start/stop decision now aggregates across all cars (mirroring the service's own loop), and a failed status fetch no longer counts as "idle" so a transient error can't tear down an active monitor.
- **FGS timeout**: while charging, the worker sends `startForegroundService()` every 30 s; the service's already-monitoring early-return never called `startForeground()`, leaving the re-armed system deadline unsatisfied (risk of `ForegroundServiceDidNotStartInTimeException`). It now re-posts the last foreground notification.
- **Duplicate `Authorization` headers** when basic auth + API token were both configured (`addHeader` appends). The API token now takes precedence; if someone relied on both being sent, their proxy was already receiving an ill-formed pair.
- **Live-charge probe**: any transient network error was cached as "endpoint unavailable" for the whole session, disabling the live charging view. Only a definitive 404 is cached now.
- **Trip merge/extend/remove-leg are now transactional** — a crash mid-merge could leave the merged trip coexisting with its originals, duplicates the fingerprint healer can't detect.
- **`fallbackToDestructiveMigration` is debug-only now** — in release a missed migration wiped all synced data (incl. the geocode cache) silently.
- **Widget prefs**: nullable fields are now removed when the API stops returning them instead of keeping stale values.

The multi-car fix isn't reproducible locally (single car); verified by inspection — the aggregation logic now matches `ChargingMonitorService.performChargingCheck`. Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)