### PR TITLE
Unify the charging/sentry check into a shared use case

### DIFF
--- a/app/src/main/java/com/matedroid/data/sync/ChargingCheckUseCase.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingCheckUseCase.kt
@@ -1,0 +1,158 @@
+package com.matedroid.data.sync
+
+import android.content.Context
+import android.util.Log
+import com.matedroid.data.api.models.CarData
+import com.matedroid.data.api.models.CarStatus
+import com.matedroid.data.local.ChargeSessionStateDataStore
+import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.data.repository.ApiResult
+import com.matedroid.data.repository.SentryEvent
+import com.matedroid.data.repository.SentryStateRepository
+import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.notification.SentryNotificationManager
+import com.matedroid.widget.CarWidgetUpdateWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The single implementation of the periodic charging/sentry check, shared by
+ * [ChargingNotificationWorker] (background 30s/5min chain) and
+ * [com.matedroid.service.ChargingMonitorService] (foreground 30s loop while charging).
+ *
+ * It owns everything both callers must agree on: fetching car statuses, persisting the
+ * DC-session flag, processing sentry events (including their notifications), and
+ * classifying each car. What it deliberately does NOT do is post charging notifications
+ * or start/stop the monitor service — the two callers render those differently
+ * (startForeground vs. plain notify) and must aggregate across all cars themselves.
+ */
+@Singleton
+class ChargingCheckUseCase @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val teslamateRepository: TeslamateRepository,
+    private val settingsDataStore: SettingsDataStore,
+    private val chargeSessionStateDataStore: ChargeSessionStateDataStore,
+    private val sentryStateRepository: SentryStateRepository,
+    private val sentryNotificationManager: SentryNotificationManager
+) {
+    companion object {
+        private const val TAG = "ChargingCheckUseCase"
+    }
+
+    sealed interface Result {
+        /** No server configured — nothing to poll. */
+        data object NotConfigured : Result
+
+        /** The cars list itself couldn't be fetched. */
+        data class Error(val message: String) : Result
+
+        data class Checked(
+            val cars: List<CarCheck>,
+            /** True when at least one car's status fetch failed — those must not count as idle. */
+            val anyCheckFailed: Boolean
+        ) : Result
+    }
+
+    data class CarCheck(
+        val car: CarData,
+        val status: CarStatus,
+        val isCharging: Boolean,
+        val dcFinishedPluggedIn: Boolean
+    ) {
+        /** The shared monitor service must run while this is true for any car. */
+        val needsMonitor: Boolean get() = isCharging || dcFinishedPluggedIn
+
+        /**
+         * 30s polling is warranted even when idle: plugged-in cars can start charging any
+         * moment, sentry-armed cars have a ~1-minute alert window, and a driving car may
+         * pull into a DC fast charger where plug-to-charging takes seconds.
+         */
+        val wantsFrequentPolling: Boolean
+            get() = needsMonitor ||
+                status.pluggedIn == true ||
+                status.sentryMode == true ||
+                status.state?.lowercase() == "driving"
+    }
+
+    suspend fun checkAllCars(): Result {
+        val settings = settingsDataStore.settings.first()
+        if (!settings.isConfigured) return Result.NotConfigured
+
+        val cars = when (val carsResult = teslamateRepository.getCars()) {
+            is ApiResult.Success -> carsResult.data
+            is ApiResult.Error -> return Result.Error(carsResult.message)
+        }
+
+        var anyCheckFailed = false
+        val checks = mutableListOf<CarCheck>()
+        for (car in cars) {
+            val check = try {
+                checkCar(car)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error checking car ${car.carId}", e)
+                null
+            }
+            if (check != null) checks.add(check) else anyCheckFailed = true
+        }
+        return Result.Checked(checks, anyCheckFailed)
+    }
+
+    private suspend fun checkCar(car: CarData): CarCheck? {
+        val carId = car.carId
+
+        val status = when (val statusResult = teslamateRepository.getCarStatus(carId)) {
+            is ApiResult.Success -> statusResult.data.status
+            is ApiResult.Error -> {
+                Log.e(TAG, "Failed to fetch status for car $carId: ${statusResult.message}")
+                return null
+            }
+        }
+
+        // Persist whether the active session is DC; this is the only moment we can
+        // tell (post-completion `charger_phases` is null regardless of charge type).
+        if (status.isCharging && status.isDcCharging) {
+            chargeSessionStateDataStore.setLastSessionDc(carId, true)
+        } else if (status.pluggedIn == false) {
+            chargeSessionStateDataStore.clear(carId)
+        }
+
+        val dcFinishedPluggedIn = status.isChargeCompletePluggedIn &&
+            chargeSessionStateDataStore.wasLastSessionDc(carId)
+
+        processSentry(car, status)
+
+        return CarCheck(
+            car = car,
+            status = status,
+            isCharging = status.isCharging,
+            dcFinishedPluggedIn = dcFinishedPluggedIn
+        )
+    }
+
+    private suspend fun processSentry(car: CarData, status: CarStatus) {
+        val carId = car.carId
+        val sentryMode = status.sentryMode ?: false
+
+        when (val event = sentryStateRepository.processStatus(
+            carId, sentryMode, status.isSentryAlerted, status.latitude, status.longitude, status.geofence
+        )) {
+            is SentryEvent.AlertDetected -> {
+                Log.d(TAG, "Sentry alert #${event.count} for car $carId (notify=${event.shouldNotify})")
+                sentryNotificationManager.showSentryAlert(
+                    carName = car.displayName,
+                    carId = carId,
+                    eventCount = event.count,
+                    shouldAlert = event.shouldNotify
+                )
+                CarWidgetUpdateWorker.scheduleImmediateUpdate(appContext)
+            }
+            is SentryEvent.SessionEnded -> {
+                Log.d(TAG, "Sentry session ended for car $carId")
+                sentryNotificationManager.cancelNotification(carId)
+            }
+            null -> { /* no event */ }
+        }
+    }
+}

