### PR TITLE
Geocoding pipeline: batch updates, honest progress, shared rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Background polling now backs off when nothing is happening** — the 30-second charging/sentry check drops to every 5 minutes while the car is parked, unplugged, and not sentry-armed, and stops entirely when no server is configured. Driving, plugged-in, sentry-armed and charging cars keep the 30-second cadence, so a fast-charge stop mid-trip is still picked up promptly.
 - **The widget updater stops itself when no widgets are on the launcher** instead of polling forever.
 - **Location lookups back off when the geocoding service is unreachable** instead of retrying the whole queue at full speed on every sync.
+- **Location identification (geocoding) is much lighter** — cached lookups are applied with indexed batch updates instead of one full-table scan per location cluster after every sync, the work queue is checked in one read instead of one query per location, and all OpenStreetMap requests (including the sentry-history and widget address lookups) now share the 1-request-per-second limit their usage policy requires.
+- **The location-identification progress bar no longer goes backwards** — already-queued work was re-counted into the total on every sync, and with two cars the counters mixed both cars' totals.
+- **Country boundaries and address lookups no longer accumulate unbounded memory** — in-memory caches are now size-capped.
 - **A sync with failed drive/charge details now reports the failure and retries them** instead of pretending everything synced.
 - **Syncs are now incremental** — instead of re-downloading the entire drive/charge history on every sync (a multi-MB download for long histories), only entries since the last sync are fetched, with a 7-day overlap and a weekly full refresh to pick up edits to older entries (e.g. charge costs added later).
 

