### PR TITLE
Idle backoff: keep 30s polling while driving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Large cost totals now use a thousands separator** (e.g. "1,234.56") consistently across the stats, mileage and trip screens, matching how distances and energy are already shown.
 
 ### Changed (battery & background work)
-- **Background polling now backs off when nothing is happening** — the 30-second charging/sentry check drops to every 5 minutes while no car is charging, plugged in, or sentry-armed, and stops entirely when no server is configured. It returns to 30 seconds as soon as a charge or sentry session could start.
+- **Background polling now backs off when nothing is happening** — the 30-second charging/sentry check drops to every 5 minutes while the car is parked, unplugged, and not sentry-armed, and stops entirely when no server is configured. Driving, plugged-in, sentry-armed and charging cars keep the 30-second cadence, so a fast-charge stop mid-trip is still picked up promptly.
 - **The widget updater stops itself when no widgets are on the launcher** instead of polling forever.
 - **Location lookups back off when the geocoding service is unreachable** instead of retrying the whole queue at full speed on every sync.
 - **A sync with failed drive/charge details now reports the failure and retries them** instead of pretending everything synced.

--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -180,8 +180,15 @@ class ChargingNotificationWorker @AssistedInject constructor(
                     CheckOutcome.Failed -> anyCheckFailed = true
                     is CheckOutcome.Idle -> {
                         // Plugged-in cars can start charging any moment; sentry-armed cars
-                        // need 30s polling to catch the ~1-minute alert window.
-                        if (outcome.status.pluggedIn == true || outcome.status.sentryMode == true) {
+                        // need 30s polling to catch the ~1-minute alert window; a driving
+                        // car may pull into a DC fast charger, where plug-to-charging is
+                        // seconds — a 5-min idle cadence would miss the start of a short
+                        // session. Only parked+unplugged+unarmed cars use the idle cadence.
+                        val status = outcome.status
+                        if (status.pluggedIn == true ||
+                            status.sentryMode == true ||
+                            status.state?.lowercase() == "driving"
+                        ) {
                             anyWantsFrequentPolling = true
                         }
                     }


### PR DESCRIPTION
Follow-up to #345 after review discussion: the idle backoff was not smart enough for road trips. While driving, nothing is charging/plugged/sentry-armed, so the check idled at 5 minutes — but driving is exactly the state that predicts an imminent DC fast-charge stop, where plug-to-charging takes seconds and a session may only last 15–20 minutes. Driving cars now keep the 30 s cadence; the 5-minute idle applies only to parked, unplugged, unarmed cars (which is where the battery win is anyway — that's most of the day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)