--- a/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
+++ b/app/src/main/java/com/matedroid/data/sync/ChargingNotificationWorker.kt
@@ -12,21 +12,11 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import com.matedroid.data.local.ChargeSessionStateDataStore
-import com.matedroid.data.local.SettingsDataStore
-import com.matedroid.data.api.models.CarData
-import com.matedroid.data.api.models.CarStatus
-import com.matedroid.data.repository.ApiResult
-import com.matedroid.data.repository.SentryEvent
-import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.notification.ChargingNotificationManager
-import com.matedroid.notification.SentryNotificationManager
 import com.matedroid.service.ChargingMonitorService
-import com.matedroid.widget.CarWidgetUpdateWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
 
 /**
@@ -40,11 +30,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val teslamateRepository: TeslamateRepository,
-    private val settingsDataStore: SettingsDataStore,
-    private val chargingNotificationManager: ChargingNotificationManager,
-    private val sentryStateRepository: SentryStateRepository,
-    private val sentryNotificationManager: SentryNotificationManager,
-    private val chargeSessionStateDataStore: ChargeSessionStateDataStore
+    private val chargingCheckUseCase: ChargingCheckUseCase,
+    private val chargingNotificationManager: ChargingNotificationManager
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -132,66 +119,48 @@ class ChargingNotificationWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         Log.d(TAG, "Starting notification check")
 
-        // Check if server is configured. Don't re-arm the frequent chain — the 15-min
-        // periodic backstop (a cheap local settings read, no network) resumes polling
-        // once the user configures a server.
-        val settings = settingsDataStore.settings.first()
-        if (!settings.isConfigured) {
-            Log.d(TAG, "Server not configured, skipping check")
+        // While the foreground monitor service is alive, its own 30s loop runs the exact
+        // same check (including sentry) — polling here too doubled every API call and made
+        // two writers race on the same DataStore and notification IDs.
+        if (ChargingMonitorService.isRunning) {
+            Log.d(TAG, "Monitor service is running, skipping duplicate check")
+            scheduleNextCheck(frequent = true)
             return Result.success()
         }
 
         try {
-            // Get list of cars
-            val carsResult = teslamateRepository.getCars()
-            val cars = when (carsResult) {
-                is ApiResult.Success -> carsResult.data
-                is ApiResult.Error -> {
-                    Log.e(TAG, "Failed to fetch cars: ${carsResult.message}")
+            val checkResult = chargingCheckUseCase.checkAllCars()
+
+            val checked = when (checkResult) {
+                is ChargingCheckUseCase.Result.NotConfigured -> {
+                    // Don't re-arm the frequent chain — the 15-min periodic backstop (a
+                    // cheap local settings read, no network) resumes polling once the
+                    // user configures a server.
+                    Log.d(TAG, "Server not configured, skipping check")
+                    return Result.success()
+                }
+                is ChargingCheckUseCase.Result.Error -> {
+                    Log.e(TAG, "Failed to fetch cars: ${checkResult.message}")
                     scheduleNextCheck(frequent = true)
                     return Result.retry()
                 }
+                is ChargingCheckUseCase.Result.Checked -> checkResult
             }
 
-            if (cars.isEmpty()) {
+            if (checked.cars.isEmpty() && !checked.anyCheckFailed) {
                 Log.d(TAG, "No cars found")
                 scheduleNextCheck(frequent = false)
                 return Result.success()
             }
 
-            Log.d(TAG, "Checking status for ${cars.size} cars")
+            // The service start/stop decision must aggregate across ALL cars: stopping
+            // per idle car would kill the other car's charging notification every 30 s.
+            val needMonitor = checked.cars.filter { it.needsMonitor }
 
-            // Check each car, collecting which ones need the shared monitor service.
-            // The start/stop decision must aggregate across ALL cars: stopping inside the
-            // per-car loop made any idle car kill the service (and every charging
-            // notification with it) 30 s after another car's iteration started it.
-            val needMonitor = mutableListOf<Pair<CarData, CarStatus>>()
-            var anyCheckFailed = false
-            var anyWantsFrequentPolling = false
-            for (car in cars) {
-                val outcome = try {
-                    checkCarStatus(car)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error checking car ${car.carId}", e)
-                    CheckOutcome.Failed
-                }
-                when (outcome) {
-                    is CheckOutcome.NeedsMonitor -> needMonitor.add(car to outcome.status)
-                    CheckOutcome.Failed -> anyCheckFailed = true
-                    is CheckOutcome.Idle -> {
-                        // Plugged-in cars can start charging any moment; sentry-armed cars
-                        // need 30s polling to catch the ~1-minute alert window; a driving
-                        // car may pull into a DC fast charger, where plug-to-charging is
-                        // seconds — a 5-min idle cadence would miss the start of a short
-                        // session. Only parked+unplugged+unarmed cars use the idle cadence.
-                        val status = outcome.status
-                        if (status.pluggedIn == true ||
-                            status.sentryMode == true ||
-                            status.state?.lowercase() == "driving"
-                        ) {
-                            anyWantsFrequentPolling = true
-                        }
-                    }
+            // Idle cars lose their charging notification (the check itself only classifies).
+            for (check in checked.cars) {
+                if (!check.needsMonitor) {
+                    chargingNotificationManager.cancelNotification(check.car.carId)
                 }
             }
 
@@ -202,17 +171,17 @@ class ChargingNotificationWorker @AssistedInject constructor(
                     // On Android 12+, can't start foreground service from background.
                     // Fall back to showing notifications directly (won't update in real-time).
                     Log.w(TAG, "Cannot start foreground service, showing notifications directly: ${e.message}")
-                    for ((car, status) in needMonitor) {
-                        if (status.isCharging) {
-                            val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(car.carId)
+                    for (check in needMonitor) {
+                        if (check.isCharging) {
+                            val liveChargeAvailable = teslamateRepository.isCurrentChargeAvailable(check.car.carId)
                             chargingNotificationManager.showChargingNotification(
-                                car, status, liveChargeAvailable,
-                                chronometerBaseMs = status.stateSinceEpochMs
+                                check.car, check.status, liveChargeAvailable,
+                                chronometerBaseMs = check.status.stateSinceEpochMs
                             )
                         }
                     }
                 }
-            } else if (!anyCheckFailed) {
+            } else if (!checked.anyCheckFailed) {
                 // Only stop when we positively know no car is charging — a failed check
                 // (transient network error) shouldn't tear down an active monitor.
                 Log.d(TAG, "No car needs monitoring, stopping monitor service")
@@ -221,8 +190,8 @@ class ChargingNotificationWorker @AssistedInject constructor(
 
             Log.d(TAG, "Check complete")
             // Back off to the idle cadence when nothing is (about to be) charging and no
-            // car is sentry-armed; keep 30s on errors so recovery is quick.
-            val frequent = needMonitor.isNotEmpty() || anyCheckFailed || anyWantsFrequentPolling
+            // car is sentry-armed or driving; keep 30s on errors so recovery is quick.
+            val frequent = checked.anyCheckFailed || checked.cars.any { it.wantsFrequentPolling }
             scheduleNextCheck(frequent)
             return Result.success()
 
@@ -231,86 +200,6 @@ class ChargingNotificationWorker @AssistedInject constructor(
             scheduleNextCheck(frequent = true)
             return Result.retry()
         }
-    }
-
-    /** Result of a per-car check; the caller aggregates these into one service start/stop decision. */
-    private sealed interface CheckOutcome {
-        /** Car is charging (or DC-finished-but-plugged) — the monitor service must run. */
-        data class NeedsMonitor(val status: CarStatus) : CheckOutcome
-        /** Car positively does not need monitoring (status carried for cadence decisions). */
-        data class Idle(val status: CarStatus) : CheckOutcome
-        /** Status unknown (fetch failed) — must not count as idle. */
-        data object Failed : CheckOutcome
-    }
-
-    /**
-     * Per-car check: persists the DC-session flag, handles sentry events, and cancels the
-     * charging notification for idle cars. Starting or stopping the shared monitor service
-     * is the caller's job — it must aggregate across all cars.
-     */
-    private suspend fun checkCarStatus(car: CarData): CheckOutcome {
-        // The car object is already in hand from doWork()'s getCars() — no refetch.
-        val carId = car.carId
-
-        val statusResult = teslamateRepository.getCarStatus(carId)
-        val statusData = when (statusResult) {
-            is ApiResult.Success -> statusResult.data
-            is ApiResult.Error -> {
-                Log.e(TAG, "Failed to fetch status for car $carId: ${statusResult.message}")
-                return CheckOutcome.Failed
-            }
-        }
-
-        val status = statusData.status
-
-        // Persist whether the active session is DC; this is the only moment we can
-        // tell (post-completion `charger_phases` is null regardless of charge type).
-        if (status.isCharging && status.isDcCharging) {
-            chargeSessionStateDataStore.setLastSessionDc(carId, true)
-        } else if (status.pluggedIn == false) {
-            chargeSessionStateDataStore.clear(carId)
-        }
-
-        val dcFinishedPluggedIn = status.isChargeCompletePluggedIn &&
-            chargeSessionStateDataStore.wasLastSessionDc(carId)
-
-        // --- Charging ---
-        val chargingOutcome = if (status.isCharging) {
-            Log.d(TAG, "Car $carId is charging at ${status.batteryLevel}%")
-            CheckOutcome.NeedsMonitor(status)
-        } else if (dcFinishedPluggedIn) {
-            // DC charge finished but cable still plugged — keep service alive
-            Log.d(TAG, "Car $carId DC charge finished but still plugged in")
-            CheckOutcome.NeedsMonitor(status)
-        } else {
-            Log.d(TAG, "Car $carId is not charging")
-            chargingNotificationManager.cancelNotification(carId)
-            CheckOutcome.Idle(status)
-        }
-
-        // --- Sentry ---
-        val sentryMode = status.sentryMode ?: false
-        val isSentryAlerted = status.isSentryAlerted
-
-        when (val event = sentryStateRepository.processStatus(carId, sentryMode, isSentryAlerted, status.latitude, status.longitude, status.geofence)) {
-            is SentryEvent.AlertDetected -> {
-                Log.d(TAG, "Sentry alert #${event.count} for car $carId (notify=${event.shouldNotify})")
-                sentryNotificationManager.showSentryAlert(
-                    carName = car.displayName,
-                    carId = carId,
-                    eventCount = event.count,
-                    shouldAlert = event.shouldNotify
-                )
-                CarWidgetUpdateWorker.scheduleImmediateUpdate(appContext)
-            }
-            is SentryEvent.SessionEnded -> {
-                Log.d(TAG, "Sentry session ended for car $carId")
-                sentryNotificationManager.cancelNotification(carId)
-            }
-            null -> { /* no event */ }
-        }
-
-        return chargingOutcome
     }
 
     /**

--- a/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
+++ b/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
@@ -11,10 +11,8 @@ import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.matedroid.R
-import com.matedroid.data.local.ChargeSessionStateDataStore
-import com.matedroid.data.local.SettingsDataStore
-import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.data.sync.ChargingCheckUseCase
 import com.matedroid.notification.ChargingNotificationManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -23,7 +21,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -42,6 +39,15 @@ class ChargingMonitorService : Service() {
         private const val UPDATE_INTERVAL_MS = 30_000L  // 30 seconds
         private const val INITIAL_NOTIFICATION_ID = 3999  // Temporary ID for initial foreground
 
+        /**
+         * True between onCreate and onDestroy. ChargingNotificationWorker skips its own
+         * check while this is set — the service's loop runs the same one (incl. sentry),
+         * and both polling would double every API call.
+         */
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
         fun start(context: Context) {
             val intent = Intent(context, ChargingMonitorService::class.java)
             context.startForegroundService(intent)
@@ -54,9 +60,8 @@ class ChargingMonitorService : Service() {
     }
 
     @Inject lateinit var teslamateRepository: TeslamateRepository
-    @Inject lateinit var settingsDataStore: SettingsDataStore
+    @Inject lateinit var chargingCheckUseCase: ChargingCheckUseCase
     @Inject lateinit var chargingNotificationManager: ChargingNotificationManager
-    @Inject lateinit var chargeSessionStateDataStore: ChargeSessionStateDataStore
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var monitorJob: Job? = null
@@ -72,6 +77,7 @@ class ChargingMonitorService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
         Log.d(TAG, "Service created")
     }
 