--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -648,26 +648,62 @@ interface AggregateDao {
     """)
     suspend fun countChargesNeedingGeocode(carId: Int): Int
 
-    // Get coordinates of drives that need geocoding (have coordinates but no country)
+    // Get ids + coordinates of drives that need geocoding (have coordinates but no country).
+    // Carrying the id lets callers apply cached geocode data with indexed per-id updates
+    // instead of CAST(lat*100)-matching UPDATEs, which SQLite can never index (full scan
+    // per grid cell).
     @Query("""
-        SELECT startLatitude AS latitude, startLongitude AS longitude FROM drive_detail_aggregates
+        SELECT driveId AS id, startLatitude AS latitude, startLongitude AS longitude
+        FROM drive_detail_aggregates
         WHERE carId = :carId
         AND startLatitude IS NOT NULL
         AND startLongitude IS NOT NULL
         AND startCountryCode IS NULL
     """)
-    suspend fun getDriveLocationsNeedingGeocode(carId: Int): List<LatLonResult>
+    suspend fun getDriveLocationsNeedingGeocode(carId: Int): List<IdLatLonResult>
 
-    // Get coordinates of charges that need geocoding
+    // (0.0, 0.0) is the sentinel for "API returned no coordinates" — exclude it or those
+    // charges get geocoded to Null Island.
     @Query("""
-        SELECT c.latitude, c.longitude FROM charge_detail_aggregates a
+        SELECT c.chargeId AS id, c.latitude, c.longitude FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId
-        AND c.latitude IS NOT NULL
-        AND c.longitude IS NOT NULL
+        AND NOT (c.latitude = 0.0 AND c.longitude = 0.0)
         AND a.countryCode IS NULL
     """)
-    suspend fun getChargeLocationsNeedingGeocode(carId: Int): List<LatLonResult>
+    suspend fun getChargeLocationsNeedingGeocode(carId: Int): List<IdLatLonResult>
+
+    @Query("""
+        UPDATE drive_detail_aggregates
+        SET startCountryCode = :countryCode,
+            startCountryName = :countryName,
+            startRegionName = :regionName,
+            startCity = :city
+        WHERE driveId IN (:driveIds)
+    """)
+    suspend fun updateDriveLocationsByIds(
+        driveIds: List<Int>,
+        countryCode: String?,
+        countryName: String?,
+        regionName: String?,
+        city: String?
+    )
+
+    @Query("""
+        UPDATE charge_detail_aggregates
+        SET countryCode = :countryCode,
+            countryName = :countryName,
+            regionName = :regionName,
+            city = :city
+        WHERE chargeId IN (:chargeIds)
+    """)
+    suspend fun updateChargeLocationsByIds(
+        chargeIds: List<Int>,
+        countryCode: String?,
+        countryName: String?,
+        regionName: String?,
+        city: String?
+    )
 
     // === Charge Locations for Country Map ===
 
@@ -774,14 +810,13 @@ data class DriveLocationResult(
 )
 
 /**
- * Simple lat/lon result for geocoding queries.
+ * Row id + coordinates for geocoding queries.
  */
-data class LatLonResult(
+data class IdLatLonResult(
+    val id: Int,
     val latitude: Double,
     val longitude: Double
-) {
-    fun toLatLon(): Pair<Double, Double> = latitude to longitude
-}
+)
 
 /**
  * Result of a country visit aggregation query.

--- a/app/src/main/java/com/matedroid/data/local/dao/GeocodeCacheDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/GeocodeCacheDao.kt
@@ -18,6 +18,14 @@ interface GeocodeCacheDao {
     @Query("SELECT COUNT(*) FROM geocode_cache")
     suspend fun count(): Int
 
+    // Full cache read for batch matching — the table holds one small row per ~1.1km grid
+    // cell ever visited, so this is cheap and replaces per-cell point queries.
+    @Query("SELECT * FROM geocode_cache")
+    suspend fun getAll(): List<GeocodeCache>
+
+    @Query("SELECT gridLat, gridLon FROM geocode_cache")
+    suspend fun getAllGridKeys(): List<GridKey>
+
     // For stats: count unique countries in cache
     @Query("SELECT COUNT(DISTINCT countryCode) FROM geocode_cache WHERE countryCode IS NOT NULL")
     suspend fun countUniqueCountries(): Int
@@ -26,3 +34,9 @@ interface GeocodeCacheDao {
     @Query("SELECT COUNT(DISTINCT city) FROM geocode_cache WHERE city IS NOT NULL")
     suspend fun countUniqueCities(): Int
 }
+
+/** A grid-cell key (0.01° precision). */
+data class GridKey(
+    val gridLat: Int,
+    val gridLon: Int
+)

--- a/app/src/main/java/com/matedroid/data/local/dao/GeocodeProgressDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/GeocodeProgressDao.kt
@@ -46,13 +46,13 @@ interface GeocodeProgressDao {
     @Query("DELETE FROM geocode_progress WHERE carId = :carId")
     suspend fun delete(carId: Int)
 
-    // Sync progress with actual cache count (fixes stale data)
-    // Sets both total and processed to cachedCount, marking geocoding as complete
+    // Queue is empty → nothing is pending, so every car's progress is complete. (The old
+    // variant wrote the GLOBAL cache count into every car's total — wrong for multi-car.)
     @Query("""
         UPDATE geocode_progress
-        SET totalLocations = :cachedCount,
-            processedLocations = :cachedCount,
+        SET processedLocations = totalLocations,
             lastUpdatedAt = :timestamp
+        WHERE processedLocations < totalLocations
     """)
-    suspend fun syncWithCache(cachedCount: Int, timestamp: Long = System.currentTimeMillis())
+    suspend fun markAllComplete(timestamp: Long = System.currentTimeMillis())
 }

--- a/app/src/main/java/com/matedroid/data/local/dao/GeocodeQueueDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/GeocodeQueueDao.kt
@@ -30,6 +30,10 @@ interface GeocodeQueueDao {
     @Query("SELECT COUNT(*) FROM geocode_queue WHERE attempts < 3")
     suspend fun countPending(): Int
 
+    // For batch dedup when enqueueing (progress totals must not re-count queued items)
+    @Query("SELECT gridLat, gridLon FROM geocode_queue")
+    suspend fun getAllGridKeys(): List<GridKey>
+
     // Flow-based query for real-time UI updates (Room emits on table changes)
     @Query("SELECT COUNT(*) FROM geocode_queue WHERE attempts < 3")
     fun observePendingCount(): Flow<Int>

--- a/app/src/main/java/com/matedroid/data/repository/GeocodingRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/GeocodingRepository.kt
@@ -6,11 +6,17 @@ import com.matedroid.data.api.NominatimAddress
 import com.matedroid.data.local.dao.GeocodeCacheDao
 import com.matedroid.data.local.dao.GeocodeProgressDao
 import com.matedroid.data.local.dao.GeocodeQueueDao
+import android.os.SystemClock
 import com.matedroid.data.local.entity.GeocodeCache
 import com.matedroid.data.local.entity.GeocodeProgress
 import com.matedroid.data.local.entity.GeocodeQueueItem
+import java.util.Collections
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -54,11 +60,40 @@ class GeocodingRepository @Inject constructor(
     companion object {
         // Grid precision: 0.01° ≈ 1.1km at equator
         private const val GRID_PRECISION = 100
+
+        // Nominatim usage policy: max 1 request/second. Enforced HERE for every call path
+        // (worker, legacy lookups, boundaries) so no caller can burst past it.
+        private const val NOMINATIM_MIN_INTERVAL_MS = 1100L
+
+        private const val ADDRESS_CACHE_SIZE = 256
+        private const val BOUNDARY_CACHE_SIZE = 3 // full-resolution polygons are MBs each
+
+        /** Bounded, access-ordered LRU map (synchronized — callers hop threads). */
+        private fun <K, V> lruCache(maxSize: Int): MutableMap<K, V> =
+            Collections.synchronizedMap(object : LinkedHashMap<K, V>(16, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?) = size > maxSize
+            })
     }
 
-    // Legacy in-memory caches (kept for backward compatibility with reverseGeocode)
-    private val addressCache = mutableMapOf<String, String>()
-    private val locationCache = mutableMapOf<String, GeocodedLocation>()
+    // Legacy in-memory caches (kept for backward compatibility with reverseGeocode),
+    // bounded so a long session can't accumulate unbounded entries.
+    private val addressCache = lruCache<String, String>(ADDRESS_CACHE_SIZE)
+    private val locationCache = lruCache<String, GeocodedLocation>(ADDRESS_CACHE_SIZE)
+
+    // Serializes all Nominatim calls at the policy rate.
+    private val nominatimMutex = Mutex()
+    private var lastNominatimCallAt = 0L
+
+    private suspend fun <T> rateLimitedNominatim(block: suspend () -> Response<T>): Response<T> =
+        nominatimMutex.withLock {
+            val wait = NOMINATIM_MIN_INTERVAL_MS - (SystemClock.elapsedRealtime() - lastNominatimCallAt)
+            if (wait > 0) delay(wait)
+            try {
+                block()
+            } finally {
+                lastNominatimCallAt = SystemClock.elapsedRealtime()
+            }
+        }
 
     /**
      * Convert coordinate to grid cell.
@@ -114,31 +149,37 @@ class GeocodingRepository @Inject constructor(
         // Deduplicate by grid cell (same location = same grid)
         val uniqueItems = items.distinctBy { it.gridLat to it.gridLon }
 
-        // Filter out already cached locations
-        val uncachedItems = uniqueItems.filter { item ->
-            geocodeCacheDao.get(item.gridLat, item.gridLon) == null
+        // Filter out already cached AND already queued cells with two batch key reads
+        // (this used to be one point query per location, and never deduped against the
+        // queue — so the progress total re-counted still-queued items on every sync and
+        // the percentage regressed instead of reaching 100%).
+        val cachedKeys = geocodeCacheDao.getAllGridKeys().mapTo(HashSet()) { it.gridLat to it.gridLon }
+        val queuedKeys = geocodeQueueDao.getAllGridKeys().mapTo(HashSet()) { it.gridLat to it.gridLon }
+        val newItems = uniqueItems.filter { item ->
+            val key = item.gridLat to item.gridLon
+            key !in cachedKeys && key !in queuedKeys
         }
 
-        if (uncachedItems.isNotEmpty()) {
-            geocodeQueueDao.enqueueAll(uncachedItems)
+        if (newItems.isNotEmpty()) {
+            geocodeQueueDao.enqueueAll(newItems)
 
-            // Update progress tracking with actual unique count
+            // Update progress tracking with actual new-work count
             val progress = geocodeProgressDao.get(carId)
             if (progress == null) {
                 geocodeProgressDao.upsert(
                     GeocodeProgress(
                         carId = carId,
-                        totalLocations = uncachedItems.size,
+                        totalLocations = newItems.size,
                         processedLocations = 0,
                         lastUpdatedAt = System.currentTimeMillis()
                     )
                 )
             } else {
-                geocodeProgressDao.incrementTotal(carId, uncachedItems.size, System.currentTimeMillis())
+                geocodeProgressDao.incrementTotal(carId, newItems.size, System.currentTimeMillis())
             }
         }
 
-        return uncachedItems.size
+        return newItems.size
     }
 
     /**
@@ -147,7 +188,7 @@ class GeocodingRepository @Inject constructor(
      */
     suspend fun geocodeAndCache(item: GeocodeQueueItem): GeocodeCache? {
         return try {
-            val response = nominatimApi.reverseGeocode(item.latitude, item.longitude)
+            val response = rateLimitedNominatim { nominatimApi.reverseGeocode(item.latitude, item.longitude) }
             if (!response.isSuccessful) {
                 geocodeQueueDao.markAttempt(item.gridLat, item.gridLon, System.currentTimeMillis())
                 return null
@@ -212,15 +253,16 @@ class GeocodingRepository @Inject constructor(
     suspend fun getCachedCount(): Int = geocodeCacheDao.count()
 
     /**
-     * Sync progress with actual cache count.
-     * Called when queue is empty but progress shows incomplete work.
-     * This fixes stale progress data from interrupted/cleared geocoding.
+     * Mark all progress records complete. Called when the queue is empty but progress
+     * shows incomplete work (stale data from interrupted/cleared geocoding).
      */
-    suspend fun syncProgressWithCache(cachedCount: Int) {
-        // Update all car progress records to match reality
-        // When queue is empty and we have cached items, those are the completed ones
-        geocodeProgressDao.syncWithCache(cachedCount)
+    suspend fun markProgressComplete() {
+        geocodeProgressDao.markAllComplete()
     }
+
+    /** Batch lookup of cached geocode data keyed by grid cell. */
+    suspend fun getAllCachedByGrid(): Map<Pair<Int, Int>, GeocodeCache> =
+        geocodeCacheDao.getAll().associateBy { it.gridLat to it.gridLon }
 
     /**
      * Observe geocoding progress for a car.
@@ -257,7 +299,7 @@ class GeocodingRepository @Inject constructor(
         addressCache[cacheKey]?.let { return it }
 
         return try {
-            val response = nominatimApi.reverseGeocode(latitude, longitude)
+            val response = rateLimitedNominatim { nominatimApi.reverseGeocode(latitude, longitude) }
             if (response.isSuccessful) {
                 val result = response.body()
                 val address = formatAddress(result?.address)
@@ -284,7 +326,7 @@ class GeocodingRepository @Inject constructor(
         locationCache[cacheKey]?.let { return it }
 
         return try {
-            val response = nominatimApi.reverseGeocode(latitude, longitude)
+            val response = rateLimitedNominatim { nominatimApi.reverseGeocode(latitude, longitude) }
             if (response.isSuccessful) {
                 val result = response.body()
                 val address = result?.address
@@ -327,8 +369,9 @@ class GeocodingRepository @Inject constructor(
 
     // === Country Boundary Methods ===
 
-    // Cache for country boundaries (in-memory, cleared on app restart)
-    private val boundaryCache = mutableMapOf<String, CountryBoundary>()
+    // Cache for country boundaries — bounded: full-resolution multipolygons (Norway/Canada
+    // coastlines) run to several MB each, so keep only the last few.
+    private val boundaryCache = lruCache<String, CountryBoundary>(BOUNDARY_CACHE_SIZE)
 
     /**
      * Fetch country boundary polygon from Nominatim.
@@ -336,51 +379,30 @@ class GeocodingRepository @Inject constructor(
      * Results are cached in memory.
      */
     suspend fun getCountryBoundary(countryCode: String): CountryBoundary? {
-        Log.d("GeocodingRepository", "getCountryBoundary called for $countryCode")
-
         // Check cache first
-        boundaryCache[countryCode]?.let {
-            Log.d("GeocodingRepository", "Returning cached boundary for $countryCode with ${it.polygons.size} polygons")
-            return it
-        }
+        boundaryCache[countryCode]?.let { return it }
 
         return try {
-            Log.d("GeocodingRepository", "Fetching boundary from API for $countryCode")
-            val response = nominatimApi.searchCountryBoundary(countryCode)
-            Log.d("GeocodingRepository", "API response: success=${response.isSuccessful}, code=${response.code()}")
-
+            val response = rateLimitedNominatim { nominatimApi.searchCountryBoundary(countryCode) }
             if (!response.isSuccessful || response.body().isNullOrEmpty()) {
-                Log.w("GeocodingRepository", "Failed to fetch boundary for $countryCode: ${response.errorBody()?.string()}")
+                Log.w("GeocodingRepository", "Failed to fetch boundary for $countryCode: code=${response.code()}")
                 return null
             }
 
-            val result = response.body()?.firstOrNull()
-            if (result == null) {
-                Log.w("GeocodingRepository", "No results in response for $countryCode")
-                return null
-            }
-
-            Log.d("GeocodingRepository", "Got result: displayName=${result.displayName}, hasGeoJson=${result.geojson != null}")
-
-            val geoJson = result.geojson
+            val geoJson = response.body()?.firstOrNull()?.geojson
             if (geoJson == null) {
                 Log.w("GeocodingRepository", "No geojson in result for $countryCode")
                 return null
             }
 
-            Log.d("GeocodingRepository", "GeoJSON type: ${geoJson.type}, coordinates class: ${geoJson.coordinates?.javaClass?.name}")
-
             val polygons = parseGeoJsonToPolygons(geoJson.type, geoJson.coordinates)
-            Log.d("GeocodingRepository", "Parsed ${polygons.size} polygons for $countryCode")
-
             if (polygons.isEmpty()) {
-                Log.w("GeocodingRepository", "No polygons parsed for $countryCode")
+                Log.w("GeocodingRepository", "No polygons parsed for $countryCode (type=${geoJson.type})")
                 return null
             }
 
             val boundary = CountryBoundary(countryCode, polygons)
             boundaryCache[countryCode] = boundary
-            Log.d("GeocodingRepository", "Successfully cached boundary for $countryCode")
             boundary
         } catch (e: Exception) {
             Log.e("GeocodingRepository", "Error fetching boundary for $countryCode", e)

--- a/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/GeocodeWorker.kt
@@ -77,12 +77,12 @@ class GeocodeWorker @AssistedInject constructor(
             geocodingRepository.resetFailedItems()
         }
 
-        // If queue is completely empty but we have cached items, progress should match cache
-        // This handles the case where queue was cleared but progress wasn't updated
+        // If queue is completely empty but progress shows incomplete work, close it out
+        // (handles the case where the queue was cleared but progress wasn't updated)
         if (totalQueue == 0 && cachedCount > 0) {
-            geocodingRepository.syncProgressWithCache(cachedCount)
-            Log.d(TAG, "Synced progress with cache count: $cachedCount")
-            log("Synced progress with cache count: $cachedCount")
+            geocodingRepository.markProgressComplete()
+            Log.d(TAG, "Queue empty — marked progress complete")
+            log("Queue empty — marked progress complete")
         }
 
         // Run as foreground service (optional - may fail from background)

--- a/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
@@ -548,70 +548,57 @@ class SyncRepository @Inject constructor(
      * Returns the number of unique locations enqueued.
      */
     suspend fun reEnqueueLocationsForGeocoding(carId: Int): Int {
-        val driveLocations = aggregateDao.getDriveLocationsNeedingGeocode(carId)
-            .mapNotNull { it.toLatLon() }
-        val chargeLocations = aggregateDao.getChargeLocationsNeedingGeocode(carId)
-            .mapNotNull { it.toLatLon() }
+        val drives = aggregateDao.getDriveLocationsNeedingGeocode(carId)
+        val charges = aggregateDao.getChargeLocationsNeedingGeocode(carId)
+        log("Found ${drives.size} drive + ${charges.size} charge locations needing geocode")
 
-        val allLocations = driveLocations + chargeLocations
-        log("Found ${driveLocations.size} drive + ${chargeLocations.size} charge locations needing geocode")
-
-        if (allLocations.isEmpty()) {
+        if (drives.isEmpty() && charges.isEmpty()) {
             log("No locations need geocoding")
             return 0
         }
 
-        // First, apply any cached geocode data to aggregates
-        val applied = applyCachedGeocodeData(carId, allLocations)
+        // First, apply any cached geocode data to aggregates. Grouping ids per cached cell
+        // and updating by primary key replaces the old per-cell CAST(lat*100)-matching
+        // UPDATEs, which SQLite could never index (a full table scan per cell, twice).
+        val cacheByGrid = geocodingRepository.getAllCachedByGrid()
+        var applied = 0
+
+        val drivesByCache = drives.groupBy { row ->
+            cacheByGrid[geocodingRepository.toGridCoord(row.latitude) to geocodingRepository.toGridCoord(row.longitude)]
+        }
+        for ((cached, rows) in drivesByCache) {
+            if (cached == null) continue
+            rows.map { it.id }.chunked(500).forEach { ids ->
+                aggregateDao.updateDriveLocationsByIds(ids, cached.countryCode, cached.countryName, cached.regionName, cached.city)
+            }
+            applied += rows.size
+        }
+
+        val chargesByCache = charges.groupBy { row ->
+            cacheByGrid[geocodingRepository.toGridCoord(row.latitude) to geocodingRepository.toGridCoord(row.longitude)]
+        }
+        for ((cached, rows) in chargesByCache) {
+            if (cached == null) continue
+            rows.map { it.id }.chunked(500).forEach { ids ->
+                aggregateDao.updateChargeLocationsByIds(ids, cached.countryCode, cached.countryName, cached.regionName, cached.city)
+            }
+            applied += rows.size
+        }
+
         if (applied > 0) {
             log("Applied cached geocode data to $applied locations")
         }
 
         // Then enqueue any still-uncached locations
-        val enqueued = geocodingRepository.enqueueLocationsForCar(carId, allLocations)
+        val uncached = (drivesByCache[null].orEmpty() + chargesByCache[null].orEmpty())
+            .map { it.latitude to it.longitude }
+        if (uncached.isEmpty()) {
+            log("All locations were served from cache")
+            return 0
+        }
+        val enqueued = geocodingRepository.enqueueLocationsForCar(carId, uncached)
         log("Re-enqueued $enqueued unique locations for geocoding")
         return enqueued
-    }
-
-    /**
-     * Apply cached geocode data to drive/charge aggregates.
-     * This handles the case where geocoding completed but aggregates weren't updated.
-     */
-    private suspend fun applyCachedGeocodeData(carId: Int, locations: List<Pair<Double, Double>>): Int {
-        var appliedCount = 0
-        val uniqueGridCells = locations
-            .map { (lat, lon) ->
-                geocodingRepository.toGridCoord(lat) to geocodingRepository.toGridCoord(lon)
-            }
-            .distinct()
-
-        for ((gridLat, gridLon) in uniqueGridCells) {
-            val cached = geocodingRepository.getFromCacheByGrid(gridLat, gridLon)
-            if (cached != null) {
-                // Update drive aggregates in this grid cell
-                aggregateDao.updateDriveLocationsInGrid(
-                    carId = carId,
-                    gridLat = gridLat,
-                    gridLon = gridLon,
-                    countryCode = cached.countryCode,
-                    countryName = cached.countryName,
-                    regionName = cached.regionName,
-                    city = cached.city
-                )
-                // Update charge aggregates in this grid cell
-                aggregateDao.updateChargeLocationsInGrid(
-                    carId = carId,
-                    gridLat = gridLat,
-                    gridLon = gridLon,
-                    countryCode = cached.countryCode,
-                    countryName = cached.countryName,
-                    regionName = cached.regionName,
-                    city = cached.city
-                )
-                appliedCount++
-            }
-        }
-        return appliedCount
     }
 }
 


### PR DESCRIPTION
Eighth cluster from the code review — the geocoding pipeline.

- **Full-scan UPDATEs eliminated**: applying cached geocode data used `UPDATE … WHERE CAST(startLatitude * 100 AS INT) = :gridLat` — unindexable, so every grid cell cost two full table scans at the end of every sync (hundreds of cells → hundreds of scans). The needing-geocode queries now return row ids, and updates run per-id in chunks of 500 through the primary key. (The GeocodeWorker's own per-geocode grid update stays — it runs at most once per second and only for freshly geocoded cells.)
- **Enqueue dedup batched**: one read of cache keys + one of queue keys instead of a point query per location — and the queue dedup is new, which fixes the **progress bar regressing**: still-queued items were re-counted into `totalLocations` on every sync. The queue-empty reconciliation now marks each car's own progress complete instead of writing the global cache count into every car's row (wrong for multi-car).
- **Nominatim rate limit enforced centrally**: `reverseGeocode`/`reverseGeocodeWithCountry` (used per-alert by sentry history and by the widget) and country-boundary fetches bypassed the worker's 1.1 s spacing — burst traffic risks an IP ban that would break everything. All Nominatim calls now serialize through one 1.1 s/request limiter in the repository.
- **Bounded caches**: address/location LRU (256), country boundaries LRU (3 — full-resolution multipolygons are several MB each).
- **Null Island**: charges whose API coordinates were null are stored as (0,0); they're now excluded from geocoding.
- Also trimmed the ~10 unconditional debug logs per boundary fetch.

Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)