### PR TITLE
Background-work hygiene: idle backoff, self-stopping chains, honest sync failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Chart labels now respect the system font size** — axis and tooltip text in the native charts was sized in raw pixels; it now scales with display density and the accessibility font setting.
 - **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.
 
+### Changed (battery & background work)
+- **Background polling now backs off when nothing is happening** — the 30-second charging/sentry check drops to every 5 minutes while no car is charging, plugged in, or sentry-armed, and stops entirely when no server is configured. It returns to 30 seconds as soon as a charge or sentry session could start.
+- **The widget updater stops itself when no widgets are on the launcher** instead of polling forever.
+- **Location lookups back off when the geocoding service is unreachable** instead of retrying the whole queue at full speed on every sync.
+- **A sync with failed drive/charge details now reports the failure and retries them** instead of pretending everything synced.
+
 ### Fixed
 - **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.
 - **Drive comparison curves are correct again for miles/imperial users** — the compare-drives overlay was applying a km→miles conversion to speeds the API had already converted (curves plotted ~40% low), and its energy estimate mixed km distances with mph speeds, skewing the consumption ranking.

--- a/app/src/main/java/com/matedroid/MateDroidApp.kt
+++ b/app/src/main/java/com/matedroid/MateDroidApp.kt
@@ -82,7 +82,8 @@ class MateDroidApp : Application(), Configuration.Provider {
 
     /**
      * Enqueue background sync work.
-     * Uses KEEP policy to not restart if already running.
+     * Uses REPLACE so a stuck/backoff-waiting worker gets a fresh start on every app open;
+     * an interrupted sync loses little (unprocessed-ID queries resume where it left off).
      */
     private fun enqueueSyncWork() {
         val constraints = Constraints.Builder()

--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -54,14 +54,19 @@ class ChargingNotificationWorker @AssistedInject constructor(
 
         private const val INTERVAL_SECONDS = 30L
 
+        // Idle cadence: nothing is charging, plugged in, or sentry-armed, so the only job is
+        // discovering a new charge/sentry session — 5 min keeps that latency acceptable while
+        // cutting idle polling 10×. The dashboard's own 5 s poll covers the app-open case.
+        private const val IDLE_INTERVAL_SECONDS = 300L
+
         /**
          * Schedule charging/sentry notification monitoring.
          *
          * Uses two strategies:
-         * 1. Self-rescheduling OneTimeWorkRequest for frequent checks (30s)
+         * 1. Self-rescheduling OneTimeWorkRequest for frequent checks (30s active / 5min idle)
          * 2. PeriodicWorkRequest (15min) as reliable fallback when app is killed
          */
-        fun schedulePeriodicWork(context: Context) {
+        fun schedulePeriodicWork(context: Context, intervalSeconds: Long = INTERVAL_SECONDS) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -69,7 +74,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
             // Strategy 1: OneTimeWorkRequest with delay for frequent checks
             val oneTimeRequest = OneTimeWorkRequestBuilder<ChargingNotificationWorker>()
                 .setConstraints(constraints)
-                .setInitialDelay(INTERVAL_SECONDS, TimeUnit.SECONDS)
+                .setInitialDelay(intervalSeconds, TimeUnit.SECONDS)
                 .addTag(TAG)
                 .build()
 
@@ -94,7 +99,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
                 periodicRequest
             )
 
-            Log.d(TAG, "Scheduled notification check (${INTERVAL_SECONDS}s + 15min backup)")
+            Log.d(TAG, "Scheduled notification check (${intervalSeconds}s + 15min backup)")
         }
 
         /**
@@ -127,11 +132,12 @@ class ChargingNotificationWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         Log.d(TAG, "Starting notification check")
 
-        // Check if server is configured
+        // Check if server is configured. Don't re-arm the frequent chain — the 15-min
+        // periodic backstop (a cheap local settings read, no network) resumes polling
+        // once the user configures a server.
         val settings = settingsDataStore.settings.first()
         if (!settings.isConfigured) {
             Log.d(TAG, "Server not configured, skipping check")
-            scheduleNextCheck()
             return Result.success()
         }
 
@@ -142,14 +148,14 @@ class ChargingNotificationWorker @AssistedInject constructor(
                 is ApiResult.Success -> carsResult.data
                 is ApiResult.Error -> {
                     Log.e(TAG, "Failed to fetch cars: ${carsResult.message}")
-                    scheduleNextCheck()
+                    scheduleNextCheck(frequent = true)
                     return Result.retry()
                 }
             }
 
             if (cars.isEmpty()) {
                 Log.d(TAG, "No cars found")
-                scheduleNextCheck()
+                scheduleNextCheck(frequent = false)
                 return Result.success()
             }
 
@@ -161,6 +167,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
             // notification with it) 30 s after another car's iteration started it.
             val needMonitor = mutableListOf<Pair<CarData, CarStatus>>()
             var anyCheckFailed = false
+            var anyWantsFrequentPolling = false
             for (car in cars) {
                 val outcome = try {
                     checkCarStatus(car)
@@ -171,7 +178,13 @@ class ChargingNotificationWorker @AssistedInject constructor(
                 when (outcome) {
                     is CheckOutcome.NeedsMonitor -> needMonitor.add(car to outcome.status)
                     CheckOutcome.Failed -> anyCheckFailed = true
-                    CheckOutcome.Idle -> { /* nothing to do */ }
+                    is CheckOutcome.Idle -> {
+                        // Plugged-in cars can start charging any moment; sentry-armed cars
+                        // need 30s polling to catch the ~1-minute alert window.
+                        if (outcome.status.pluggedIn == true || outcome.status.sentryMode == true) {
+                            anyWantsFrequentPolling = true
+                        }
+                    }
                 }
             }
 