@@ -106,6 +112,7 @@ class ChargingMonitorService : Service() {
 
     override fun onDestroy() {
         Log.d(TAG, "Service destroyed, cancelling ${activeNotificationCarIds.size} notifications")
+        isRunning = false
         isMonitoring = false
         monitorJob?.cancel()
 
@@ -231,50 +238,27 @@ class ChargingMonitorService : Service() {
      */
     private suspend fun performChargingCheck(): Boolean {
         try {
-            val settings = settingsDataStore.settings.first()
-            if (!settings.isConfigured) {
-                Log.d(TAG, "Server not configured")
-                return false
-            }
-
-            val carsResult = teslamateRepository.getCars()
-            val cars = when (carsResult) {
-                is ApiResult.Success -> carsResult.data
-                is ApiResult.Error -> {
-                    Log.e(TAG, "Failed to fetch cars: ${carsResult.message}")
+            val checked = when (val result = chargingCheckUseCase.checkAllCars()) {
+                is ChargingCheckUseCase.Result.NotConfigured -> {
+                    Log.d(TAG, "Server not configured")
                     return false
                 }
+                is ChargingCheckUseCase.Result.Error -> {
+                    Log.e(TAG, "Failed to fetch cars: ${result.message}")
+                    return false
+                }
+                is ChargingCheckUseCase.Result.Checked -> result
             }
 
             var anyCharging = false
 
-            for (car in cars) {
-                val statusResult = teslamateRepository.getCarStatus(car.carId)
-                val statusData = when (statusResult) {
-                    is ApiResult.Success -> statusResult.data
-                    is ApiResult.Error -> {
-                        Log.e(TAG, "Failed to fetch status for car ${car.carId}: ${statusResult.message}")
-                        continue
-                    }
-                }
-
-                val status = statusData.status
-
+            for (check in checked.cars) {
+                val car = check.car
+                val status = check.status
                 val notificationId = ChargingNotificationManager.NOTIFICATION_ID_BASE + car.carId
 
-                // Only `isCharging && phases == 0` confirms DC. After completion phases
-                // is null for any charge type, so we persist the in-session flag.
-                if (status.isCharging && status.isDcCharging) {
-                    chargeSessionStateDataStore.setLastSessionDc(car.carId, true)
-                } else if (status.pluggedIn == false) {
-                    chargeSessionStateDataStore.clear(car.carId)
-                }
-
-                val wasDcSession = chargeSessionStateDataStore.wasLastSessionDc(car.carId)
-                val dcFinishedPluggedIn = status.isChargeCompletePluggedIn && wasDcSession
-
                 when {
-                    status.isCharging -> {
+                    check.isCharging -> {
                         anyCharging = true
                         activeNotificationCarIds.add(car.carId)
                         Log.d(TAG, "Car ${car.carId} charging at ${status.batteryLevel}%")
@@ -287,7 +271,7 @@ class ChargingMonitorService : Service() {
                         updateForegroundNotification(notificationId, notification, car, status, liveChargeAvailable)
                     }
 
-                    dcFinishedPluggedIn -> {
+                    check.dcFinishedPluggedIn -> {
                         // DC charge finished but cable still plugged — keep notification alive
                         anyCharging = true
                         activeNotificationCarIds.add(car.carId)


### PR DESCRIPTION
Ninth cluster from the code review.

`ChargingNotificationWorker.checkCarStatus` and `ChargingMonitorService.performChargingCheck` were near-duplicates: both fetched cars + statuses, persisted the DC-session flag, computed `dcFinishedPluggedIn`, and classified each car — and while the service was alive both ran concurrently at 30 s cadence, doubling every API call and racing as two writers on the same `ChargeSessionStateDataStore` and notification IDs. This duplication is what allowed the multi-car flap bug (#341) to exist in one copy but not the other.

- New `ChargingCheckUseCase.checkAllCars()` owns: configured check, cars fetch, per-car status fetch, DC-session persistence, **sentry processing** (notifications + widget kick), and classification (`isCharging` / `dcFinishedPluggedIn` / `needsMonitor` / `wantsFrequentPolling`).
- Callers keep what genuinely differs: the worker aggregates the service start/stop decision, falls back to direct notifications when the FGS can't start, and picks the polling cadence; the service renders `startForeground` notifications and keeps its consecutive-failure shutdown.
- The worker now **skips its check while the service is running** (`ChargingMonitorService.isRunning`, set in onCreate/onDestroy) — sentry keeps working through the service since it's in the use case. The 65 s sentry debounce makes the brief handover race harmless.

No behavior change intended beyond eliminating the double polling. Local `lintDebug` + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)