### PR TITLE
Performance pass: recomposition churn, chart draw paths, main-thread bitmap work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Snappier throughout** — smoother list scrolling, lighter chart rendering, the Stats and Trips screens do their heavy work off the UI thread, and the dashboard stops polling for status while it's off screen (less background battery use). No change to how anything looks.
+- **Smoother charts and screens (second pass)** — dragging the crosshair on charge/drive charts no longer recomputes the whole screen per frame, chart drawing stops allocating per frame, the dashboard car image and its charging glow render off the UI thread (no more hiccup when swiping between cars), detail screens fetch their data truly in parallel, and the Stats auto-refresh pauses while the app is in the background.
+- **Chart labels now respect the system font size** — axis and tooltip text in the native charts was sized in raw pixels; it now scales with display density and the accessibility font setting.
 - **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.
 
 ### Fixed

--- a/app/src/main/java/com/matedroid/domain/TripDetector.kt
+++ b/app/src/main/java/com/matedroid/domain/TripDetector.kt
@@ -51,7 +51,9 @@ class TripDetector @Inject constructor() {
         val events = mutableListOf<Event>()
         realDrives.forEach { events.add(Event.Drive(it)) }
         dcCharges.forEach { events.add(Event.Charge(it)) }
-        events.sortBy { parseDateTime(it.startDate) ?: LocalDateTime.MIN }
+        // Timestamps are uniform ISO-8601, so lexicographic order == chronological order.
+        // Sorting by the raw string avoids parsing a date per comparison.
+        events.sortBy { it.startDate }
 
         val trips = mutableListOf<Trip>()
         var currentDrives = mutableListOf<DriveSummary>()

--- a/app/src/main/java/com/matedroid/notification/ChargingNotificationManager.kt
+++ b/app/src/main/java/com/matedroid/notification/ChargingNotificationManager.kt
@@ -19,6 +19,7 @@ import com.matedroid.data.api.models.CarStatus
 import com.matedroid.domain.model.CarImageResolver
 import com.matedroid.ui.theme.CarColorPalettes
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -42,6 +43,9 @@ class ChargingNotificationManager @Inject constructor(
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE)
             as NotificationManager
+
+    // Decoded car images keyed by asset path (singleton-lifetime, a handful of small PNGs)
+    private val carImageCache = ConcurrentHashMap<String, Bitmap>()
 
     /**
      * Show or update the charging notification for a car.
@@ -324,6 +328,9 @@ class ChargingNotificationManager @Inject constructor(
 
     /**
      * Load car image from assets.
+     * Decoded bitmaps are memoized per asset path — this runs on every notification
+     * update (every 30s while charging), so avoid re-decoding the same PNG.
+     * Failures are not cached, so a null result can be retried.
      */
     private fun loadCarImage(car: CarData): Bitmap? {
         return try {
@@ -334,9 +341,9 @@ class ChargingNotificationManager @Inject constructor(
                 trimBadging = car.carDetails?.trimBadging
             )
 
-            context.assets.open(assetPath).use { inputStream ->
+            carImageCache[assetPath] ?: context.assets.open(assetPath).use { inputStream ->
                 BitmapFactory.decodeStream(inputStream)
-            }
+            }?.also { carImageCache[assetPath] = it }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to load car image", e)
             null

--- a/app/src/main/java/com/matedroid/ui/components/CarImagePickerDialog.kt
+++ b/app/src/main/java/com/matedroid/ui/components/CarImagePickerDialog.kt
@@ -1,5 +1,6 @@
 package com.matedroid.ui.components
 
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -35,6 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -54,6 +56,8 @@ import com.matedroid.R
 import com.matedroid.data.local.CarImageOverride
 import com.matedroid.domain.model.CarImageResolver
 import com.matedroid.domain.model.WheelOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * A dialog for manually selecting car appearance (variant and wheel style).
@@ -361,15 +365,20 @@ private fun WheelOptionItem(
 ) {
     val context = LocalContext.current
 
-    val bitmap = remember(wheel.assetPath) {
-        try {
-            context.assets.open(wheel.assetPath).use { inputStream ->
-                BitmapFactory.decodeStream(inputStream)
+    // Decode off the main thread; the placeholder box renders while null.
+    // Reset first so a recycled LazyRow slot never shows the previous wheel's image.
+    val bitmap = produceState<Bitmap?>(initialValue = null, wheel.assetPath) {
+        value = null
+        value = withContext(Dispatchers.IO) {
+            try {
+                context.assets.open(wheel.assetPath).use { inputStream ->
+                    BitmapFactory.decodeStream(inputStream)
+                }
+            } catch (e: Exception) {
+                null
             }
-        } catch (e: Exception) {
-            null
         }
-    }
+    }.value
 
     val borderColor = if (isSelected) {
         MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ChartDrawUtils.kt
@@ -237,6 +237,23 @@ private fun computeMonotoneTangents(xs: FloatArray, ys: FloatArray): FloatArray 
 private val dashEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 4f))
 private val crosshairDashEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f))
 
+// Reused across draw frames (crosshair drags and entrance animations redraw every frame).
+// Draws only happen on the UI thread, so shared mutable instances are safe.
+private val chipTextPaint = Paint().apply {
+    color = android.graphics.Color.WHITE
+    isAntiAlias = true
+    textAlign = Paint.Align.CENTER
+}
+private val chipBgPaint = Paint().apply {
+    isAntiAlias = true
+}
+private val chipRect = android.graphics.RectF()
+
+// Gradient fill brushes are cached per (color, alpha): drawGradientFill runs on every draw
+// frame, and Brush.verticalGradient with default bounds is size-independent so the same
+// instance can be reused. Chart colors come from the theme, so the map stays tiny.
+private val gradientFillCache = HashMap<Pair<Color, Float>, Brush>()
+
 /**
  * Draws Grafana-style annotation bands on the chart.
  * Each range is rendered as a semi-transparent vertical band spanning the full chart height,
@@ -324,9 +341,11 @@ fun DrawScope.drawGradientFill(
     alpha: Float = 0.3f,
     progress: Float = 1f
 ) {
-    val brush = Brush.verticalGradient(
-        listOf(color.copy(alpha = alpha), Color.Transparent)
-    )
+    val brush = gradientFillCache.getOrPut(color to alpha) {
+        Brush.verticalGradient(
+            listOf(color.copy(alpha = alpha), Color.Transparent)
+        )
+    }
     if (progress >= 1f) {
         drawPath(fillPath, brush = brush)
     } else {
@@ -481,29 +500,22 @@ fun DrawScope.drawFloatingTimeChip(
     chipColor: Color,
     chartHeight: Float,
     timeLabelHeight: Float,
-    canvasWidth: Float
+    canvasWidth: Float,
+    textSizePx: Float
 ) {
     drawContext.canvas.nativeCanvas.apply {
-        val textPaint = Paint().apply {
-            color = android.graphics.Color.WHITE
-            textSize = 28f
-            isAntiAlias = true
-            textAlign = Paint.Align.CENTER
-        }
-        val bgPaint = Paint().apply {
-            color = chipColor.copy(alpha = 0.9f).toArgb()
-            isAntiAlias = true
-        }
+        chipTextPaint.textSize = textSizePx
+        chipBgPaint.color = chipColor.copy(alpha = 0.9f).toArgb()
 
-        val textWidth = textPaint.measureText(timeStr)
+        val textWidth = chipTextPaint.measureText(timeStr)
         val chipPadding = 12f
         val chipWidth = textWidth + chipPadding * 2
         val chipHeight = timeLabelHeight * 0.85f
         val chipTop = chartHeight + (timeLabelHeight - chipHeight) / 2
         val chipLeft = (xCenter - chipWidth / 2).coerceIn(0f, canvasWidth - chipWidth)
 
-        val rect = android.graphics.RectF(chipLeft, chipTop, chipLeft + chipWidth, chipTop + chipHeight)
-        drawRoundRect(rect, 8f, 8f, bgPaint)
-        drawText(timeStr, chipLeft + chipWidth / 2, chipTop + chipHeight / 2 + textPaint.textSize / 3, textPaint)
+        chipRect.set(chipLeft, chipTop, chipLeft + chipWidth, chipTop + chipHeight)
+        drawRoundRect(chipRect, 8f, 8f, chipBgPaint)
+        drawText(timeStr, chipLeft + chipWidth / 2, chipTop + chipHeight / 2 + chipTextPaint.textSize / 3, chipTextPaint)
     }
 }

--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlin.math.roundToInt
 
 /**
@@ -66,28 +67,34 @@ fun DualAxisLineChart(
 ) {
     if (dataLeft.size < 2 && dataRight.size < 2) return
 
+    val density = LocalDensity.current
+    // Text sizes in sp so labels respect density and the user's font scale.
+    val axisLabelTextSizePx = with(density) { 9.sp.toPx() }
+    val timeLabelTextSizePx = with(density) { 10.sp.toPx() }
+    val chipTextSizePx = with(density) { 11.sp.toPx() }
+
     val surfaceColor = MaterialTheme.colorScheme.onSurface
     // Built once and reused across draws (the 800ms entrance redraws every frame).
-    val leftLabelPaint = remember(colorLeft) {
+    val leftLabelPaint = remember(colorLeft, axisLabelTextSizePx) {
         android.graphics.Paint().apply {
             color = colorLeft.copy(alpha = 0.8f).toArgb()
-            textSize = 24f
+            textSize = axisLabelTextSizePx
             isAntiAlias = true
             textAlign = android.graphics.Paint.Align.LEFT
         }
     }
-    val rightLabelPaint = remember(colorRight) {
+    val rightLabelPaint = remember(colorRight, axisLabelTextSizePx) {
         android.graphics.Paint().apply {
             color = colorRight.copy(alpha = 0.8f).toArgb()
-            textSize = 24f
+            textSize = axisLabelTextSizePx
             isAntiAlias = true
             textAlign = android.graphics.Paint.Align.RIGHT
         }
     }
-    val timeLabelPaint = remember(surfaceColor) {
+    val timeLabelPaint = remember(surfaceColor, timeLabelTextSizePx) {
         android.graphics.Paint().apply {
             color = surfaceColor.copy(alpha = 0.7f).toArgb()
-            textSize = 26f
+            textSize = timeLabelTextSizePx
             isAntiAlias = true
         }
     }
@@ -98,7 +105,6 @@ fun DualAxisLineChart(
     val chartDataLeft = remember(dataLeft) { prepareChartData(dataLeft, fixedMinMax = null) { it } }
     val chartDataRight = remember(dataRight) { prepareChartData(dataRight, fixedMinMax = null) { it } }
 
-    val density = LocalDensity.current
     val chartHeightPx = with(density) { chartHeight.toPx() }
     var canvasWidthPx by remember { mutableStateOf(0f) }
 
@@ -106,7 +112,7 @@ fun DualAxisLineChart(
     // points, so tap indices must index those too. Raw indices past
     // MAX_DISPLAY_POINTS would look up nothing and leave the tooltip valueless.
     val dataSize = maxOf(chartDataLeft.displayPoints.size, chartDataRight.displayPoints.size)
-    val rightLabelWidth = 70f
+    val rightLabelWidth = with(density) { 27.dp.toPx() }
 
     // Pre-compute smooth paths
     val chartWidth = (canvasWidthPx - rightLabelWidth).coerceAtLeast(0f)
@@ -293,7 +299,7 @@ fun DualAxisLineChart(
                 if (fractionToTimeLabel != null && timeLabelHeightPx > 0) {
                     val fraction = if (dataSize > 1) point.index.toFloat() / (dataSize - 1) else 0f
                     val timeStr = fractionToTimeLabel(fraction)
-                    drawFloatingTimeChip(timeStr, pointX, colorLeft, chartHeightPx, timeLabelHeightPx, width - rLabelWidth)
+                    drawFloatingTimeChip(timeStr, pointX, colorLeft, chartHeightPx, timeLabelHeightPx, width - rLabelWidth, chipTextSizePx)
                 }
             }
         }

--- a/app/src/main/java/com/matedroid/ui/components/InteractiveBarChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/InteractiveBarChart.kt
@@ -69,7 +69,9 @@ fun InteractiveBarChart(
 ) {
     if (data.isEmpty()) return
 
-    val textMeasurer = rememberTextMeasurer()
+    // Default cache holds 8 layouts; monthly/daily charts draw up to 31 X labels + 2 Y labels
+    // per frame, so a larger cache avoids re-measuring every label on every draw.
+    val textMeasurer = rememberTextMeasurer(cacheSize = 64)
     val maxValue = data.maxOfOrNull { it.value } ?: 1.0
 
     // Reset selection when data changes to avoid IndexOutOfBoundsException

--- a/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
+++ b/app/src/main/java/com/matedroid/ui/components/MonthScrollIndicator.kt
@@ -151,25 +151,22 @@ fun MonthScrollIndicator(
     val currentDateAt by rememberUpdatedState(dateAt)
 
     // Distinct month count drives the label format. Computing this only when
-    // `totalItems` changes (data loaded / filter changed) keeps it off the hot
-    // scroll path — `derivedStateOf` would otherwise re-iterate every time the
-    // captured dateAt lambda changes identity, which is every recomposition.
-    val monthCount by remember {
-        derivedStateOf {
-            val total = state.layoutInfo.totalItemsCount
-            if (total == 0) return@derivedStateOf 0
-            var count = 0
-            var prev: YearMonth? = null
-            for (i in 0 until total) {
-                val date = currentDateAt(i) ?: continue
-                val ym = YearMonth.from(date)
-                if (ym != prev) {
-                    count++
-                    prev = ym
-                }
+    // `totalItems` changes (data loaded / filter changed) keeps the O(n) date
+    // parse loop off the hot scroll path — a `derivedStateOf` reading
+    // `state.layoutInfo` would re-run the loop on every scroll/drag frame.
+    val monthCount = remember(totalItems) {
+        if (totalItems == 0) return@remember 0
+        var count = 0
+        var prev: YearMonth? = null
+        for (i in 0 until totalItems) {
+            val date = currentDateAt(i) ?: continue
+            val ym = YearMonth.from(date)
+            if (ym != prev) {
+                count++
+                prev = ym
             }
-            count
         }
+        count
     }
 
     var trackHeightPx by remember { mutableIntStateOf(0) }
@@ -254,8 +251,9 @@ fun MonthScrollIndicator(
 
     // Label text is a derivedStateOf so it only invalidates when the rendered
     // string actually changes — many drag-fraction updates within the same row
-    // produce the same date and don't recompose Text.
-    val labelText by remember {
+    // produce the same date and don't recompose Text. Keyed on monthCount (now a
+    // plain remembered value) so the closure never holds a stale format choice.
+    val labelText by remember(monthCount) {
         derivedStateOf {
             val frac = dragFraction ?: return@derivedStateOf null
             val info = state.layoutInfo

--- a/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlin.math.roundToInt
 
 /**
@@ -68,12 +69,17 @@ fun OptimizedLineChart(
 ) {
     if (data.size < 2) return
 
+    val density = LocalDensity.current
+    // Text sizes in sp so labels respect density and the user's font scale.
+    val labelTextSizePx = with(density) { 10.sp.toPx() }
+    val chipTextSizePx = with(density) { 11.sp.toPx() }
+
     val surfaceColor = MaterialTheme.colorScheme.onSurface
     // Built once and reused across draws (the 800ms entrance redraws every frame).
-    val labelPaint = remember(surfaceColor) {
+    val labelPaint = remember(surfaceColor, labelTextSizePx) {
         android.graphics.Paint().apply {
             this.color = surfaceColor.copy(alpha = 0.7f).toArgb()
-            textSize = 26f
+            textSize = labelTextSizePx
             isAntiAlias = true
         }
     }
@@ -86,7 +92,6 @@ fun OptimizedLineChart(
     }
 
     // Pre-compute the smooth path and fill path
-    val density = LocalDensity.current
     val chartHeightPx = with(density) { chartHeight.toPx() }
     var canvasWidthPx by remember { mutableStateOf(0f) }
 
@@ -233,7 +238,7 @@ fun OptimizedLineChart(
                     val pts = chartData.displayPoints
                     val fraction = if (pts.size > 1) point.index.toFloat() / (pts.size - 1) else 0f
                     val timeStr = fractionToTimeLabel(fraction)
-                    drawFloatingTimeChip(timeStr, point.position.x, color, chartHeightPx, timeLabelHeightPx, width)
+                    drawFloatingTimeChip(timeStr, point.position.x, color, chartHeightPx, timeLabelHeightPx, width, chipTextSizePx)
                 }
             }
         }

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -45,8 +45,19 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlin.math.ceil
 import kotlin.math.roundToInt
+
+private val overlayDashEffect = PathEffect.dashPathEffect(floatArrayOf(12f, 10f))
+
+/** Pre-built render geometry for one curve, so paths aren't rebuilt on every draw frame. */
+private class RenderedCurve(
+    val curve: OverlayCurve,
+    val path: Path,
+    val fillPath: Path?,
+    val fillBrush: Brush?
+)
 
 /** One session's curve. [points] are (x, y). [dashed] draws it as a thin dashed reference line. */
 data class OverlayCurve(
@@ -104,11 +115,45 @@ fun PowerSocOverlayChart(
     // Parent bumps dismissKey (on an outside tap or a scroll) to clear the tooltip.
     LaunchedEffect(dismissKey) { selectedSoc = null }
 
-    val labelPaint = remember(labelColor) {
+    // Label size in sp so it respects density and the user's font scale.
+    val labelTextSizePx = with(density) { 10.sp.toPx() }
+    val labelPaint = remember(labelColor, labelTextSizePx) {
         android.graphics.Paint().apply {
             color = labelColor.toArgb()
-            textSize = 26f
+            textSize = labelTextSizePx
             isAntiAlias = true
+        }
+    }
+
+    // Curve geometry (paths, base fill + gradient brush) is rebuilt only when the data or
+    // canvas geometry changes — not on every draw frame during crosshair drags. The Canvas
+    // below fills the container, so containerWidthPx (tracked via onSizeChanged) is its width.
+    val renderedCurves = remember(renderCurves, containerWidthPx, socMin, socMax, powerMax, chartHeightPx) {
+        val w = containerWidthPx.toFloat()
+        if (w <= 0f) return@remember emptyList()
+        val plotH = chartHeightPx - topPad
+        fun xFor(soc: Float) = (soc - socMin) / socRange * w
+        fun yFor(power: Float) = topPad + (1f - power / powerMax) * plotH
+        renderCurves.map { c ->
+            val pts = c.points
+            val path = Path()
+            pts.forEachIndexed { idx, p ->
+                val px = xFor(p.x)
+                val py = yFor(p.y)
+                if (idx == 0) path.moveTo(px, py) else path.lineTo(px, py)
+            }
+            val fillPath = if (c.isBase) {
+                Path().apply {
+                    addPath(path)
+                    lineTo(xFor(pts.last().x), yFor(0f))
+                    lineTo(xFor(pts.first().x), yFor(0f))
+                    close()
+                }
+            } else null
+            val fillBrush = if (c.isBase) {
+                Brush.verticalGradient(listOf(c.color.copy(alpha = 0.25f), c.color.copy(alpha = 0f)))
+            } else null
+            RenderedCurve(c, path, fillPath, fillBrush)
         }
     }
 
@@ -165,35 +210,19 @@ fun PowerSocOverlayChart(
                 )
             }
 
-            // Curves — others first so the base draws on top (points pre-sorted above)
-            renderCurves.forEach { c ->
-                val pts = c.points
-                val path = Path()
-                pts.forEachIndexed { idx, p ->
-                    val px = xFor(p.x)
-                    val py = yFor(p.y)
-                    if (idx == 0) path.moveTo(px, py) else path.lineTo(px, py)
-                }
-                if (c.isBase) {
-                    val fill = Path().apply {
-                        addPath(path)
-                        lineTo(xFor(pts.last().x), yFor(0f))
-                        lineTo(xFor(pts.first().x), yFor(0f))
-                        close()
-                    }
-                    drawPath(
-                        fill,
-                        Brush.verticalGradient(listOf(c.color.copy(alpha = 0.25f), c.color.copy(alpha = 0f)))
-                    )
+            // Curves — others first so the base draws on top (geometry pre-built above)
+            renderedCurves.forEach { rc ->
+                if (rc.fillPath != null && rc.fillBrush != null) {
+                    drawPath(rc.fillPath, rc.fillBrush)
                 }
                 drawPath(
-                    path,
-                    c.color,
+                    rc.path,
+                    rc.curve.color,
                     style = Stroke(
-                        width = if (c.isBase) 7f else if (c.dashed) 3f else 4f,
+                        width = if (rc.curve.isBase) 7f else if (rc.curve.dashed) 3f else 4f,
                         cap = StrokeCap.Round,
                         join = StrokeJoin.Round,
-                        pathEffect = if (c.dashed) PathEffect.dashPathEffect(floatArrayOf(12f, 10f)) else null
+                        pathEffect = if (rc.curve.dashed) overlayDashEffect else null
                     )
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryScreen.kt
@@ -138,7 +138,7 @@ fun BatteryScreen(
                 if (uiState.isLoading && !uiState.isRefreshing) {
                     MateDroidLoadingPlaceholder(color = palette.accent)
                 } else {
-                    val stats = viewModel.computeStats()
+                    val stats = uiState.stats
                     if (stats != null) {
                         BatteryHealthContent(
                             stats = stats,
@@ -168,7 +168,7 @@ fun BatteryScreen(
             enter = slideInVertically(initialOffsetY = { it }),
             exit = slideOutVertically(targetOffsetY = { it })
         ) {
-            val stats = viewModel.computeStats()
+            val stats = uiState.stats
             if (stats != null) {
                 BatteryDetailScreen(
                     stats = stats,

--- a/app/src/main/java/com/matedroid/ui/screens/battery/BatteryViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/battery/BatteryViewModel.kt
@@ -24,7 +24,9 @@ data class BatteryUiState(
     val units: Units? = null,
     val originalCapacity: Double = 82.0, // Default for Model 3 LR, could be fetched from car details
     val ratedEfficiency: Double = 0.0,
-    val showDetail: Boolean = false
+    val showDetail: Boolean = false,
+    // Derived from batteryHealth/carStatus when they land, so composition never recomputes it
+    val stats: BatteryStats? = null
 )
 
 // Computed battery statistics
@@ -102,7 +104,7 @@ class BatteryViewModel @Inject constructor(
             when {
                 healthResult is ApiResult.Success && statusResult is ApiResult.Success -> {
                     _uiState.update {
-                        it.copy(
+                        val updated = it.copy(
                             isLoading = false,
                             isRefreshing = false,
                             batteryHealth = healthResult.data,
@@ -110,6 +112,7 @@ class BatteryViewModel @Inject constructor(
                             units = statusResult.data.units,
                             error = null
                         )
+                        updated.copy(stats = computeStats(updated))
                     }
                 }
                 healthResult is ApiResult.Error -> {
@@ -134,8 +137,7 @@ class BatteryViewModel @Inject constructor(
         }
     }
 
-    fun computeStats(): BatteryStats? {
-        val state = _uiState.value
+    private fun computeStats(state: BatteryUiState): BatteryStats? {
         val health = state.batteryHealth ?: return null
         val status = state.carStatus
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -200,9 +200,12 @@ private fun ChargeDetailContent(
     }
 
     // Chart time labels are shared by the primary power chart and the secondary charts.
+    // Remembered so crosshair-drag recompositions don't re-parse every point's date.
     val chargePoints = detail.chargePoints
-    val timeLabels = chargePoints?.takeIf { it.size > 2 }
-        ?.let { extractTimeLabels(it, is24Hour) } ?: emptyList()
+    val timeLabels = remember(chargePoints, is24Hour) {
+        chargePoints?.takeIf { it.size > 2 }
+            ?.let { extractTimeLabels(it, is24Hour) } ?: emptyList()
+    }
     val fractionToTimeLabel: (Float) -> String = label@{ fraction ->
         val cp = chargePoints
         if (cp == null || cp.size <= 2) return@label ""
@@ -243,7 +246,8 @@ private fun ChargeDetailContent(
 
         // Primary chart: power curve, accent-tinted by charge type (DC orange / AC green)
         val cp = chargePoints
-        if (cp != null && cp.size > 2 && cp.any { (it.chargerPower ?: 0) > 0 }) {
+        val hasPower = remember(cp) { cp?.any { (it.chargerPower ?: 0) > 0 } == true }
+        if (cp != null && cp.size > 2 && hasPower) {
             PowerChartCard(
                 chargePoints = cp,
                 timeLabels = timeLabels,
@@ -973,7 +977,7 @@ private fun PowerChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val powers = chargePoints.mapNotNull { it.chargerPower?.toFloat() }
+    val powers = remember(chargePoints) { chargePoints.mapNotNull { it.chargerPower?.toFloat() } }
     if (powers.size < 2) return
 
     ChartCard(
@@ -998,7 +1002,7 @@ private fun VoltageChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val voltages = chargePoints.mapNotNull { it.chargerVoltage?.toFloat() }
+    val voltages = remember(chargePoints) { chargePoints.mapNotNull { it.chargerVoltage?.toFloat() } }
     if (voltages.size < 2) return
 
     ChartCard(
@@ -1023,7 +1027,7 @@ private fun CurrentChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val currents = chargePoints.mapNotNull { it.chargerCurrent?.toFloat() }
+    val currents = remember(chargePoints) { chargePoints.mapNotNull { it.chargerCurrent?.toFloat() } }
     if (currents.size < 2) return
 
     ChartCard(
@@ -1049,13 +1053,16 @@ private fun TemperatureChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val temps = chargePoints.mapNotNull { it.outsideTemp?.toFloat() }
+    val temps = remember(chargePoints) { chargePoints.mapNotNull { it.outsideTemp?.toFloat() } }
     if (temps.size < 2) return
-    var yMin = kotlin.math.floor(temps.min())
-    var yMax = kotlin.math.ceil(temps.max())
-    if (yMin == yMax) {
-        yMin -= 1
-        yMax += 1
+    val fixedMinMax = remember(temps) {
+        var yMin = kotlin.math.floor(temps.min())
+        var yMax = kotlin.math.ceil(temps.max())
+        if (yMin == yMax) {
+            yMin -= 1
+            yMax += 1
+        }
+        Pair(yMin, yMax)
     }
     ChartCard(
         title = title,
@@ -1064,7 +1071,7 @@ private fun TemperatureChartCard(
         color = Color(0xFFFF9800),
         unit = UnitFormatter.getTemperatureUnit(units),
         timeLabels = timeLabels,
-        fixedMinMax = Pair(yMin, yMax),
+        fixedMinMax = fixedMinMax,
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,
         fractionToTimeLabel = fractionToTimeLabel
@@ -1081,13 +1088,16 @@ private fun BatteryChartCard(
     onXSelected: ((Float?) -> Unit)? = null,
     fractionToTimeLabel: ((Float) -> String)? = null
 ) {
-    val batteryLevels = chargePoints.mapNotNull { it.batteryLevel?.toFloat() }
+    val batteryLevels = remember(chargePoints) { chargePoints.mapNotNull { it.batteryLevel?.toFloat() } }
     if (batteryLevels.size < 2) return
-    var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
-    var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
-    if (yMin == yMax) {
-        yMin -= 1
-        yMax += 1
+    val fixedMinMax = remember(batteryLevels) {
+        var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
+        var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
+        if (yMin == yMax) {
+            yMin -= 1
+            yMax += 1
+        }
+        Pair(yMin, yMax)
     }
 
     ChartCard(
@@ -1096,7 +1106,7 @@ private fun BatteryChartCard(
         data = batteryLevels,
         color = color,
         unit = "%",
-        fixedMinMax = Pair(yMin, yMax),
+        fixedMinMax = fixedMinMax,
         timeLabels = timeLabels,
         externalSelectedFraction = externalSelectedFraction,
         onXSelected = onXSelected,

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailViewModel.kt
@@ -15,6 +15,8 @@ import com.matedroid.domain.LegRef
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -112,8 +114,11 @@ class ChargeDetailViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
 
             // Fetch charge detail and units in parallel
-            val detailResult = repository.getChargeDetail(carId, chargeId)
-            val statusResult = repository.getCarStatus(carId)
+            val (detailResult, statusResult) = coroutineScope {
+                val detail = async { repository.getChargeDetail(carId, chargeId) }
+                val status = async { repository.getCarStatus(carId) }
+                detail.await() to status.await()
+            }
 
             val units = when (statusResult) {
                 is ApiResult.Success -> statusResult.data.units

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -873,39 +873,41 @@ private fun ChargesChartPage(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        val barData = when (chartType) {
-            ChargesChartType.ENERGY -> chartData.map { data ->
-                BarChartData(
-                    label = data.label,
-                    value = data.totalEnergy,
-                    displayValue = "%.1f kWh".format(data.totalEnergy),
-                    segments = listOf(
-                        BarSegment(data.energyAc, palette.acColor, "AC"),
-                        BarSegment(data.energyDc, palette.dcColor, "DC")
+        val barData = remember(chartData, chartType, currencySymbol, palette) {
+            when (chartType) {
+                ChargesChartType.ENERGY -> chartData.map { data ->
+                    BarChartData(
+                        label = data.label,
+                        value = data.totalEnergy,
+                        displayValue = "%.1f kWh".format(data.totalEnergy),
+                        segments = listOf(
+                            BarSegment(data.energyAc, palette.acColor, "AC"),
+                            BarSegment(data.energyDc, palette.dcColor, "DC")
+                        )
                     )
-                )
-            }
-            ChargesChartType.COST -> chartData.map { data ->
-                BarChartData(
-                    label = data.label,
-                    value = data.totalCost,
-                    displayValue = "$currencySymbol%.2f".format(data.totalCost),
-                    segments = listOf(
-                        BarSegment(data.costAc, palette.acColor, "AC"),
-                        BarSegment(data.costDc, palette.dcColor, "DC")
+                }
+                ChargesChartType.COST -> chartData.map { data ->
+                    BarChartData(
+                        label = data.label,
+                        value = data.totalCost,
+                        displayValue = "$currencySymbol%.2f".format(data.totalCost),
+                        segments = listOf(
+                            BarSegment(data.costAc, palette.acColor, "AC"),
+                            BarSegment(data.costDc, palette.dcColor, "DC")
+                        )
                     )
-                )
-            }
-            ChargesChartType.COUNT -> chartData.map { data ->
-                BarChartData(
-                    label = data.label,
-                    value = data.count.toDouble(),
-                    displayValue = data.count.toString(),
-                    segments = listOf(
-                        BarSegment(data.countAc.toDouble(), palette.acColor, "AC"),
-                        BarSegment(data.countDc.toDouble(), palette.dcColor, "DC")
+                }
+                ChargesChartType.COUNT -> chartData.map { data ->
+                    BarChartData(
+                        label = data.label,
+                        value = data.count.toDouble(),
+                        displayValue = data.count.toString(),
+                        segments = listOf(
+                            BarSegment(data.countAc.toDouble(), palette.acColor, "AC"),
+                            BarSegment(data.countDc.toDouble(), palette.dcColor, "DC")
+                        )
                     )
-                )
+                }
             }
         }
 

--- a/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/CurrentChargeScreen.kt
@@ -289,10 +289,17 @@ private fun CurrentChargeContent(
             DcUnplugWarningBanner(dcFinishedSince = dcFinishedSince)
         }
 
-        // Charts - always show cards, even with few data points
-        val timeLabels = extractChronoTimeLabels(chronologicalPoints, is24Hour)
-        val powers = chronologicalPoints.mapNotNull { it.chargerPower?.toFloat() }
-        val batteryLevels = chronologicalPoints.mapNotNull { it.batteryLevel?.toFloat() }
+        // Charts - always show cards, even with few data points.
+        // Derivations are remembered so crosshair-drag recompositions don't recompute them.
+        val timeLabels = remember(chronologicalPoints, is24Hour) {
+            extractChronoTimeLabels(chronologicalPoints, is24Hour)
+        }
+        val powers = remember(chronologicalPoints) {
+            chronologicalPoints.mapNotNull { it.chargerPower?.toFloat() }
+        }
+        val batteryLevels = remember(chronologicalPoints) {
+            chronologicalPoints.mapNotNull { it.batteryLevel?.toFloat() }
+        }
         val fractionToTimeLabel: (Float) -> String = { fraction ->
             val pts = chronologicalPoints
             val index = (fraction * pts.lastIndex).roundToInt().coerceIn(0, pts.lastIndex)
@@ -308,17 +315,20 @@ private fun CurrentChargeContent(
             icon = Icons.Default.Bolt
         ) {
             if (powers.size >= 2) {
-                var yMin = kotlin.math.floor(powers.min())
-                var yMax = kotlin.math.ceil(powers.max())
-                if (yMin == yMax) {
-                    yMin -= 1
-                    yMax += 1
+                val fixedMinMax = remember(powers) {
+                    var yMin = kotlin.math.floor(powers.min())
+                    var yMax = kotlin.math.ceil(powers.max())
+                    if (yMin == yMax) {
+                        yMin -= 1
+                        yMax += 1
+                    }
+                    Pair(yMin, yMax)
                 }
                 FullscreenLineChart(
                     data = powers,
                     color = accentColor,
                     unit = "kW",
-                    fixedMinMax = Pair(yMin, yMax),
+                    fixedMinMax = fixedMinMax,
                     timeLabels = timeLabels,
                     externalSelectedFraction = sharedXFraction,
                     onXSelected = { sharedXFraction = it },
@@ -330,8 +340,12 @@ private fun CurrentChargeContent(
 
         // Voltage & Current combined chart (AC only)
         if (!isDcCharge) {
-            val voltages = chronologicalPoints.mapNotNull { it.chargerVoltage?.toFloat() }
-            val currents = chronologicalPoints.mapNotNull { it.chargerCurrent?.toFloat() }
+            val voltages = remember(chronologicalPoints) {
+                chronologicalPoints.mapNotNull { it.chargerVoltage?.toFloat() }
+            }
+            val currents = remember(chronologicalPoints) {
+                chronologicalPoints.mapNotNull { it.chargerCurrent?.toFloat() }
+            }
 
             val vcTitle = stringResource(R.string.voltage_and_current_profile)
             LiveChartCard(
@@ -363,17 +377,20 @@ private fun CurrentChargeContent(
             icon = Icons.Default.BatteryChargingFull
         ) {
             if (batteryLevels.size >= 2) {
-                var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
-                var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
-                if (yMin == yMax) {
-                    yMin -= 1
-                    yMax += 1
+                val fixedMinMax = remember(batteryLevels) {
+                    var yMin = (kotlin.math.floor(batteryLevels.min() / 10.0) * 10).toFloat()
+                    var yMax = (kotlin.math.ceil(batteryLevels.max() / 10.0) * 10).toFloat()
+                    if (yMin == yMax) {
+                        yMin -= 1
+                        yMax += 1
+                    }
+                    Pair(yMin, yMax)
                 }
                 FullscreenLineChart(
                     data = batteryLevels,
                     color = MaterialTheme.colorScheme.primary,
                     unit = "%",
-                    fixedMinMax = Pair(yMin, yMax),
+                    fixedMinMax = fixedMinMax,
                     timeLabels = timeLabels,
                     externalSelectedFraction = sharedXFraction,
                     onXSelected = { sharedXFraction = it },

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -120,12 +120,15 @@ import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asImageBitmap
@@ -996,23 +999,28 @@ private fun CarImage(
         }
     }
 
-    val bitmap = remember(assetPath) {
-        try {
-            context.assets.open(assetPath).use { inputStream ->
-                BitmapFactory.decodeStream(inputStream)
-            }
-        } catch (e: Exception) {
-            // Try fallback to default
+    // Decode off the main thread: this runs per pager swipe between cars
+    val bitmap = produceState<Bitmap?>(initialValue = null, assetPath) {
+        // Reset before decoding so a stale image never shows when the car changes
+        value = null
+        value = withContext(Dispatchers.Default) {
             try {
-                val fallbackPath = CarImageResolver.getDefaultAssetPath(carModel)
-                context.assets.open(fallbackPath).use { inputStream ->
+                context.assets.open(assetPath).use { inputStream ->
                     BitmapFactory.decodeStream(inputStream)
                 }
-            } catch (e2: Exception) {
-                null
+            } catch (e: Exception) {
+                // Try fallback to default
+                try {
+                    val fallbackPath = CarImageResolver.getDefaultAssetPath(carModel)
+                    context.assets.open(fallbackPath).use { inputStream ->
+                        BitmapFactory.decodeStream(inputStream)
+                    }
+                } catch (e2: Exception) {
+                    null
+                }
             }
         }
-    }
+    }.value
 
     // Glow radius in pixels
     val glowRadius = 70f
@@ -1037,18 +1045,22 @@ private fun CarImage(
     // Color subtly shifts between accent and a blend with AC/DC color
     val glowColor = androidx.compose.ui.graphics.lerp(accentColor, chargeTypeColor, breathProgress * 0.4f)
 
-    // Create single glow bitmap
-    val glowBitmap = remember(bitmap, isCharging) {
-        if (isCharging && bitmap != null) {
-            createGlowBitmap(
-                source = bitmap,
-                glowColor = Color.White,
-                glowRadius = glowRadius
-            )
+    // Create single glow bitmap — triple-blur render is expensive, keep it off the main thread
+    val glowBitmap = produceState<Bitmap?>(initialValue = null, bitmap, isCharging) {
+        // Reset so a stale glow never lingers over a different bitmap
+        value = null
+        value = if (isCharging && bitmap != null) {
+            withContext(Dispatchers.Default) {
+                createGlowBitmap(
+                    source = bitmap,
+                    glowColor = Color.White,
+                    glowRadius = glowRadius
+                )
+            }
         } else {
             null
         }
-    }
+    }.value
 
     // Calculate scale compensation for glow (glow bitmap is larger due to padding)
     val glowScaleCompensation = remember(bitmap, glowBitmap) {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/CompareDrivesScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -473,35 +472,41 @@ private fun LineOverlay(
         Color(0xFF5B8DD9), Color(0xFF4CAF50), Color(0xFF9B6BD9), Color(0xFF6D7A92)
     )
     val thisDriveLabel = stringResource(R.string.compare_this_drive)
+    val averageLabel = stringResource(R.string.compare_average)
+    val averageColor = MaterialTheme.colorScheme.onSurfaceVariant
 
-    var otherIndex = 0
-    val overlay = curves.map { sessionCurve ->
-        val meta = byId[sessionCurve.driveId]
-        val color = if (sessionCurve.isBase) palette.accent else otherColors[otherIndex++ % otherColors.size]
-        val label = if (sessionCurve.isBase) {
-            thisDriveLabel
-        } else {
-            meta?.startDate?.let { parseIsoDateTime(it)?.toLocalDate()?.formatMedium(Locale.getDefault()) } ?: ""
+    // Curve point lists hold thousands of Offsets — build them once per data/palette change,
+    // not on every recomposition (e.g. while a tooltip is being dragged).
+    val allOverlay = remember(curves, averageCurve, palette, comparison) {
+        var otherIndex = 0
+        val overlay = curves.map { sessionCurve ->
+            val meta = byId[sessionCurve.driveId]
+            val color = if (sessionCurve.isBase) palette.accent else otherColors[otherIndex++ % otherColors.size]
+            val label = if (sessionCurve.isBase) {
+                thisDriveLabel
+            } else {
+                meta?.startDate?.let { parseIsoDateTime(it)?.toLocalDate()?.formatMedium(Locale.getDefault()) } ?: ""
+            }
+            OverlayCurve(
+                label = label,
+                color = color,
+                isBase = sessionCurve.isBase,
+                points = sessionCurve.points.map { Offset(it.distance, it.value) }
+            )
         }
-        OverlayCurve(
-            label = label,
-            color = color,
-            isBase = sessionCurve.isBase,
-            points = sessionCurve.points.map { Offset(it.distance, it.value) }
-        )
+        val averageOverlay = averageCurve.takeIf { it.isNotEmpty() }?.let { avg ->
+            OverlayCurve(
+                label = averageLabel,
+                color = averageColor,
+                isBase = false,
+                points = avg.map { Offset(it.distance, it.value) },
+                dashed = true
+            )
+        }
+        overlay + listOfNotNull(averageOverlay)
     }
-    val averageOverlay = averageCurve.takeIf { it.isNotEmpty() }?.let { avg ->
-        OverlayCurve(
-            label = stringResource(R.string.compare_average),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            isBase = false,
-            points = avg.map { Offset(it.distance, it.value) },
-            dashed = true
-        )
-    }
-    val allOverlay = overlay + listOfNotNull(averageOverlay)
 
-    if (overlay.isEmpty()) {
+    if (curves.isEmpty()) {
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -199,6 +199,9 @@ private fun DriveDetailContent(
     val timeLabels = remember(positions) {
         if (hasCharts) extractTimeLabels(positions!!, is24Hour) else emptyList()
     }
+    val hasSpeedData = remember(positions) {
+        hasCharts && positions!!.any { it.speed != null }
+    }
     val fractionToTimeLabel: (Float) -> String = remember(positions) {
         label@{ fraction: Float ->
             val pos = positions
@@ -230,9 +233,9 @@ private fun DriveDetailContent(
         }
 
         // Primary chart: speed profile, accent-tinted
-        if (hasCharts && positions!!.any { it.speed != null }) {
+        if (hasSpeedData) {
             SpeedChartCard(
-                positions = positions,
+                positions = positions!!,
                 units = units,
                 color = palette.accent,
                 timeLabels = timeLabels,
@@ -669,7 +672,10 @@ private fun DriveMoreDetails(
                         onXSelected = onXSelected,
                         fractionToTimeLabel = fractionToTimeLabel
                     )
-                    if (positions.any { it.elevation != null && it.elevation != 0 }) {
+                    val hasElevationData = remember(positions) {
+                        positions.any { it.elevation != null && it.elevation != 0 }
+                    }
+                    if (hasElevationData) {
                         ElevationChartCard(
                             positions = positions,
                             timeLabels = timeLabels,
@@ -688,7 +694,9 @@ private fun DriveMoreDetails(
 private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
     val context = LocalContext.current
     val routeColorArgb = routeColor.toArgb()
-    val validPositions = positions.filter { it.latitude != null && it.longitude != null }
+    val validPositions = remember(positions) {
+        positions.filter { it.latitude != null && it.longitude != null }
+    }
 
     if (validPositions.isEmpty()) return
 

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DrivesScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -83,8 +84,10 @@ import com.matedroid.util.formatDurationCompact
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import java.time.LocalDate
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
 fun DrivesScreen(
     carId: Int,
@@ -109,12 +112,11 @@ fun DrivesScreen(
         viewModel.setCarId(carId)
     }
 
-    // Save scroll position when it changes
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-        viewModel.saveScrollPosition(
-            listState.firstVisibleItemIndex,
-            listState.firstVisibleItemScrollOffset
-        )
+    // Save scroll position when it changes (debounced so we don't emit per scrolled pixel)
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .debounce(200)
+            .collect { (index, offset) -> viewModel.saveScrollPosition(index, offset) }
     }
 
     LaunchedEffect(uiState.error) {

--- a/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/mileage/MileageScreen.kt
@@ -275,7 +275,7 @@ private fun YearOverviewContent(
         }
 
         // Year list
-        items(uiState.yearlyData, contentType = { "year" }) { yearData ->
+        items(uiState.yearlyData, key = { it.year }, contentType = { "year" }) { yearData ->
             YearRow(
                 yearData = yearData,
                 units = uiState.units,
@@ -508,7 +508,7 @@ private fun YearDetailScreen(
             }
 
             // Monthly list
-            items(uiState.monthlyData, contentType = { "month" }) { monthData ->
+            items(uiState.monthlyData, key = { it.yearMonth.toString() }, contentType = { "month" }) { monthData ->
                 MonthRow(
                     monthData = monthData,
                     units = uiState.units,
@@ -768,7 +768,7 @@ private fun MonthDetailScreen(
                 }
 
                 // Daily trip rows
-                items(dailyData, contentType = { "day" }) { dayData ->
+                items(dailyData, key = { it.date.toString() }, contentType = { "day" }) { dayData ->
                     DayTripRow(
                         dayData = dayData,
                         units = units,
@@ -1428,7 +1428,7 @@ private fun DayDetailScreen(
                 }
 
                 // Drive rows
-                items(dayData.drives, contentType = { "drive" }) { drive ->
+                items(dayData.drives, key = { it.driveId }, contentType = { "drive" }) { drive ->
                     DriveRow(
                         drive = drive,
                         units = units,

--- a/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -123,7 +124,9 @@ fun SentryHistoryScreen(
     onNavigateBack: () -> Unit = {},
     viewModel: SentryHistoryViewModel = hiltViewModel()
 ) {
-    viewModel.setCarId(carId)
+    LaunchedEffect(carId) {
+        viewModel.setCarId(carId)
+    }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isDarkTheme = isSystemInDarkTheme()
     val palette = CarColorPalettes.forExteriorColor(exteriorColor, isDarkTheme)

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedViewModel.kt
@@ -57,39 +57,14 @@ data class RegionsVisitedUiState(
     val availableYears: List<Int> = emptyList(),    // Years with data in this country
     val selectedMapYear: Int? = null,                // null = all years
     val sortOrder: GeoSortOrder = GeoSortOrder.FIRST_VISIT,
-    val error: String? = null
-) {
+    // Precomputed by the ViewModel whenever the source lists or filters change,
+    // so composition reads don't re-filter the full lists
     /** Charges filtered by type and year for map display */
-    val filteredChargeLocations: List<ChargeLocation>
-        get() {
-            var filtered = chargeLocations
-
-            // Filter by year if selected
-            if (selectedMapYear != null) {
-                filtered = filtered.filter { charge ->
-                    charge.date.take(4).toIntOrNull() == selectedMapYear
-                }
-            }
-
-            // Filter by charge type
-            filtered = when (chargeTypeFilter) {
-                ChargeTypeFilter.ALL -> filtered
-                ChargeTypeFilter.AC_ONLY -> filtered.filter { !it.isDcCharge }
-                ChargeTypeFilter.DC_ONLY -> filtered.filter { it.isDcCharge }
-            }
-
-            return filtered
-        }
-
+    val filteredChargeLocations: List<ChargeLocation> = emptyList(),
     /** Drives filtered by year for map display */
-    val filteredDriveLocations: List<DriveLocation>
-        get() {
-            if (selectedMapYear == null) return driveLocations
-            return driveLocations.filter { drive ->
-                drive.date.take(4).toIntOrNull() == selectedMapYear
-            }
-        }
-}
+    val filteredDriveLocations: List<DriveLocation> = emptyList(),
+    val error: String? = null
+)
 
 @HiltViewModel
 class RegionsVisitedViewModel @Inject constructor(
@@ -143,7 +118,7 @@ class RegionsVisitedViewModel @Inject constructor(
                         driveLocations = driveLocations,
                         availableYears = availableYears,
                         error = null
-                    )
+                    ).withFilteredLocations()
                 }
 
                 // Fetch country boundary asynchronously (non-blocking)
@@ -185,12 +160,44 @@ class RegionsVisitedViewModel @Inject constructor(
             } else {
                 filter
             }
-            current.copy(chargeTypeFilter = newFilter)
+            current.copy(chargeTypeFilter = newFilter).withFilteredLocations()
         }
     }
 
     fun setMapYearFilter(year: Int?) {
-        _uiState.update { it.copy(selectedMapYear = year) }
+        _uiState.update { it.copy(selectedMapYear = year).withFilteredLocations() }
+    }
+
+    /** Recompute the filtered map locations from the current source lists and filters. */
+    private fun RegionsVisitedUiState.withFilteredLocations(): RegionsVisitedUiState {
+        var filteredCharges = chargeLocations
+
+        // Filter by year if selected
+        if (selectedMapYear != null) {
+            filteredCharges = filteredCharges.filter { charge ->
+                charge.date.take(4).toIntOrNull() == selectedMapYear
+            }
+        }
+
+        // Filter by charge type
+        filteredCharges = when (chargeTypeFilter) {
+            ChargeTypeFilter.ALL -> filteredCharges
+            ChargeTypeFilter.AC_ONLY -> filteredCharges.filter { !it.isDcCharge }
+            ChargeTypeFilter.DC_ONLY -> filteredCharges.filter { it.isDcCharge }
+        }
+
+        val filteredDrives = if (selectedMapYear == null) {
+            driveLocations
+        } else {
+            driveLocations.filter { drive ->
+                drive.date.take(4).toIntOrNull() == selectedMapYear
+            }
+        }
+
+        return copy(
+            filteredChargeLocations = filteredCharges,
+            filteredDriveLocations = filteredDrives
+        )
     }
 
     private fun sortRegions(

--- a/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/StatsScreen.kt
@@ -58,7 +58,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -137,11 +140,14 @@ fun StatsScreen(
         viewModel.setCarId(carId)
     }
 
-    // Periodic sync every 60 seconds while the screen is visible
-    LaunchedEffect(Unit) {
-        while (true) {
-            kotlinx.coroutines.delay(60_000L) // Wait 60 seconds
-            viewModel.triggerSync()
+    // Periodic sync every 60 seconds, only while the screen is actually visible
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            while (true) {
+                kotlinx.coroutines.delay(60_000L) // Wait 60 seconds
+                viewModel.triggerSync()
+            }
         }
     }
 
@@ -782,114 +788,134 @@ private fun RecordsCard(
     val categoryMisc = stringResource(R.string.stats_category_misc)
     val gapTypeCharging = stringResource(R.string.gap_type_charging)
     val gapTypeDriving = stringResource(R.string.gap_type_driving)
+    val valueNotAvailable = stringResource(R.string.value_not_available)
+    // Data-dependent strings resolved here because stringResource is composable and
+    // cannot be called inside the remember block below
+    val valueLongestStreak = quickStats.longestDrivingStreak?.let { stringResource(R.string.format_days_count, it.streakDays) }
+    val valueBusiestDay = quickStats.busiestDay?.let { stringResource(R.string.format_drives_count, it.count) }
+    val valueCountriesVisited = deepStats?.countriesVisitedCount?.let { pluralStringResource(R.plurals.format_countries_count, it, it) }
+    val valueGapCharging = quickStats.longestGapWithoutCharging?.let { stringResource(R.string.format_days, it.gapDays) }
+    val valueGapDriving = quickStats.longestGapWithoutDriving?.let { stringResource(R.string.format_days, it.gapDays) }
 
-    // Category 1: Drives
-    val driveRecords = mutableListOf<RecordData>()
-    quickStats.longestDrive?.let { drive ->
-        driveRecords.add(RecordData("📏", labelLongestDrive, UnitFormatter.formatDistance(drive.distance, units), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
-    }
-    quickStats.fastestDrive?.let { drive ->
-        driveRecords.add(RecordData("🏎️", labelTopSpeed, UnitFormatter.formatSpeed(drive.speedMax.toDouble(), units), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
-    }
-    quickStats.mostEfficientDrive?.let { drive ->
-        driveRecords.add(RecordData("🌱", labelMostEfficient, UnitFormatter.formatEfficiency(drive.efficiency ?: 0.0, units, 0), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
-    }
-    quickStats.longestDrivingStreak?.let { streak ->
-        driveRecords.add(RecordData("🔥", labelLongestStreak, stringResource(R.string.format_days_count, streak.streakDays), "${streak.startDate} → ${streak.endDate}", null))
-    }
-    quickStats.busiestDay?.let { day ->
-        driveRecords.add(RecordData("📅", labelBusiestDay, stringResource(R.string.format_drives_count, day.count), day.day) { onDayClick(day.day) })
-    }
-    deepStats?.countriesVisitedCount?.let { count ->
-        driveRecords.add(RecordData("🌍", labelCountriesVisited, pluralStringResource(R.plurals.format_countries_count, count, count), "") { onCountriesVisitedClick() })
-    }
-
-    // Category 2: Battery
-    val batteryRecords = mutableListOf<RecordData>()
-    quickStats.biggestBatteryGainCharge?.let { record ->
-        batteryRecords.add(RecordData("🔋", labelBiggestGain, "+${record.percentChange}%", "${record.startLevel}% → ${record.endLevel}%") { onChargeClick(record.recordId) })
-    }
-    quickStats.biggestBatteryDrainDrive?.let { record ->
-        batteryRecords.add(RecordData("📉", labelBiggestDrain, "-${record.percentChange}%", "${record.startLevel}% → ${record.endLevel}%") { onDriveClick(record.recordId) })
-    }
-    quickStats.biggestCharge?.let { charge ->
-        batteryRecords.add(RecordData("⚡", labelBiggestCharge, "%.0f kWh".format(charge.energyAdded), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
-    }
-    deepStats?.chargeWithMaxPower?.let { record ->
-        batteryRecords.add(RecordData("⚡", labelPeakPower, "${record.powerKw} kW", record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
-    }
-    quickStats.mostExpensiveCharge?.let { charge ->
-        charge.cost?.let { cost ->
-            batteryRecords.add(RecordData("💸", labelMostExpensive, UnitFormatter.formatCost(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+    // Records and paging are pure derivations of the stats — rebuild only when inputs change,
+    // not on every pager swipe recomposition
+    val pages = remember(quickStats, deepStats, units, currencySymbol) {
+        // Category 1: Drives
+        val driveRecords = mutableListOf<RecordData>()
+        quickStats.longestDrive?.let { drive ->
+            driveRecords.add(RecordData("📏", labelLongestDrive, UnitFormatter.formatDistance(drive.distance, units), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
         }
-    }
-    quickStats.mostExpensivePerKwhCharge?.let { charge ->
-        charge.cost?.let { cost ->
-            if (charge.energyAdded > 0) {
-                batteryRecords.add(RecordData("📈", labelPriciestKwh, UnitFormatter.formatCost(cost / charge.energyAdded, currencySymbol, perKwh = true), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+        quickStats.fastestDrive?.let { drive ->
+            driveRecords.add(RecordData("🏎️", labelTopSpeed, UnitFormatter.formatSpeed(drive.speedMax.toDouble(), units), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
+        }
+        quickStats.mostEfficientDrive?.let { drive ->
+            driveRecords.add(RecordData("🌱", labelMostEfficient, UnitFormatter.formatEfficiency(drive.efficiency ?: 0.0, units, 0), drive.startDate.take(10)) { onDriveClick(drive.driveId) })
+        }
+        quickStats.longestDrivingStreak?.let { streak ->
+            driveRecords.add(RecordData("🔥", labelLongestStreak, valueLongestStreak ?: "", "${streak.startDate} → ${streak.endDate}", null))
+        }
+        quickStats.busiestDay?.let { day ->
+            driveRecords.add(RecordData("📅", labelBusiestDay, valueBusiestDay ?: "", day.day) { onDayClick(day.day) })
+        }
+        deepStats?.countriesVisitedCount?.let {
+            driveRecords.add(RecordData("🌍", labelCountriesVisited, valueCountriesVisited ?: "", "") { onCountriesVisitedClick() })
+        }
+
+        // Category 2: Battery
+        val batteryRecords = mutableListOf<RecordData>()
+        quickStats.biggestBatteryGainCharge?.let { record ->
+            batteryRecords.add(RecordData("🔋", labelBiggestGain, "+${record.percentChange}%", "${record.startLevel}% → ${record.endLevel}%") { onChargeClick(record.recordId) })
+        }
+        quickStats.biggestBatteryDrainDrive?.let { record ->
+            batteryRecords.add(RecordData("📉", labelBiggestDrain, "-${record.percentChange}%", "${record.startLevel}% → ${record.endLevel}%") { onDriveClick(record.recordId) })
+        }
+        quickStats.biggestCharge?.let { charge ->
+            batteryRecords.add(RecordData("⚡", labelBiggestCharge, "%.0f kWh".format(charge.energyAdded), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+        }
+        deepStats?.chargeWithMaxPower?.let { record ->
+            batteryRecords.add(RecordData("⚡", labelPeakPower, "${record.powerKw} kW", record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
+        }
+        quickStats.mostExpensiveCharge?.let { charge ->
+            charge.cost?.let { cost ->
+                batteryRecords.add(RecordData("💸", labelMostExpensive, UnitFormatter.formatCost(cost, currencySymbol), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
             }
         }
+        quickStats.mostExpensivePerKwhCharge?.let { charge ->
+            charge.cost?.let { cost ->
+                if (charge.energyAdded > 0) {
+                    batteryRecords.add(RecordData("📈", labelPriciestKwh, UnitFormatter.formatCost(cost / charge.energyAdded, currencySymbol, perKwh = true), charge.startDate.take(10)) { onChargeClick(charge.chargeId) })
+                }
+            }
+        }
+
+        // Category 3: Weather & Altitude
+        val weatherRecords = mutableListOf<RecordData>()
+        deepStats?.driveWithMaxElevation?.let { record ->
+            weatherRecords.add(RecordData("🏔️", labelHighestPoint, UnitFormatter.formatElevation(record.elevationM, units), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
+        }
+        deepStats?.driveWithMostClimbing?.let { record ->
+            weatherRecords.add(RecordData("⛰️", labelMostClimbing, record.elevationGainM?.let { "+" + UnitFormatter.formatElevation(it, units) } ?: valueNotAvailable, record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
+        }
+        deepStats?.hottestDrive?.let { record ->
+            weatherRecords.add(RecordData("🌡️", labelHottestDrive, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
+        }
+        deepStats?.coldestDrive?.let { record ->
+            weatherRecords.add(RecordData("🧊", labelColdestDrive, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
+        }
+        deepStats?.hottestCharge?.let { record ->
+            weatherRecords.add(RecordData("☀️", labelHottestCharge, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
+        }
+        deepStats?.coldestCharge?.let { record ->
+            weatherRecords.add(RecordData("❄️", labelColdestCharge, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
+        }
+
+        // Category 4: Miscelaneous
+        val miscRecords = mutableListOf<RecordData>()
+        quickStats.maxDistanceBetweenCharges?.let { record ->
+            miscRecords.add(RecordData("🔋", labelLongestRange, UnitFormatter.formatDistance(record.distance, units), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
+        }
+        quickStats.longestGapWithoutCharging?.let { gap ->
+            miscRecords.add(RecordData("⏰", labelNoCharging, valueGapCharging ?: "", "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeCharging) })
+        }
+        quickStats.longestGapWithoutDriving?.let { gap ->
+            miscRecords.add(RecordData("🅿️", labelNoDriving, valueGapDriving ?: "", "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeDriving) })
+        }
+        quickStats.mostDistanceDay?.let { day ->
+            miscRecords.add(RecordData("🛣️", labelMostDistanceDay, UnitFormatter.formatDistance(day.totalDistance, units), day.day) { onDayClick(day.day) })
+        }
+
+        // Build list of all categories with their records
+        data class CategoryData(val title: String, val emoji: String, val records: List<RecordData>)
+        val allCategories = mutableListOf<CategoryData>()
+        if (driveRecords.isNotEmpty()) allCategories.add(CategoryData(categoryDrives, "🚗", driveRecords))
+        if (batteryRecords.isNotEmpty()) allCategories.add(CategoryData(categoryBattery, "🔋", batteryRecords))
+        if (weatherRecords.isNotEmpty()) allCategories.add(CategoryData(categoryWeather, "🌡️", weatherRecords))
+        if (miscRecords.isNotEmpty()) allCategories.add(CategoryData(categoryMisc, "📍", miscRecords))
+
+        // Split categories into pages of max RECORDS_PER_PAGE records each
+        val recordPages = mutableListOf<RecordPage>()
+        allCategories.forEach { category ->
+            val chunks = category.records.chunked(RECORDS_PER_PAGE)
+            chunks.forEachIndexed { index, chunk ->
+                recordPages.add(RecordPage(
+                    categoryTitle = category.title,
+                    categoryEmoji = category.emoji,
+                    records = chunk,
+                    pageIndex = index,
+                    totalPagesInCategory = chunks.size
+                ))
+            }
+        }
+        recordPages
     }
 
-    // Category 3: Weather & Altitude
-    val weatherRecords = mutableListOf<RecordData>()
-    deepStats?.driveWithMaxElevation?.let { record ->
-        weatherRecords.add(RecordData("🏔️", labelHighestPoint, UnitFormatter.formatElevation(record.elevationM, units), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
-    }
-    deepStats?.driveWithMostClimbing?.let { record ->
-        weatherRecords.add(RecordData("⛰️", labelMostClimbing, record.elevationGainM?.let { "+" + UnitFormatter.formatElevation(it, units) } ?: stringResource(R.string.value_not_available), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
-    }
-    deepStats?.hottestDrive?.let { record ->
-        weatherRecords.add(RecordData("🌡️", labelHottestDrive, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
-    }
-    deepStats?.coldestDrive?.let { record ->
-        weatherRecords.add(RecordData("🧊", labelColdestDrive, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onDriveClick(record.driveId) })
-    }
-    deepStats?.hottestCharge?.let { record ->
-        weatherRecords.add(RecordData("☀️", labelHottestCharge, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
-    }
-    deepStats?.coldestCharge?.let { record ->
-        weatherRecords.add(RecordData("❄️", labelColdestCharge, UnitFormatter.formatTemperature(record.tempC, units, 1), record.date?.take(10) ?: "") { onChargeClick(record.chargeId) })
-    }
+    // Don't render anything if no categories produced records
+    if (pages.isEmpty()) return
 
-    // Category 4: Miscelaneous
-    val miscRecords = mutableListOf<RecordData>()
-    quickStats.maxDistanceBetweenCharges?.let { record ->
-        miscRecords.add(RecordData("🔋", labelLongestRange, UnitFormatter.formatDistance(record.distance, units), "${record.fromDate.take(10)} → ${record.toDate.take(10)}") { onRangeRecordClick(record) })
-    }
-    quickStats.longestGapWithoutCharging?.let { gap ->
-        miscRecords.add(RecordData("⏰", labelNoCharging, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeCharging) })
-    }
-    quickStats.longestGapWithoutDriving?.let { gap ->
-        miscRecords.add(RecordData("🅿️", labelNoDriving, stringResource(R.string.format_days, gap.gapDays), "${gap.fromDate.take(10)} → ${gap.toDate.take(10)}") { onGapRecordClick(gap.gapDays, gap.fromDate, gap.toDate, gapTypeDriving) })
-    }
-    quickStats.mostDistanceDay?.let { day ->
-        miscRecords.add(RecordData("🛣️", labelMostDistanceDay, UnitFormatter.formatDistance(day.totalDistance, units), day.day) { onDayClick(day.day) })
-    }
-
-    // Build list of all categories with their records
-    data class CategoryData(val title: String, val emoji: String, val records: List<RecordData>)
-    val allCategories = mutableListOf<CategoryData>()
-    if (driveRecords.isNotEmpty()) allCategories.add(CategoryData(categoryDrives, "🚗", driveRecords))
-    if (batteryRecords.isNotEmpty()) allCategories.add(CategoryData(categoryBattery, "🔋", batteryRecords))
-    if (weatherRecords.isNotEmpty()) allCategories.add(CategoryData(categoryWeather, "🌡️", weatherRecords))
-    if (miscRecords.isNotEmpty()) allCategories.add(CategoryData(categoryMisc, "📍", miscRecords))
-
-    // Don't render anything if no categories
-    if (allCategories.isEmpty()) return
-
-    // Split categories into pages of max RECORDS_PER_PAGE records each
-    val pages = mutableListOf<RecordPage>()
-    allCategories.forEach { category ->
-        val chunks = category.records.chunked(RECORDS_PER_PAGE)
-        chunks.forEachIndexed { index, chunk ->
-            pages.add(RecordPage(
-                categoryTitle = category.title,
-                categoryEmoji = category.emoji,
-                records = chunk,
-                pageIndex = index,
-                totalPagesInCategory = chunks.size
-            ))
+    // Category summaries for the page indicator (pages are grouped per category, in order)
+    val categorySummaries = remember(pages) {
+        pages.groupBy { it.categoryTitle }.map { (title, categoryPages) ->
+            Triple(title, categoryPages.first().categoryEmoji, categoryPages.size)
         }
     }
 
@@ -906,7 +932,7 @@ private fun RecordsCard(
     )
 
 // Update selected category when page changes
-    LaunchedEffect(pagerState.currentPage) {
+    LaunchedEffect(pagerState, pages) {
         snapshotFlow { pagerState.currentPage }
             .collect { page ->
                 if (page < pages.size) {
@@ -962,8 +988,7 @@ private fun RecordsCard(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     var pageOffset = 0
-                    allCategories.forEach { category ->
-                        val categoryPageCount = (category.records.size + RECORDS_PER_PAGE - 1) / RECORDS_PER_PAGE
+                    categorySummaries.forEach { (categoryTitle, categoryEmoji, categoryPageCount) ->
                         val isCurrentCategory = pagerState.currentPage >= pageOffset &&
                                 pagerState.currentPage < pageOffset + categoryPageCount
                         val currentPageInCategory = if (isCurrentCategory) pagerState.currentPage - pageOffset else -1
@@ -980,13 +1005,13 @@ private fun RecordsCard(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
-                                text = category.emoji,
+                                text = categoryEmoji,
                                 style = MaterialTheme.typography.bodySmall
                             )
                             if (isCurrentCategory) {
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text(
-                                    text = category.title,
+                                    text = categoryTitle,
                                     style = MaterialTheme.typography.labelSmall,
                                     color = palette.accent,
                                     fontWeight = FontWeight.Bold
@@ -1640,7 +1665,7 @@ private fun RangeRecordDialog(
                             modifier = Modifier.fillMaxSize(),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            items(drives) { drive ->
+                            items(drives, key = { it.driveId }) { drive ->
                                 DriveListItem(
                                     drive = drive,
                                     palette = palette,

--- a/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/AddLegSheet.kt
@@ -123,7 +123,7 @@ fun AddLegSheet(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(bottom = 24.dp)
                 ) {
-                    items(merged) { candidate ->
+                    items(merged, key = { it.toRef().let { ref -> "${ref.type}:${ref.id}" } }) { candidate ->
                         val ref = candidate.toRef()
                         CandidateRow(
                             candidate = candidate,

--- a/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/MergeTripSheet.kt
@@ -86,7 +86,7 @@ fun MergeTripSheet(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(bottom = 24.dp)
                 ) {
-                    items(adjacentTrips) { (id, trip) ->
+                    items(adjacentTrips, key = { it.first }) { (id, trip) ->
                         AdjacentTripRow(
                             trip = trip,
                             units = units,

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -377,12 +377,14 @@ private fun MonthlyUpdatesChart(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            val chartData = monthlyData.map { data ->
-                BarChartData(
-                    label = data.yearMonth.format(DateTimeFormatter.ofPattern("MMM", Locale.getDefault())),
-                    value = data.count.toDouble(),
-                    displayValue = updatesFormat.format(data.count)
-                )
+            val chartData = remember(monthlyData, updatesFormat) {
+                monthlyData.map { data ->
+                    BarChartData(
+                        label = data.yearMonth.format(DateTimeFormatter.ofPattern("MMM", Locale.getDefault())),
+                        value = data.count.toDouble(),
+                        displayValue = updatesFormat.format(data.count)
+                    )
+                }
             }
 
             InteractiveBarChart(


### PR DESCRIPTION
Fifth and final cluster from the full-repo code review — Compose/chart performance. No visual or behavioral changes, with one deliberate exception: native-canvas chart text is now sized in sp instead of raw px, so it scales with density and the accessibility font setting.

- **Crosshair-drag storms**: charge/drive detail and live-charge screens re-parsed every ISO timestamp and re-extracted 4–5 data series on every drag frame; all derivations are now `remember`ed keyed on the data.
- **Chart draw paths**: cached chip `Paint`s/gradient `Brush`es in `ChartDrawUtils`, pre-built curve `Path`s in `PowerSocOverlayChart` (was re-tessellating every curve per frame), 64-entry text-measure cache in `InteractiveBarChart`, remembered comparison overlays in `CompareDrivesScreen`.
- **Main-thread bitmap work**: dashboard car PNG decode + triple-blur glow render moved to `produceState` on a background dispatcher (removes the jank when swiping between cars), car-picker wheel decodes on IO, charging-notification car bitmap memoized in the singleton (was decoding from assets every 30 s).
- **Screen-level churn**: drives scroll position saved via debounced `snapshotFlow` (was a state emission per scrolled pixel), Stats `RecordsCard` pages remembered (was rebuilding ~25 records per swipe), Stats 60 s auto-sync gated on `repeatOnLifecycle(STARTED)`, battery stats computed in the ViewModel instead of twice per recomposition, `MonthScrollIndicator` no longer does O(items) date parses per drag frame, `TripDetector` sorts by raw ISO string instead of parsing inside the comparator, `ChargeDetail`/`Battery` fetches actually parallel, missing LazyColumn keys added (Mileage, Stats dialog, trip sheets).

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)