### PR TITLE
Fix small UI correctness bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configuring both HTTP basic auth and an API token no longer sends two Authorization headers** (which some reverse proxies reject) — the API token takes precedence.
 - **A missed database migration can no longer silently wipe synced data in release builds** — that recovery path is now debug-only.
 - **The widget no longer keeps a stale colour or car model** if the server stops reporting a field.
+- **The regions map frames correctly in the Americas and the southern hemisphere** — the initial zoom stretched to the equator/Greenwich meridian for all-negative coordinates.
+- **Viewing a chart fullscreen no longer locks the whole app to portrait afterwards** — the previous orientation setting is restored on exit.
+- **The system back button now closes the year/month/day overlays on the Mileage screen and the Battery detail overlay** instead of leaving the screen entirely.
+- **Maps no longer leak background tile-loader threads** — every embedded map now releases its resources when its screen closes.
+- **The dashboard map now follows the car while driving** instead of staying centered on where the car was when the dashboard opened.
 
 ## [1.10.0] - 2026-07-01
 

--- a/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
+++ b/app/src/main/java/com/matedroid/ui/components/FullscreenChartFrame.kt
@@ -109,6 +109,10 @@ private fun FullscreenChartOverlay(
 
     // Lock orientation to landscape and hide system bars for the duration of the overlay.
     DisposableEffect(Unit) {
+        // Restore whatever policy the activity had (usually UNSPECIFIED) — hardcoding
+        // PORTRAIT on dispose locked the whole app to portrait after one fullscreen use.
+        val priorOrientation = activity?.requestedOrientation
+            ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
         activity?.window?.let { window ->
             WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -118,7 +122,7 @@ private fun FullscreenChartOverlay(
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
         onDispose {
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            activity?.requestedOrientation = priorOrientation
             activity?.window?.let { window ->
                 WindowCompat.setDecorFitsSystemWindows(window, true)
                 val controller = WindowInsetsControllerCompat(window, view)

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.AlertDialog
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -100,6 +101,11 @@ fun BatteryScreen(
             snackbarHostState.showSnackbar(error)
             viewModel.clearError()
         }
+    }
+
+    // System back closes the detail overlay instead of popping the whole screen.
+    BackHandler(enabled = uiState.showDetail) {
+        viewModel.hideDetail()
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -840,6 +840,8 @@ private fun ChargeMapCard(latitude: Double, longitude: Double, accent: Color) {
                             controller.setCenter(geoPoint)
                         }
                     },
+                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
+                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -2059,6 +2059,18 @@ private fun LocationCard(
                             setOnTouchListener { _, _ -> true }
                         }
                     },
+                    // factory only runs once — without this the map stays centered on
+                    // wherever the car was at first composition while the status polls on.
+                    update = { map ->
+                        val center = GeoPoint(latitude, longitude)
+                        if (map.mapCenter.latitude != center.latitude ||
+                            map.mapCenter.longitude != center.longitude
+                        ) {
+                            map.controller.setCenter(center)
+                        }
+                    },
+                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
+                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -779,6 +779,9 @@ private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
                             }
                         }
                     },
+                    // onDetach() shuts down osmdroid's tile-loader threads and cache;
+                    // without it every visit to this screen leaks a tile provider.
+                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -122,6 +123,15 @@ fun MileageScreen(
         uiState.error?.let { error ->
             snackbarHostState.showSnackbar(error)
             viewModel.clearError()
+        }
+    }
+
+    // System back closes the innermost overlay level instead of popping the whole screen.
+    BackHandler(enabled = uiState.selectedYear != null) {
+        when {
+            uiState.selectedDay != null -> viewModel.clearSelectedDay()
+            uiState.selectedMonth != null -> viewModel.clearSelectedMonth()
+            else -> viewModel.clearSelectedYear()
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -519,6 +519,8 @@ private fun CountryMapCard(
                             }
                         }
                     },
+                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
+                    onRelease = { it.onDetach() },
                     update = { mapView ->
                         // Clear all overlays except keep any info windows
                         mapView.overlays.clear()
@@ -807,17 +809,12 @@ private fun calculateChargeBoundingBox(chargeLocations: List<ChargeLocation>): B
         return BoundingBox(55.0, 15.0, 35.0, -10.0)
     }
 
-    var minLat = Double.MAX_VALUE
-    var maxLat = Double.MIN_VALUE
-    var minLon = Double.MAX_VALUE
-    var maxLon = Double.MIN_VALUE
-
-    chargeLocations.forEach { location ->
-        minLat = minOf(minLat, location.latitude)
-        maxLat = maxOf(maxLat, location.latitude)
-        minLon = minOf(minLon, location.longitude)
-        maxLon = maxOf(maxLon, location.longitude)
-    }
+    // Note: Double.MIN_VALUE is the smallest POSITIVE double, not the most negative —
+    // seeding max with it breaks for all-negative coordinates (southern/western hemispheres).
+    val minLat = chargeLocations.minOf { it.latitude }
+    val maxLat = chargeLocations.maxOf { it.latitude }
+    val minLon = chargeLocations.minOf { it.longitude }
+    val maxLon = chargeLocations.maxOf { it.longitude }
 
     // Add some padding (about 10% on each side)
     val latPadding = (maxLat - minLat) * 0.15
@@ -845,17 +842,11 @@ private fun calculateDriveBoundingBox(driveLocations: List<DriveLocation>): Boun
         return BoundingBox(55.0, 15.0, 35.0, -10.0)
     }
 