@@ -200,12 +213,15 @@ class ChargingNotificationWorker @AssistedInject constructor(
             }
 
             Log.d(TAG, "Check complete")
-            scheduleNextCheck()
+            // Back off to the idle cadence when nothing is (about to be) charging and no
+            // car is sentry-armed; keep 30s on errors so recovery is quick.
+            val frequent = needMonitor.isNotEmpty() || anyCheckFailed || anyWantsFrequentPolling
+            scheduleNextCheck(frequent)
             return Result.success()
 
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error in worker", e)
-            scheduleNextCheck()
+            scheduleNextCheck(frequent = true)
             return Result.retry()
         }
     }
@@ -214,8 +230,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
     private sealed interface CheckOutcome {
         /** Car is charging (or DC-finished-but-plugged) — the monitor service must run. */
         data class NeedsMonitor(val status: CarStatus) : CheckOutcome
-        /** Car positively does not need monitoring. */
-        data object Idle : CheckOutcome
+        /** Car positively does not need monitoring (status carried for cadence decisions). */
+        data class Idle(val status: CarStatus) : CheckOutcome
         /** Status unknown (fetch failed) — must not count as idle. */
         data object Failed : CheckOutcome
     }
@@ -262,7 +278,7 @@ class ChargingNotificationWorker @AssistedInject constructor(
         } else {
             Log.d(TAG, "Car $carId is not charging")
             chargingNotificationManager.cancelNotification(carId)
-            CheckOutcome.Idle
+            CheckOutcome.Idle(status)
         }
 
         // --- Sentry ---
