### PR TITLE
Localization sweep: move all hardcoded UI strings to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The system back button now closes the year/month/day overlays on the Mileage screen and the Battery detail overlay** instead of leaving the screen entirely.
 - **Maps no longer leak background tile-loader threads** — every embedded map now releases its resources when its screen closes.
 - **The dashboard map now follows the car while driving** instead of staying centered on where the car was when the dashboard opened.
+- **Every remaining hardcoded English (and one Spanish) label is now translated** — settings validation and sync errors, the charges location-filter chip, the trip cost donut, the trip energy-flow labels, the merge-trip sheet, "N/A" placeholders on the Stats screen, and the "Where was I" speed/power labels are now proper string resources in all six languages.
 
 ## [1.10.0] - 2026-07-01
 

--- a/app/src/main/java/com/matedroid/domain/model/CarStats.kt
+++ b/app/src/main/java/com/matedroid/domain/model/CarStats.kt
@@ -22,11 +22,6 @@ data class CarStats(
 sealed class YearFilter {
     data object AllTime : YearFilter()
     data class Year(val year: Int) : YearFilter()
-
-    fun toDisplayString(): String = when (this) {
-        is AllTime -> "All Time"
-        is Year -> year.toString()
-    }
 }
 
 /**
@@ -121,19 +116,7 @@ data class DeepStats(
     // === Sync Progress ===
     val driveDetailsProcessed: Int,
     val chargeDetailsProcessed: Int
-) {
-    val acDcRatio: String
-        get() {
-            val total = acChargeCount + dcChargeCount
-            return if (total > 0) {
-                val acPercent = (acChargeCount * 100) / total
-                val dcPercent = (dcChargeCount * 100) / total
-                "$acPercent% AC / $dcPercent% DC"
-            } else {
-                "N/A"
-            }
-        }
-}
+)
 
 /**
  * Record for elevation-related drives.

--- a/app/src/main/java/com/matedroid/ui/components/CarImagePickerDialog.kt
+++ b/app/src/main/java/com/matedroid/ui/components/CarImagePickerDialog.kt
@@ -107,7 +107,7 @@ fun CarImagePickerDialog(
                         style = MaterialTheme.typography.headlineSmall
                     )
                     Spacer(modifier = Modifier.height(16.dp))
-                    Text("No variants available for this model.")
+                    Text(stringResource(R.string.car_picker_no_variants))
                     Spacer(modifier = Modifier.height(16.dp))
                     TextButton(onClick = onDismiss) {
                         Text(stringResource(R.string.ok))

--- a/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
+++ b/app/src/main/java/com/matedroid/ui/components/TripCostDonut.kt
@@ -32,8 +32,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.matedroid.R
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.util.formatDuration
@@ -266,7 +269,7 @@ private fun DonutCanvas(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Total",
+                    text = stringResource(R.string.total),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -277,7 +280,7 @@ private fun DonutCanvas(
                     fontWeight = FontWeight.Bold
                 )
                 Text(
-                    text = "${stops.size} stops",
+                    text = pluralStringResource(R.plurals.trip_cost_stops, stops.size, stops.size),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -953,7 +954,11 @@ private fun LocationFilterDropdown(
                     if (hasSelection && selectedLocations.size == 1)
                         selectedLocations.first()
                     else if (hasSelection)
-                        "${selectedLocations.size} ubicaciones"
+                        pluralStringResource(
+                            R.plurals.charges_locations_selected,
+                            selectedLocations.size,
+                            selectedLocations.size
+                        )
                     else
                         stringResource(R.string.filter_location)
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -1979,7 +1979,8 @@ private fun LocationCard(
 
     val headline = geofence?.takeIf { it.isNotBlank() }
         ?: resolvedAddress?.takeIf { it.isNotBlank() }
-        ?: if (latitude != null && longitude != null) "%.5f, %.5f".format(latitude, longitude) else "Unknown"
+        ?: if (latitude != null && longitude != null) "%.5f, %.5f".format(latitude, longitude)
+        else stringResource(R.string.unknown)
     // Show the street address as a subline only when the headline is a geofence name.
     val subAddress = resolvedAddress?.takeIf { it.isNotBlank() && it != headline }
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -367,7 +367,8 @@ private fun DriveHeroSection(
                     )
                     Spacer(modifier = Modifier.width(5.dp))
                     Text(
-                        text = formatDateTime(detail.startDate, is24Hour),
+                        text = formatDateTime(detail.startDate, is24Hour)
+                            ?: stringResource(R.string.unknown),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -1069,8 +1070,8 @@ private fun extractTimeLabels(positions: List<DrivePosition>, is24Hour: Boolean?
     }
 }
 
-private fun formatDateTime(dateStr: String?, is24Hour: Boolean? = null): String {
-    if (dateStr.isNullOrBlank()) return "Unknown"
+private fun formatDateTime(dateStr: String?, is24Hour: Boolean? = null): String? {
+    if (dateStr.isNullOrBlank()) return null
     val dt = parseIsoDateTime(dateStr) ?: return dateStr
     val locale = java.util.Locale.getDefault()
     return "${dt.toLocalDate().formatMedium(locale)} ${dt.formatTime(locale, is24Hour)}"

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesViewModel.kt
@@ -36,16 +36,6 @@ enum class DriveDistanceFilter(
     COMMUTE(10.0, null),           // < 10 km / 6 mi
     DAY_TRIP(100.0, 10.0),         // 10-100 km / 6-60 mi
     ROAD_TRIP(null, 100.0);        // > 100 km / 60 mi
-
-    fun getLabel(units: Units?): String {
-        val isImperial = units?.isImperial == true
-        return when (this) {
-            ALL -> "All"
-            COMMUTE -> if (isImperial) "Commute (< 6 mi)" else "Commute (< 10 km)"
-            DAY_TRIP -> if (isImperial) "Day trip (6-60 mi)" else "Day trip (10-100 km)"
-            ROAD_TRIP -> if (isImperial) "Road trip (> 60 mi)" else "Road trip (> 100 km)"
-        }
-    }
 }
 
 data class DriveChartData(

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -192,7 +192,7 @@ class SettingsViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     isTesting = false,
                     testResult = TestResult(
-                        primaryResult = ServerTestResult.Failure("Server URL is required")
+                        primaryResult = ServerTestResult.Failure(context.getString(R.string.settings_error_server_url_required))
                     )
                 )
                 return@launch
@@ -202,7 +202,7 @@ class SettingsViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     isTesting = false,
                     testResult = TestResult(
-                        primaryResult = ServerTestResult.Failure("URL must start with http:// or https://")
+                        primaryResult = ServerTestResult.Failure(context.getString(R.string.settings_error_url_scheme))
                     )
                 )
                 return@launch
@@ -214,8 +214,8 @@ class SettingsViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     isTesting = false,
                     testResult = TestResult(
-                        primaryResult = ServerTestResult.Failure("Primary URL not tested"),
-                        secondaryResult = ServerTestResult.Failure("Secondary URL must start with http:// or https://")
+                        primaryResult = ServerTestResult.Failure(context.getString(R.string.settings_error_primary_not_tested)),
+                        secondaryResult = ServerTestResult.Failure(context.getString(R.string.settings_error_secondary_url_scheme))
                     )
                 )
                 return@launch
@@ -279,7 +279,7 @@ class SettingsViewModel @Inject constructor(
                 if (url.isBlank()) {
                     _uiState.value = _uiState.value.copy(
                         isSaving = false,
-                        error = "Server URL is required"
+                        error = context.getString(R.string.settings_error_server_url_required)
                     )
                     return@launch
                 }
@@ -304,7 +304,7 @@ class SettingsViewModel @Inject constructor(
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     isSaving = false,
-                    error = e.message ?: "Failed to save settings"
+                    error = e.message ?: context.getString(R.string.settings_error_save_failed)
                 )
             }
         }
@@ -336,20 +336,20 @@ class SettingsViewModel @Inject constructor(
                         triggerImmediateSync()
                         _uiState.value = _uiState.value.copy(
                             isResyncing = false,
-                            successMessage = "Full resync started. All cached data cleared. Check the Stats screen for progress."
+                            successMessage = context.getString(R.string.settings_resync_started)
                         )
                     }
                     is ApiResult.Error -> {
                         _uiState.value = _uiState.value.copy(
                             isResyncing = false,
-                            error = "Failed to start resync: ${result.message}"
+                            error = context.getString(R.string.settings_error_resync_failed, result.message)
                         )
                     }
                 }
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     isResyncing = false,
-                    error = "Failed to start resync: ${e.message}"
+                    error = context.getString(R.string.settings_error_resync_failed, e.message ?: "")
                 )
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/CountriesVisitedViewModel.kt
@@ -1,7 +1,9 @@
 package com.matedroid.ui.screens.stats
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.StatsRepository
@@ -9,6 +11,7 @@ import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.model.CountryRecord
 import com.matedroid.domain.model.YearFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,6 +33,7 @@ data class CountriesVisitedUiState(
 
 @HiltViewModel
 class CountriesVisitedViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val statsRepository: StatsRepository,
     private val teslamateRepository: TeslamateRepository
 ) : ViewModel() {
@@ -65,7 +69,7 @@ class CountriesVisitedViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        error = e.message ?: "Failed to load countries"
+                        error = e.message ?: context.getString(R.string.countries_error_load_failed)
                     )
                 }
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
@@ -1,7 +1,9 @@
 package com.matedroid.ui.screens.stats
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.CountryBoundary
@@ -13,6 +15,7 @@ import com.matedroid.domain.model.DriveLocation
 import com.matedroid.domain.model.RegionRecord
 import com.matedroid.domain.model.YearFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -90,6 +93,7 @@ data class RegionsVisitedUiState(
 
 @HiltViewModel
 class RegionsVisitedViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val statsRepository: StatsRepository,
     private val teslamateRepository: TeslamateRepository
 ) : ViewModel() {
@@ -152,7 +156,7 @@ class RegionsVisitedViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        error = e.message ?: "Failed to load regions"
+                        error = e.message ?: context.getString(R.string.regions_error_load_failed)
                     )
                 }
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -668,7 +668,7 @@ private fun QuickStatsDrivesCard(quickStats: QuickStats, palette: CarColorPalett
             )
             StatItem(
                 label = stringResource(R.string.stats_cost_per_distance, UnitFormatter.getDistanceUnit(units)),
-                value = costPer100Km?.let { UnitFormatter.formatCost(it, currencySymbol) } ?: "N/A",
+                value = costPer100Km?.let { UnitFormatter.formatCost(it, currencySymbol) } ?: stringResource(R.string.value_not_available),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -704,7 +704,7 @@ private fun QuickStatsChargesCard(quickStats: QuickStats, palette: CarColorPalet
                 )
                 StatItem(
                     label = stringResource(R.string.stats_avg_cost_kwh),
-                    value = quickStats.avgCostPerKwh?.let { UnitFormatter.formatCost(it, currencySymbol, perKwh = true) } ?: "N/A",
+                    value = quickStats.avgCostPerKwh?.let { UnitFormatter.formatCost(it, currencySymbol, perKwh = true) } ?: stringResource(R.string.value_not_available),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -837,7 +837,7 @@ private fun RecordsCard(
         weatherRecords.add(RecordData("🏔️", labelHighestPoint, UnitFormatter.formatElevation(record.elevationM, units), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
     }
     deepStats?.driveWithMostClimbing?.let { record ->
-        weatherRecords.add(RecordData("⛰️", labelMostClimbing, record.elevationGainM?.let { "+" + UnitFormatter.formatElevation(it, units) } ?: "N/A", record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
+        weatherRecords.add(RecordData("⛰️", labelMostClimbing, record.elevationGainM?.let { "+" + UnitFormatter.formatElevation(it, units) } ?: stringResource(R.string.value_not_available), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
     }
     deepStats?.hottestDrive?.let { record ->
         weatherRecords.add(RecordData("🌡️", labelHottestDrive, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
@@ -1100,12 +1100,12 @@ private fun TemperatureStatsCard(deepStats: DeepStats, palette: CarColorPalette,
         Row(modifier = Modifier.fillMaxWidth()) {
             StatItem(
                 label = stringResource(R.string.stats_hottest),
-                value = deepStats.maxOutsideTempDrivingC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: "N/A",
+                value = deepStats.maxOutsideTempDrivingC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: stringResource(R.string.value_not_available),
                 modifier = Modifier.weight(1f)
             )
             StatItem(
                 label = stringResource(R.string.stats_coldest),
-                value = deepStats.minOutsideTempDrivingC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: "N/A",
+                value = deepStats.minOutsideTempDrivingC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: stringResource(R.string.value_not_available),
                 modifier = Modifier.weight(1f)
             )
         }
@@ -1122,12 +1122,12 @@ private fun TemperatureStatsCard(deepStats: DeepStats, palette: CarColorPalette,
             Row(modifier = Modifier.fillMaxWidth()) {
                 StatItem(
                     label = stringResource(R.string.stats_hottest),
-                    value = deepStats.maxCabinTempC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: "N/A",
+                    value = deepStats.maxCabinTempC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: stringResource(R.string.value_not_available),
                     modifier = Modifier.weight(1f)
                 )
                 StatItem(
                     label = stringResource(R.string.stats_coldest),
-                    value = deepStats.minCabinTempC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: "N/A",
+                    value = deepStats.minCabinTempC?.let { UnitFormatter.formatTemperature(it, units, 1) } ?: stringResource(R.string.value_not_available),
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
+import com.matedroid.R
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.model.Currency
@@ -273,7 +274,7 @@ class StatsViewModel @Inject constructor(
         } catch (e: Exception) {
             _uiState.update {
                 it.copy(
-                    error = e.message ?: "Failed to load stats"
+                    error = e.message ?: context.getString(R.string.stats_error_load_failed)
                 )
             }
         }

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -143,7 +144,11 @@ private fun AdjacentTripRow(
                 fontWeight = FontWeight.Bold
             )
             Text(
-                text = "${trip.drives.size + trip.charges.size} legs",
+                text = pluralStringResource(
+                    R.plurals.trip_legs,
+                    trip.drives.size + trip.charges.size,
+                    trip.drives.size + trip.charges.size
+                ),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -224,7 +224,7 @@ fun TripDetailScreen(
                         .fillMaxSize()
                         .padding(padding),
                     contentAlignment = Alignment.Center
-                ) { Text("Trip not found") }
+                ) { Text(stringResource(R.string.trip_not_found)) }
             }
             else -> {
                 val trip = uiState.trip!!
@@ -971,7 +971,7 @@ private fun HorizontalEnergyFlow(
                     color = accent
                 )
                 Text(
-                    text = "kWh charged",
+                    text = stringResource(R.string.trip_kwh_charged),
                     style = MaterialTheme.typography.labelSmall,
                     color = accent.copy(alpha = 0.78f)
                 )
@@ -999,7 +999,7 @@ private fun HorizontalEnergyFlow(
                     color = dcColor
                 )
                 Text(
-                    text = "%.0f kW avg".format(dcAvgKw),
+                    text = stringResource(R.string.power_kw_avg, "%.0f".format(dcAvgKw)),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1021,7 +1021,7 @@ private fun HorizontalEnergyFlow(
                     color = acColor
                 )
                 Text(
-                    text = "%.1f kW avg".format(acAvgKw),
+                    text = stringResource(R.string.power_kw_avg, "%.1f".format(acAvgKw)),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsViewModel.kt
@@ -1,11 +1,14 @@
 package com.matedroid.ui.screens.updates
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.matedroid.R
 import com.matedroid.data.api.models.UpdateData
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,6 +56,7 @@ data class SoftwareVersionItem(
 
 @HiltViewModel
 class SoftwareVersionsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val repository: TeslamateRepository
 ) : ViewModel() {
 
@@ -256,7 +260,7 @@ class SoftwareVersionsViewModel @Inject constructor(
      * "2025.44.25.1 abc123def456" -> "2025.44.25.1"
      */
     private fun cleanVersion(version: String?): String {
-        if (version == null) return "Unknown"
+        if (version == null) return context.getString(R.string.unknown)
         // Split by space and take only the first part (the version number)
         return version.split(" ").firstOrNull() ?: version
     }

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -408,7 +408,7 @@ fun WhereWasIScreen(
                                     CarActivityState.DRIVING -> {
                                         Row(modifier = Modifier.fillMaxWidth()) {
                                             InfoItem(
-                                                label = stringResource(R.string.speed_profile).split(" ").first(),
+                                                label = stringResource(R.string.speed),
                                                 value = state.speed?.let { "$it ${UnitFormatter.getSpeedUnit(state.units)}" } ?: "—",
                                                 palette = palette,
                                                 modifier = Modifier.weight(1f)
@@ -432,7 +432,7 @@ fun WhereWasIScreen(
                                                 modifier = Modifier.weight(1f)
                                             )
                                             InfoItem(
-                                                label = stringResource(R.string.power_profile).split(" ").first(),
+                                                label = stringResource(R.string.power),
                                                 value = state.chargerPower?.let { "$it kW" } ?: "—",
                                                 palette = palette,
                                                 modifier = Modifier.weight(1f)

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIViewModel.kt
@@ -3,6 +3,7 @@ package com.matedroid.ui.screens.wherewasi
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.matedroid.R
 import com.matedroid.data.api.OpenMeteoApi
 import com.matedroid.data.api.models.ChargeData
 import com.matedroid.data.api.models.DriveData
@@ -84,7 +85,10 @@ class WhereWasIViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val targetTime = parseDateTime(timestamp) ?: run {
-                    _uiState.value = WhereWasIUiState(isLoading = false, error = "Invalid date")
+                    _uiState.value = WhereWasIUiState(
+                        isLoading = false,
+                        error = appContext.getString(R.string.wherewasi_error_invalid_date)
+                    )
                     return@launch
                 }
 

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1279,4 +1279,46 @@
         <item quantity="one">%d càrrega comparable a prop</item>
         <item quantity="other">%d càrregues comparables a prop</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="one">%d ubicació</item>
+        <item quantity="other">%d ubicacions</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">L\'URL del servidor és obligatori</string>
+    <string name="settings_error_url_scheme">L\'URL ha de començar per http:// o https://</string>
+    <string name="settings_error_primary_not_tested">URL principal no provada</string>
+    <string name="settings_error_secondary_url_scheme">L\'URL secundària ha de començar per http:// o https://</string>
+    <string name="settings_error_save_failed">No s\'han pogut desar els ajustos</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">Resincronització completa iniciada. S\'han esborrat totes les dades en memòria cau. Consulta la pantalla d\'Estadístiques per veure el progrés.</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">No s\'ha pogut iniciar la resincronització: %1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">No s\'han pogut carregar les estadístiques</string>
+    <string name="regions_error_load_failed">No s\'han pogut carregar les regions</string>
+    <string name="countries_error_load_failed">No s\'han pogut carregar els països</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">Data no vàlida</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="one">%d parada</item>
+        <item quantity="other">%d parades</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">No hi ha variants disponibles per a aquest model.</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">Viatge no trobat</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">kWh carregats</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">%1$s kW de mitjana</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="one">%d tram</item>
+        <item quantity="other">%d trams</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">N/D</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1394,4 +1394,46 @@
         <item quantity="one">%d vergleichbare Ladung in der Nähe</item>
         <item quantity="other">%d vergleichbare Ladungen in der Nähe</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="one">%d Standort</item>
+        <item quantity="other">%d Standorte</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">Server-URL ist erforderlich</string>
+    <string name="settings_error_url_scheme">Die URL muss mit http:// oder https:// beginnen</string>
+    <string name="settings_error_primary_not_tested">Primäre URL nicht getestet</string>
+    <string name="settings_error_secondary_url_scheme">Die sekundäre URL muss mit http:// oder https:// beginnen</string>
+    <string name="settings_error_save_failed">Einstellungen konnten nicht gespeichert werden</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">Vollständige Neusynchronisierung gestartet. Alle zwischengespeicherten Daten wurden gelöscht. Den Fortschritt siehst du im Statistik-Bildschirm.</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">Neusynchronisierung konnte nicht gestartet werden: %1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">Statistiken konnten nicht geladen werden</string>
+    <string name="regions_error_load_failed">Regionen konnten nicht geladen werden</string>
+    <string name="countries_error_load_failed">Länder konnten nicht geladen werden</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">Ungültiges Datum</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="one">%d Stopp</item>
+        <item quantity="other">%d Stopps</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">Für dieses Modell sind keine Varianten verfügbar.</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">Trip nicht gefunden</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">kWh geladen</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">Ø %1$s kW</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="one">%d Etappe</item>
+        <item quantity="other">%d Etappen</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">k. A.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1279,4 +1279,46 @@
         <item quantity="one">%d carga comparable cerca</item>
         <item quantity="other">%d cargas comparables cerca</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="one">%d ubicación</item>
+        <item quantity="other">%d ubicaciones</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">La URL del servidor es obligatoria</string>
+    <string name="settings_error_url_scheme">La URL debe empezar por http:// o https://</string>
+    <string name="settings_error_primary_not_tested">URL principal no probada</string>
+    <string name="settings_error_secondary_url_scheme">La URL secundaria debe empezar por http:// o https://</string>
+    <string name="settings_error_save_failed">No se pudieron guardar los ajustes</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">Resincronización completa iniciada. Se han borrado todos los datos en caché. Consulta la pantalla de Estadísticas para ver el progreso.</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">No se pudo iniciar la resincronización: %1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">No se pudieron cargar las estadísticas</string>
+    <string name="regions_error_load_failed">No se pudieron cargar las regiones</string>
+    <string name="countries_error_load_failed">No se pudieron cargar los países</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">Fecha no válida</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="one">%d parada</item>
+        <item quantity="other">%d paradas</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">No hay variantes disponibles para este modelo.</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">Viaje no encontrado</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">kWh cargados</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">%1$s kW de media</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="one">%d tramo</item>
+        <item quantity="other">%d tramos</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">N/D</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1279,4 +1279,46 @@
         <item quantity="one">%d ricarica confrontabile nelle vicinanze</item>
         <item quantity="other">%d ricariche confrontabili nelle vicinanze</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="one">%d posizione</item>
+        <item quantity="other">%d posizioni</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">L\'URL del server è obbligatorio</string>
+    <string name="settings_error_url_scheme">L\'URL deve iniziare con http:// o https://</string>
+    <string name="settings_error_primary_not_tested">URL primario non testato</string>
+    <string name="settings_error_secondary_url_scheme">L\'URL secondario deve iniziare con http:// o https://</string>
+    <string name="settings_error_save_failed">Impossibile salvare le impostazioni</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">Risincronizzazione completa avviata. Tutti i dati in cache sono stati cancellati. Controlla la schermata Statistiche per i progressi.</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">Impossibile avviare la risincronizzazione: %1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">Impossibile caricare le statistiche</string>
+    <string name="regions_error_load_failed">Impossibile caricare le regioni</string>
+    <string name="countries_error_load_failed">Impossibile caricare i paesi</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">Data non valida</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="one">%d sosta</item>
+        <item quantity="other">%d soste</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">Nessuna variante disponibile per questo modello.</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">Viaggio non trovato</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">kWh caricati</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">%1$s kW medi</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="one">%d tappa</item>
+        <item quantity="other">%d tappe</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">N/D</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1301,4 +1301,43 @@
     <plurals name="compare_sessions_nearby">
         <item quantity="other">附近 %d 次可比充电</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="other">%d 个地点</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">服务器 URL 为必填项</string>
+    <string name="settings_error_url_scheme">URL 必须以 http:// 或 https:// 开头</string>
+    <string name="settings_error_primary_not_tested">未测试主 URL</string>
+    <string name="settings_error_secondary_url_scheme">备用 URL 必须以 http:// 或 https:// 开头</string>
+    <string name="settings_error_save_failed">无法保存设置</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">已开始完全重新同步。所有缓存数据已清除。请在统计页面查看进度。</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">无法开始重新同步：%1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">无法加载统计数据</string>
+    <string name="regions_error_load_failed">无法加载地区</string>
+    <string name="countries_error_load_failed">无法加载国家/地区</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">日期无效</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="other">%d 次停靠</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">此车型没有可用的变体。</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">未找到旅程</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">已充电 kWh</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">平均 %1$s kW</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="other">%d 段</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">暂无</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1413,4 +1413,46 @@
         <item quantity="one">%d comparable charge nearby</item>
         <item quantity="other">%d comparable charges nearby</item>
     </plurals>
+
+    <!-- Charges location filter chip when several locations are selected. %d = count -->
+    <plurals name="charges_locations_selected">
+        <item quantity="one">%d location</item>
+        <item quantity="other">%d locations</item>
+    </plurals>
+    <!-- Settings: server connection validation / save errors -->
+    <string name="settings_error_server_url_required">Server URL is required</string>
+    <string name="settings_error_url_scheme">URL must start with http:// or https://</string>
+    <string name="settings_error_primary_not_tested">Primary URL not tested</string>
+    <string name="settings_error_secondary_url_scheme">Secondary URL must start with http:// or https://</string>
+    <string name="settings_error_save_failed">Failed to save settings</string>
+    <!-- Snackbar after the debug "force full resync" action succeeds -->
+    <string name="settings_resync_started">Full resync started. All cached data cleared. Check the Stats screen for progress.</string>
+    <!-- %1$s = error detail from the server -->
+    <string name="settings_error_resync_failed">Failed to start resync: %1$s</string>
+    <!-- Generic load-failure snackbars -->
+    <string name="stats_error_load_failed">Failed to load stats</string>
+    <string name="regions_error_load_failed">Failed to load regions</string>
+    <string name="countries_error_load_failed">Failed to load countries</string>
+    <!-- Where-was-I: shown when the requested timestamp can't be parsed -->
+    <string name="wherewasi_error_invalid_date">Invalid date</string>
+    <!-- Center of the trip cost donut. %d = number of charging stops -->
+    <plurals name="trip_cost_stops">
+        <item quantity="one">%d stop</item>
+        <item quantity="other">%d stops</item>
+    </plurals>
+    <!-- Car image picker: model has a single render, nothing to choose -->
+    <string name="car_picker_no_variants">No variants available for this model.</string>
+    <!-- Trip detail: the requested trip no longer exists -->
+    <string name="trip_not_found">Trip not found</string>
+    <!-- Label under the total in the trip energy flow diagram (kWh is not translated) -->
+    <string name="trip_kwh_charged">kWh charged</string>
+    <!-- Average power label in the trip energy flow. %1$s = pre-formatted number, kW not translated -->
+    <string name="power_kw_avg">%1$s kW avg</string>
+    <!-- Merge sheet: how many drives+charges a trip contains. %d = count -->
+    <plurals name="trip_legs">
+        <item quantity="one">%d leg</item>
+        <item quantity="other">%d legs</item>
+    </plurals>
+    <!-- Placeholder when a stat has no value -->
+    <string name="value_not_available">N/A</string>
 </resources>

--- a/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
@@ -53,6 +53,18 @@ class SettingsViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         context = mockk(relaxed = true)
+        // Error strings are now resources; return their English values so the
+        // assertions below keep testing the user-visible messages.
+        every { context.getString(com.matedroid.R.string.settings_error_server_url_required) } returns
+            "Server URL is required"
+        every { context.getString(com.matedroid.R.string.settings_error_url_scheme) } returns
+            "URL must start with http:// or https://"
+        every { context.getString(com.matedroid.R.string.settings_error_primary_not_tested) } returns
+            "Primary URL not tested"
+        every { context.getString(com.matedroid.R.string.settings_error_secondary_url_scheme) } returns
+            "Secondary URL must start with http:// or https://"
+        every { context.getString(com.matedroid.R.string.settings_error_save_failed) } returns
+            "Failed to save settings"
         settingsDataStore = mockk()
         repository = mockk()
         syncManager = mockk()


### PR DESCRIPTION
Fourth cluster from the full-repo code review — every user-visible hardcoded string moved to string resources in all six locales (en, it, es, ca, de, zh).

- **Worst case**: the charges location-filter chip showed literal Spanish `"N ubicaciones"` to every user; now a proper plural resource.
- Settings validation/save/resync errors and the full-resync snackbar (ViewModels use `context.getString`; three ViewModels gained `@ApplicationContext`).
- Stats/Regions/Countries load-failure snackbars, "N/A" placeholders (`value_not_available`), trip cost donut ("Total", "N stops"), trip energy-flow labels ("kWh charged", "kW avg"), merge sheet ("N legs" plural), "Trip not found", car-picker "No variants…", software-version "Unknown".
- "Where was I": replaced the `stringResource(R.string.speed_profile).split(" ").first()` hack (broken in Chinese) with dedicated `speed`/`power` resources.
- Deleted dead untranslatable helpers with zero callers: `DriveDistanceFilter.getLabel`, `YearFilter.toDisplayString`, `DeepStats.acDcRatio`.
- Updated `SettingsViewModelTest` to mock the new resource lookups with their English values.

Plurals follow the existing `compare_*` conventions (zh uses `other` only). Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)