-    var minLat = Double.MAX_VALUE
-    var maxLat = Double.MIN_VALUE
-    var minLon = Double.MAX_VALUE
-    var maxLon = Double.MIN_VALUE
-
-    driveLocations.forEach { location ->
-        minLat = minOf(minLat, location.latitude)
-        maxLat = maxOf(maxLat, location.latitude)
-        minLon = minOf(minLon, location.longitude)
-        maxLon = maxOf(maxLon, location.longitude)
-    }
+    // See calculateChargeBoundingBox — Double.MIN_VALUE seeding broke negative coordinates.
+    val minLat = driveLocations.minOf { it.latitude }
+    val maxLat = driveLocations.maxOf { it.latitude }
+    val minLon = driveLocations.minOf { it.longitude }
+    val maxLon = driveLocations.maxOf { it.longitude }
 
     // Add some padding (about 10% on each side)
     val latPadding = (maxLat - minLat) * 0.15

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1381,6 +1381,8 @@ private fun TripMapAndroidView(
                     }
                 }
             },
+            // onDetach() shuts down osmdroid's tile-loader threads and cache.
+            onRelease = { it.onDetach() },
             modifier = Modifier.fillMaxSize()
         )
 

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -232,6 +232,8 @@ fun WhereWasIScreen(
                                             overlays.add(marker)
                                         }
                                     },
+                                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
+                                    onRelease = { it.onDetach() },
                                     modifier = Modifier.fillMaxSize()
                                 )
                                 FilledIconButton(


### PR DESCRIPTION
Third cluster from the full-repo code review — small, independent UI bugs.

- **Regions map bounding box**: seeded with `Double.MIN_VALUE` (the smallest *positive* double), so all-negative latitude/longitude datasets (Americas, southern hemisphere) framed to the equator/Greenwich. Now uses `minOf`/`maxOf`.
- **Fullscreen chart orientation**: exiting fullscreen hardcoded `SCREEN_ORIENTATION_PORTRAIT`, locking the whole app to portrait for the rest of the process. The prior policy is captured and restored.
- **BackHandler on pseudo-navigation overlays**: system back now closes the Mileage year/month/day levels and the Battery detail overlay (innermost first) instead of popping the whole screen, matching the TripDetail convention.
- **osmdroid MapView leak**: all six embedded maps now pass `onRelease = { it.onDetach() }`, shutting down tile-loader threads and caches when the screen closes.
- **Dashboard map**: added the missing `update` block so the mini-map re-centers as the car moves (the factory-only view stayed frozen at the first position).

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)