@@ -292,8 +308,12 @@ class ChargingNotificationWorker @AssistedInject constructor(
 
     /**
      * Schedule the next check using self-rescheduling pattern.
+     * [frequent] = 30s (charging/plugged/sentry-armed/errors); otherwise the 5-min idle cadence.
      */
-    private fun scheduleNextCheck() {
-        schedulePeriodicWork(appContext)
+    private fun scheduleNextCheck(frequent: Boolean) {
+        schedulePeriodicWork(
+            appContext,
+            if (frequent) INTERVAL_SECONDS else IDLE_INTERVAL_SECONDS
+        )
     }
 }

--- a/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
@@ -68,8 +68,10 @@ class GeocodeWorker @AssistedInject constructor(
         Log.d(TAG, "Queue state: total=$totalQueue, pending=$pendingQueue, failed=$failedQueue, cached=$cachedCount")
         log("Queue state: total=$totalQueue, pending=$pendingQueue, failed=$failedQueue, cached=$cachedCount")
 
-        // If there are failed items but no pending items, reset and retry them
-        if (pendingQueue == 0 && failedQueue > 0) {
+        // If there are failed items but no pending items, reset and retry them — but only on
+        // a fresh trigger (a sync enqueued us), never on our own backoff retries. Resetting on
+        // every run made a dead endpoint burn through the whole queue again on each attempt.
+        if (runAttemptCount == 0 && pendingQueue == 0 && failedQueue > 0) {
             Log.d(TAG, "Resetting $failedQueue failed items to retry")
             log("Resetting $failedQueue failed items to retry")
             geocodingRepository.resetFailedItems()
@@ -130,6 +132,14 @@ class GeocodeWorker @AssistedInject constructor(
 
         Log.d(TAG, "Processed $processedCount locations this run")
         log("Processed $processedCount locations this run")
+
+        // Persistent errors → the endpoint is likely down or throttling us. Retry with
+        // WorkManager's exponential backoff instead of hammering Nominatim immediately.
+        if (consecutiveErrors >= 5) {
+            Log.w(TAG, "Too many consecutive errors, retrying with backoff")
+            log("Too many consecutive errors, retrying with backoff")
+            return Result.retry()
+        }
 
         // Check if there's more work to do
         val remaining = geocodingRepository.getPendingCount()

--- a/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
@@ -102,19 +102,20 @@ class SyncRepository @Inject constructor(
             return true
         }
 
-        // Phase 2: Sync drive details
-        val driveSuccess = syncDriveDetails(carId)
-        if (!driveSuccess) {
-            syncManager.markSyncError(carId, "Failed to sync drive details")
+        // Phase 2: Sync drive details. Failed items keep no aggregate row, so a retry
+        // reprocesses only them — don't mark the phase complete while failures remain.
+        val driveFailures = syncDriveDetails(carId)
+        if (driveFailures > 0) {
+            syncManager.markSyncError(carId, "$driveFailures drive details failed — will retry")
             return false
         }
 
         syncManager.markDriveDetailsComplete(carId)
 
         // Phase 3: Sync charge details
-        val chargeSuccess = syncChargeDetails(carId)
-        if (!chargeSuccess) {
-            syncManager.markSyncError(carId, "Failed to sync charge details")
+        val chargeFailures = syncChargeDetails(carId)
+        if (chargeFailures > 0) {
+            syncManager.markSyncError(carId, "$chargeFailures charge details failed — will retry")
             return false
         }
 
@@ -167,8 +168,11 @@ class SyncRepository @Inject constructor(
      * Processes drives in parallel batches for improved performance.
      * Locations are enqueued for geocoding incrementally (per batch) and geocoding
      * starts in parallel without blocking drive retrieval.
+     *
+     * @return number of drives whose detail fetch failed (0 = fully synced)
      */
-    suspend fun syncDriveDetails(carId: Int): Boolean {
+    suspend fun syncDriveDetails(carId: Int): Int {
+        var failures = 0
         val unprocessedIds = driveSummaryDao.getUnprocessedDriveIds(carId, SchemaVersion.CURRENT)
         val total = unprocessedIds.size
         log("Processing $total drive details for car $carId (batch size: $BATCH_SIZE)")
@@ -203,6 +207,7 @@ class SyncRepository @Inject constructor(
                     }
                     is ApiResult.Error -> {
                         logError("Drive $driveId failed: ${result.message}")
+                        failures++
                         null
                     }
                 }
@@ -237,7 +242,7 @@ class SyncRepository @Inject constructor(
             }
         }
 
-        return true
+        return failures
     }
 
     /**
@@ -245,8 +250,11 @@ class SyncRepository @Inject constructor(
      * Processes charges in parallel batches for improved performance.
      * Locations are enqueued for geocoding incrementally (per batch) and geocoding
      * starts in parallel without blocking charge retrieval.
+     *
+     * @return number of charges whose detail fetch failed (0 = fully synced)
      */
-    suspend fun syncChargeDetails(carId: Int): Boolean {
+    suspend fun syncChargeDetails(carId: Int): Int {
+        var failures = 0
         val unprocessedIds = chargeSummaryDao.getUnprocessedChargeIds(carId, SchemaVersion.CURRENT)
         val total = unprocessedIds.size
         log("Processing $total charge details for car $carId (batch size: $BATCH_SIZE)")
@@ -289,6 +297,7 @@ class SyncRepository @Inject constructor(
                     is ApiResult.Error -> {
                         logError("Charge $chargeId failed: ${result.message}")
                         // Continue with other charges instead of failing entirely
+                        failures++
                     }
                 }
             }
@@ -322,7 +331,7 @@ class SyncRepository @Inject constructor(
             }
         }
 
-        return true
+        return failures
     }
 
     /**

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -185,6 +185,10 @@ class TeslamateApiFactory(
                 }
                 chain.proceed(requestBuilder.build())
             }
+            // Deliberately aggressive: executeWithFallback tries the primary server on EVERY
+            // request, and dual-address setups (local IP + VPN IP) hit this timeout on each
+            // call while on the other network before falling back to the secondary. Raising
+            // it makes every operation that much slower for those users — don't.
             .connectTimeout(1, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/matedroid/widget/CarWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidgetUpdateWorker.kt
@@ -123,8 +123,11 @@ class CarWidgetUpdateWorker @AssistedInject constructor(
         val glanceIds = manager.getGlanceIds(CarWidget::class.java)
 
         if (glanceIds.isEmpty()) {
-            Log.d(TAG, "No active widgets, skipping update")
-            scheduleNextUpdate()
+            // No widgets on any launcher: stop the chain AND the periodic backup instead of
+            // rescheduling forever. onDisabled can't cover chains started by
+            // scheduleImmediateUpdate (e.g. a sentry alert) on a device with no widgets.
+            Log.d(TAG, "No active widgets, stopping update work")
+            cancelWork(appContext)
             return Result.success()
         }
 


### PR DESCRIPTION
Sixth cluster from the code review — battery-focused WorkManager fixes.

- **Charging/sentry polling backs off when idle**: 30 s only while a car is charging, plugged in, or sentry-armed (or after an error); 5 min otherwise; fully stopped while no server is configured (the 15-min periodic backstop — a local settings read, no network — resumes it). Previously the 30 s chain ran 24/7 unconditionally and its cancel function had no callers.
- **Widget update chain stops with zero widgets** (sentry alerts could start it on widget-less devices and nothing ever cancelled it; `onEnabled` reschedules when a widget is added).
- **GeocodeWorker**: failed items are reset only on fresh triggers, and 5 consecutive errors now trigger `Result.retry()` with exponential backoff instead of immediately re-enqueuing and burning the whole queue against a dead Nominatim.
- **Detail-sync failures are no longer swallowed**: `syncDriveDetails`/`syncChargeDetails` return failure counts; `syncCar` keeps the phase incomplete and reports the error, so the worker retries just the failed items (they have no aggregate rows yet).
- **Docs**: the 1 s connect timeout is now documented as deliberate (dual local+VPN address setups pay it on every request before failover — raising it would slow every call on the "other" network); fixed the `enqueueSyncWork` doc that claimed KEEP while the code intentionally uses REPLACE.

Considered and skipped: switching the self-rescheduling chains from `ExistingWorkPolicy.REPLACE` to `APPEND_OR_REPLACE` (makes WorkManager records honest but risks chain growth when external triggers race the chain).

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)