### PR TITLE
Incremental summary sync via startDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The widget updater stops itself when no widgets are on the launcher** instead of polling forever.
 - **Location lookups back off when the geocoding service is unreachable** instead of retrying the whole queue at full speed on every sync.
 - **A sync with failed drive/charge details now reports the failure and retries them** instead of pretending everything synced.
+- **Syncs are now incremental** — instead of re-downloading the entire drive/charge history on every sync (a multi-MB download for long histories), only entries since the last sync are fetched, with a 7-day overlap and a weekly full refresh to pick up edits to older entries (e.g. charge costs added later).
 
 ### Fixed
 - **Efficiency and speed figures are correct again for miles/imperial users** — the lifetime and yearly efficiency on the Mileage screen and the speed-profile chart on the drive detail screen were applying a km→miles conversion to values the API had already converted, so imperial users saw numbers around 40% too low. The values are now shown as returned.

--- a/app/schemas/com.matedroid.data.local.StatsDatabase/13.json
+++ b/app/schemas/com.matedroid.data.local.StatsDatabase/13.json
@@ -1,0 +1,1144 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "5eff759c0325a8eae183843d22f2672f",
+    "entities": [
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`carId` INTEGER NOT NULL, `lastDriveSyncAt` INTEGER NOT NULL, `lastChargeSyncAt` INTEGER NOT NULL, `lastFullSummarySyncAt` INTEGER NOT NULL, `lastDriveDetailId` INTEGER NOT NULL, `lastChargeDetailId` INTEGER NOT NULL, `detailSchemaVersion` INTEGER NOT NULL, `totalDrivesToProcess` INTEGER NOT NULL, `totalChargesToProcess` INTEGER NOT NULL, `drivesProcessed` INTEGER NOT NULL, `chargesProcessed` INTEGER NOT NULL, `summariesSynced` INTEGER NOT NULL, `detailsSynced` INTEGER NOT NULL, PRIMARY KEY(`carId`))",
+        "fields": [
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDriveSyncAt",
+            "columnName": "lastDriveSyncAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChargeSyncAt",
+            "columnName": "lastChargeSyncAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFullSummarySyncAt",
+            "columnName": "lastFullSummarySyncAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDriveDetailId",
+            "columnName": "lastDriveDetailId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChargeDetailId",
+            "columnName": "lastChargeDetailId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailSchemaVersion",
+            "columnName": "detailSchemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDrivesToProcess",
+            "columnName": "totalDrivesToProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChargesToProcess",
+            "columnName": "totalChargesToProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "drivesProcessed",
+            "columnName": "drivesProcessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chargesProcessed",
+            "columnName": "chargesProcessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summariesSynced",
+            "columnName": "summariesSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailsSynced",
+            "columnName": "detailsSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "carId"
+          ]
+        }
+      },
+      {
+        "tableName": "drives_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`driveId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, `durationMin` INTEGER NOT NULL, `startAddress` TEXT NOT NULL, `endAddress` TEXT NOT NULL, `distance` REAL NOT NULL, `speedMax` INTEGER NOT NULL, `speedAvg` INTEGER NOT NULL, `powerMax` INTEGER NOT NULL, `powerMin` INTEGER NOT NULL, `startBatteryLevel` INTEGER NOT NULL, `endBatteryLevel` INTEGER NOT NULL, `outsideTempAvg` REAL, `insideTempAvg` REAL, `energyConsumed` REAL, `efficiency` REAL, PRIMARY KEY(`driveId`))",
+        "fields": [
+          {
+            "fieldPath": "driveId",
+            "columnName": "driveId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMin",
+            "columnName": "durationMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startAddress",
+            "columnName": "startAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAddress",
+            "columnName": "endAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedMax",
+            "columnName": "speedMax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedAvg",
+            "columnName": "speedAvg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerMax",
+            "columnName": "powerMax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerMin",
+            "columnName": "powerMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startBatteryLevel",
+            "columnName": "startBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endBatteryLevel",
+            "columnName": "endBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outsideTempAvg",
+            "columnName": "outsideTempAvg",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "insideTempAvg",
+            "columnName": "insideTempAvg",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "energyConsumed",
+            "columnName": "energyConsumed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "efficiency",
+            "columnName": "efficiency",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "driveId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drives_summary_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drives_summary_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_drives_summary_carId_startDate",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "startDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drives_summary_carId_startDate` ON `${TABLE_NAME}` (`carId`, `startDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "charges_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chargeId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, `durationMin` INTEGER NOT NULL, `address` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `energyAdded` REAL NOT NULL, `energyUsed` REAL, `cost` REAL, `startBatteryLevel` INTEGER NOT NULL, `endBatteryLevel` INTEGER NOT NULL, `outsideTempAvg` REAL, `odometer` REAL NOT NULL, PRIMARY KEY(`chargeId`))",
+        "fields": [
+          {
+            "fieldPath": "chargeId",
+            "columnName": "chargeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMin",
+            "columnName": "durationMin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energyAdded",
+            "columnName": "energyAdded",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energyUsed",
+            "columnName": "energyUsed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "startBatteryLevel",
+            "columnName": "startBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endBatteryLevel",
+            "columnName": "endBatteryLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outsideTempAvg",
+            "columnName": "outsideTempAvg",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometer",
+            "columnName": "odometer",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chargeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_charges_summary_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charges_summary_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_charges_summary_carId_startDate",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "startDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charges_summary_carId_startDate` ON `${TABLE_NAME}` (`carId`, `startDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "drive_detail_aggregates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`driveId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `schemaVersion` INTEGER NOT NULL, `computedAt` INTEGER NOT NULL, `maxElevation` INTEGER, `minElevation` INTEGER, `startElevation` INTEGER, `endElevation` INTEGER, `elevationGain` INTEGER, `elevationLoss` INTEGER, `hasElevationData` INTEGER NOT NULL, `maxInsideTemp` REAL, `minInsideTemp` REAL, `maxOutsideTemp` REAL, `minOutsideTemp` REAL, `maxPower` INTEGER, `minPower` INTEGER, `climateOnPositions` INTEGER NOT NULL, `positionCount` INTEGER NOT NULL, `startLatitude` REAL, `startLongitude` REAL, `startCountryCode` TEXT, `startCountryName` TEXT, `startRegionName` TEXT, `startCity` TEXT, `endLatitude` REAL, `endLongitude` REAL, `extraJson` TEXT, PRIMARY KEY(`driveId`), FOREIGN KEY(`driveId`) REFERENCES `drives_summary`(`driveId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "driveId",
+            "columnName": "driveId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxElevation",
+            "columnName": "maxElevation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minElevation",
+            "columnName": "minElevation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startElevation",
+            "columnName": "startElevation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endElevation",
+            "columnName": "endElevation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "elevationGain",
+            "columnName": "elevationGain",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "elevationLoss",
+            "columnName": "elevationLoss",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasElevationData",
+            "columnName": "hasElevationData",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxInsideTemp",
+            "columnName": "maxInsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "minInsideTemp",
+            "columnName": "minInsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "maxOutsideTemp",
+            "columnName": "maxOutsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "minOutsideTemp",
+            "columnName": "minOutsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "maxPower",
+            "columnName": "maxPower",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minPower",
+            "columnName": "minPower",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "climateOnPositions",
+            "columnName": "climateOnPositions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionCount",
+            "columnName": "positionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startLatitude",
+            "columnName": "startLatitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "startLongitude",
+            "columnName": "startLongitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "startCountryCode",
+            "columnName": "startCountryCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startCountryName",
+            "columnName": "startCountryName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startRegionName",
+            "columnName": "startRegionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startCity",
+            "columnName": "startCity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endLatitude",
+            "columnName": "endLatitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "endLongitude",
+            "columnName": "endLongitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "extraJson",
+            "columnName": "extraJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "driveId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drive_detail_aggregates_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_detail_aggregates_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_drive_detail_aggregates_driveId",
+            "unique": false,
+            "columnNames": [
+              "driveId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_detail_aggregates_driveId` ON `${TABLE_NAME}` (`driveId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "drives_summary",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "driveId"
+            ],
+            "referencedColumns": [
+              "driveId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "charge_detail_aggregates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chargeId` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `schemaVersion` INTEGER NOT NULL, `computedAt` INTEGER NOT NULL, `isFastCharger` INTEGER NOT NULL, `fastChargerBrand` TEXT, `connectorType` TEXT, `maxChargerPower` INTEGER, `maxChargerVoltage` INTEGER, `maxChargerCurrent` INTEGER, `chargerPhases` INTEGER, `maxOutsideTemp` REAL, `minOutsideTemp` REAL, `chargePointCount` INTEGER NOT NULL, `countryCode` TEXT, `countryName` TEXT, `regionName` TEXT, `city` TEXT, `extraJson` TEXT, PRIMARY KEY(`chargeId`), FOREIGN KEY(`chargeId`) REFERENCES `charges_summary`(`chargeId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chargeId",
+            "columnName": "chargeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schemaVersion",
+            "columnName": "schemaVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "computedAt",
+            "columnName": "computedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFastCharger",
+            "columnName": "isFastCharger",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fastChargerBrand",
+            "columnName": "fastChargerBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connectorType",
+            "columnName": "connectorType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxChargerPower",
+            "columnName": "maxChargerPower",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "maxChargerVoltage",
+            "columnName": "maxChargerVoltage",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "maxChargerCurrent",
+            "columnName": "maxChargerCurrent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "chargerPhases",
+            "columnName": "chargerPhases",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "maxOutsideTemp",
+            "columnName": "maxOutsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "minOutsideTemp",
+            "columnName": "minOutsideTemp",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "chargePointCount",
+            "columnName": "chargePointCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "countryName",
+            "columnName": "countryName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionName",
+            "columnName": "regionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "extraJson",
+            "columnName": "extraJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chargeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_charge_detail_aggregates_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charge_detail_aggregates_carId` ON `${TABLE_NAME}` (`carId`)"
+          },
+          {
+            "name": "index_charge_detail_aggregates_chargeId",
+            "unique": false,
+            "columnNames": [
+              "chargeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_charge_detail_aggregates_chargeId` ON `${TABLE_NAME}` (`chargeId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "charges_summary",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chargeId"
+            ],
+            "referencedColumns": [
+              "chargeId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "geocode_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gridLat` INTEGER NOT NULL, `gridLon` INTEGER NOT NULL, `countryCode` TEXT, `countryName` TEXT, `regionName` TEXT, `city` TEXT, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`gridLat`, `gridLon`))",
+        "fields": [
+          {
+            "fieldPath": "gridLat",
+            "columnName": "gridLat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridLon",
+            "columnName": "gridLon",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryCode",
+            "columnName": "countryCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "countryName",
+            "columnName": "countryName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "regionName",
+            "columnName": "regionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "gridLat",
+            "gridLon"
+          ]
+        }
+      },
+      {
+        "tableName": "geocode_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gridLat` INTEGER NOT NULL, `gridLon` INTEGER NOT NULL, `carId` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `addedAt` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, PRIMARY KEY(`gridLat`, `gridLon`))",
+        "fields": [
+          {
+            "fieldPath": "gridLat",
+            "columnName": "gridLat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gridLon",
+            "columnName": "gridLon",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "gridLat",
+            "gridLon"
+          ]
+        }
+      },
+      {
+        "tableName": "geocode_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`carId` INTEGER NOT NULL, `totalLocations` INTEGER NOT NULL, `processedLocations` INTEGER NOT NULL, `lastUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`carId`))",
+        "fields": [
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalLocations",
+            "columnName": "totalLocations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processedLocations",
+            "columnName": "processedLocations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "carId"
+          ]
+        }
+      },
+      {
+        "tableName": "sentry_alert_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `carId` INTEGER NOT NULL, `detectedAt` INTEGER NOT NULL, `sessionStartedAt` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `address` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detectedAt",
+            "columnName": "detectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionStartedAt",
+            "columnName": "sessionStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sentry_alert_log_carId_detectedAt",
+            "unique": false,
+            "columnNames": [
+              "carId",
+              "detectedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sentry_alert_log_carId_detectedAt` ON `${TABLE_NAME}` (`carId`, `detectedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "trip_route_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripKey` TEXT NOT NULL, `segmentIndex` INTEGER NOT NULL, `segmentData` BLOB NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`tripKey`, `segmentIndex`))",
+        "fields": [
+          {
+            "fieldPath": "tripKey",
+            "columnName": "tripKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "segmentIndex",
+            "columnName": "segmentIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "segmentData",
+            "columnName": "segmentData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripKey",
+            "segmentIndex"
+          ]
+        }
+      },
+      {
+        "tableName": "trip_country_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripKey` TEXT NOT NULL, `countries` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`tripKey`))",
+        "fields": [
+          {
+            "fieldPath": "tripKey",
+            "columnName": "tripKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countries",
+            "columnName": "countries",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripKey"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_trips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `carId` INTEGER NOT NULL, `name` TEXT, `source` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carId",
+            "columnName": "carId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trips_carId",
+            "unique": false,
+            "columnNames": [
+              "carId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trips_carId` ON `${TABLE_NAME}` (`carId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "saved_trip_legs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tripId` INTEGER NOT NULL, `position` INTEGER NOT NULL, `legType` TEXT NOT NULL, `legId` INTEGER NOT NULL, PRIMARY KEY(`tripId`, `position`), FOREIGN KEY(`tripId`) REFERENCES `saved_trips`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tripId",
+            "columnName": "tripId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legType",
+            "columnName": "legType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legId",
+            "columnName": "legId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tripId",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trip_legs_legType_legId",
+            "unique": false,
+            "columnNames": [
+              "legType",
+              "legId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trip_legs_legType_legId` ON `${TABLE_NAME}` (`legType`, `legId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "saved_trips",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tripId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "saved_trip_consumed_fingerprints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`savedTripId` INTEGER NOT NULL, `fingerprint` TEXT NOT NULL, PRIMARY KEY(`savedTripId`, `fingerprint`), FOREIGN KEY(`savedTripId`) REFERENCES `saved_trips`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "savedTripId",
+            "columnName": "savedTripId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fingerprint",
+            "columnName": "fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "savedTripId",
+            "fingerprint"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_saved_trip_consumed_fingerprints_fingerprint",
+            "unique": false,
+            "columnNames": [
+              "fingerprint"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_saved_trip_consumed_fingerprints_fingerprint` ON `${TABLE_NAME}` (`fingerprint`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "saved_trips",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "savedTripId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5eff759c0325a8eae183843d22f2672f')"
+    ]
+  }
+}

--- a/app/src/main/java/com/matedroid/data/local/StatsDatabase.kt
+++ b/app/src/main/java/com/matedroid/data/local/StatsDatabase.kt
@@ -59,7 +59,7 @@ import com.matedroid.data.local.entity.TripRouteCache
         SavedTripLeg::class,
         SavedTripConsumedFingerprint::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = true
 )
 abstract class StatsDatabase : RoomDatabase() {
@@ -317,6 +317,12 @@ abstract class StatsDatabase : RoomDatabase() {
             }
         }
 
-        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
+        val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE sync_state ADD COLUMN lastFullSummarySyncAt INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13)
     }
 }

--- a/app/src/main/java/com/matedroid/data/local/dao/SyncStateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/SyncStateDao.kt
@@ -25,6 +25,10 @@ interface SyncStateDao {
     """)
     suspend fun markSummariesSynced(carId: Int, timestamp: Long)
 
+    // Recorded only when the summary fetch ran without a startDate filter
+    @Query("UPDATE sync_state SET lastFullSummarySyncAt = :timestamp WHERE carId = :carId")
+    suspend fun markFullSummarySync(carId: Int, timestamp: Long)
+
     // Detail sync progress updates
     @Query("""
         UPDATE sync_state

--- a/app/src/main/java/com/matedroid/data/local/entity/SyncState.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SyncState.kt
@@ -16,6 +16,11 @@ data class SyncState(
     val lastDriveSyncAt: Long = 0,
     val lastChargeSyncAt: Long = 0,
 
+    // Last time summaries were fetched WITHOUT a startDate filter. Incremental syncs only
+    // fetch entries newer than the last sync (minus an overlap window), so a periodic full
+    // fetch picks up server-side edits (e.g. costs added to old charges).
+    val lastFullSummarySyncAt: Long = 0,
+
     // Detail sync tracking (individual endpoints)
     val lastDriveDetailId: Int = 0,
     val lastChargeDetailId: Int = 0,

--- a/app/src/main/java/com/matedroid/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncManager.kt
@@ -69,9 +69,15 @@ class SyncManager @Inject constructor(
 
     /**
      * Mark summaries as synced and calculate total items to process.
+     * [wasFullSync] records that this fetch had no startDate filter, resetting the
+     * periodic full-refresh clock used by incremental syncs.
      */
-    suspend fun markSummariesComplete(carId: Int) {
-        syncStateDao.markSummariesSynced(carId, System.currentTimeMillis())
+    suspend fun markSummariesComplete(carId: Int, wasFullSync: Boolean = true) {
+        val now = System.currentTimeMillis()
+        syncStateDao.markSummariesSynced(carId, now)
+        if (wasFullSync) {
+            syncStateDao.markFullSummarySync(carId, now)
+        }
 
         // Calculate total items to process for detail sync
         val unprocessedDrives = driveSummaryDao.countUnprocessedDrives(carId, SchemaVersion.CURRENT)

--- a/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
@@ -47,10 +47,25 @@ class SyncRepository @Inject constructor(
         private const val TAG = "SyncRepository"
         private const val THROTTLE_DELAY_MS = 10L  // Reduced from 100ms
         private const val BATCH_SIZE = 10  // Number of concurrent API calls
+
+        // Incremental summary sync: fetch entries newer than the last sync minus this
+        // overlap (absorbs clock skew, in-progress drives, and recent cost edits)...
+        private const val SUMMARY_OVERLAP_MS = 7L * 24 * 60 * 60 * 1000
+        // ...and do a periodic unfiltered fetch to pick up older server-side edits.
+        private const val FULL_REFRESH_INTERVAL_MS = 7L * 24 * 60 * 60 * 1000
     }
 
     private fun log(message: String) = logCollector.log(TAG, message)
     private fun logError(message: String, error: Throwable? = null) = logCollector.logError(TAG, message, error)
+
+    /**
+     * RFC3339 UTC ("2024-12-07T00:00:00Z") — one of the two formats TeslamateApi's
+     * parseDateParam accepts. The 7-day overlap absorbs any timezone interpretation drift.
+     */
+    private fun formatSyncStartDate(epochMs: Long): String =
+        java.time.Instant.ofEpochMilli(epochMs)
+            .truncatedTo(java.time.temporal.ChronoUnit.SECONDS)
+            .toString()
 
     /**
      * Ensure geocoding worker is running or scheduled.
@@ -88,13 +103,27 @@ class SyncRepository @Inject constructor(
         // Phase 1: Sync summaries
         syncManager.updateSummaryProgress(carId, "Fetching drives and charges...")
 
-        val summariesSuccess = syncSummaries(carId)
+        // Incremental fetch when possible: for large histories the unfiltered list endpoints
+        // are a multi-MB download + full-table upsert on EVERY sync.
+        val state = syncManager.getOrCreateSyncState(carId)
+        val now = System.currentTimeMillis()
+        val fullSync = !state.summariesSynced ||
+            state.lastDriveSyncAt == 0L ||
+            state.lastChargeSyncAt == 0L ||
+            now - state.lastFullSummarySyncAt > FULL_REFRESH_INTERVAL_MS
+        val startDate = if (fullSync) {
+            null
+        } else {
+            formatSyncStartDate(minOf(state.lastDriveSyncAt, state.lastChargeSyncAt) - SUMMARY_OVERLAP_MS)
+        }
+
+        val summariesSuccess = syncSummaries(carId, startDate)
         if (!summariesSuccess) {
             syncManager.markSyncError(carId, "Failed to sync summaries")
             return false
         }
 
-        syncManager.markSummariesComplete(carId)
+        syncManager.markSummariesComplete(carId, wasFullSync = fullSync)
 
         // Check if details need syncing
         if (syncManager.areDetailsSynced(carId)) {
@@ -130,12 +159,16 @@ class SyncRepository @Inject constructor(
     /**
      * Sync only summaries (Quick Stats).
      * Fast operation - 2 API calls regardless of data size.
+     * [startDate] (RFC3339) limits the fetch to entries newer than it; null fetches everything.
      */
-    suspend fun syncSummaries(carId: Int): Boolean {
-        log("Syncing summaries for car $carId")
+    suspend fun syncSummaries(carId: Int, startDate: String? = null): Boolean {
+        log(
+            if (startDate == null) "Syncing summaries for car $carId (full)"
+            else "Syncing summaries for car $carId (incremental since $startDate)"
+        )
 
         // Fetch and store drives
-        when (val drivesResult = teslamateRepository.getDrives(carId)) {
+        when (val drivesResult = teslamateRepository.getDrives(carId, startDate = startDate)) {
             is ApiResult.Success -> {
                 val summaries = drivesResult.data.map { it.toDriveSummary(carId) }
                 driveSummaryDao.upsertAll(summaries)
@@ -148,7 +181,7 @@ class SyncRepository @Inject constructor(
         }
 
         // Fetch and store charges
-        when (val chargesResult = teslamateRepository.getCharges(carId)) {
+        when (val chargesResult = teslamateRepository.getCharges(carId, startDate = startDate)) {
             is ApiResult.Success -> {
                 val summaries = chargesResult.data.map { it.toChargeSummary(carId) }
                 chargeSummaryDao.upsertAll(summaries)


### PR DESCRIPTION
Seventh cluster from the code review.

`syncSummaries` fetched the entire drive/charge history (`show=50000`, no `startDate`) on every sync — for a 7.8k-drive history that's a multi-MB JSON download, Moshi parse and full-table upsert each time, even though `SyncState` already tracked last-sync timestamps.

- Incremental fetch: `startDate = min(lastDriveSyncAt, lastChargeSyncAt) − 7 days` (overlap absorbs clock skew, in-progress drives, and cost edits made shortly after a charge).
- Weekly full refresh (new `lastFullSummarySyncAt` column, migration 12→13) picks up older server-side edits; "Force full resync" in Settings still covers everything else. First sync after this update is a full one.
- Verified against the live TeslamateApi: unfiltered = 7839 drives; `startDate=2026-08-01T00:00:00Z` = 49 drives, oldest `2026-08-01T09:40:24+02:00` — filter honored, RFC3339 accepted.

Note: sync never deletes rows, so entries deleted server-side linger exactly as before — no regression from incrementality.

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)