### PR TITLE
Collapse all-time/in-range DAO query duplication

### DIFF
--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -8,6 +8,10 @@ import com.matedroid.data.local.entity.ChargeDetailAggregate
 import com.matedroid.data.local.entity.ChargeSummary
 import com.matedroid.data.local.entity.DriveDetailAggregate
 
+/**
+ * Range-parameterized queries: callers wanting all-time results pass
+ * [DateBounds.MIN] / [DateBounds.MAX] as the date bounds.
+ */
 @Dao
 interface AggregateDao {
 
@@ -41,29 +45,16 @@ interface AggregateDao {
 
     // === Deep Stats: Elevation ===
 
-    // Highest altitude ever reached
-    @Query("""
-        SELECT MAX(maxElevation) FROM drive_detail_aggregates
-        WHERE carId = :carId AND hasElevationData = 1
-    """)
-    suspend fun maxElevation(carId: Int): Int?
-
+    // Highest altitude reached
     @Query("""
         SELECT MAX(maxElevation) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.hasElevationData = 1
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun maxElevationInRange(carId: Int, startDate: String, endDate: String): Int?
+    suspend fun maxElevation(carId: Int, startDate: String, endDate: String): Int?
 
     // Drive with highest altitude
-    @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
-        WHERE a.carId = :carId AND a.hasElevationData = 1
-        ORDER BY a.maxElevation DESC LIMIT 1
-    """)
-    suspend fun driveWithMaxElevation(carId: Int): DriveDetailAggregate?
-
     @Query("""
         SELECT a.* FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
@@ -71,7 +62,7 @@ interface AggregateDao {
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.maxElevation DESC LIMIT 1
     """)
-    suspend fun driveWithMaxElevationInRange(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun driveWithMaxElevation(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
 
     // Lowest altitude ever reached
     @Query("""
@@ -91,47 +82,26 @@ interface AggregateDao {
     // Drive with most accumulated elevation gain (total meters climbed)
     @Query("""
         SELECT a.* FROM drive_detail_aggregates a
-        WHERE a.carId = :carId
-        AND a.elevationGain IS NOT NULL
-        ORDER BY a.elevationGain DESC LIMIT 1
-    """)
-    suspend fun driveWithMostElevationGain(carId: Int): DriveDetailAggregate?
-
-    @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND a.elevationGain IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.elevationGain DESC LIMIT 1
     """)
-    suspend fun driveWithMostElevationGainInRange(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun driveWithMostElevationGain(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
 
     // === Deep Stats: Temperature (Driving) ===
 
     // Hottest outside temperature while driving
-    @Query("""
-        SELECT MAX(maxOutsideTemp) FROM drive_detail_aggregates
-        WHERE carId = :carId
-    """)
-    suspend fun maxOutsideTempDriving(carId: Int): Double?
-
     @Query("""
         SELECT MAX(maxOutsideTemp) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun maxOutsideTempDrivingInRange(carId: Int, startDate: String, endDate: String): Double?
+    suspend fun maxOutsideTempDriving(carId: Int, startDate: String, endDate: String): Double?
 
     // Drive with hottest temperature
-    @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
-        WHERE a.carId = :carId AND a.maxOutsideTemp IS NOT NULL
-        ORDER BY a.maxOutsideTemp DESC LIMIT 1
-    """)
-    suspend fun hottestDrive(carId: Int): DriveDetailAggregate?
-
     @Query("""
         SELECT a.* FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
@@ -139,32 +109,18 @@ interface AggregateDao {
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.maxOutsideTemp DESC LIMIT 1
     """)
-    suspend fun hottestDriveInRange(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun hottestDrive(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
 
     // Coldest outside temperature while driving
-    @Query("""
-        SELECT MIN(minOutsideTemp) FROM drive_detail_aggregates
-        WHERE carId = :carId
-    """)
-    suspend fun minOutsideTempDriving(carId: Int): Double?
-
-    // Drive with coldest temperature
-    @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
-        WHERE a.carId = :carId AND a.minOutsideTemp IS NOT NULL
-        ORDER BY a.minOutsideTemp ASC LIMIT 1
-    """)
-    suspend fun coldestDrive(carId: Int): DriveDetailAggregate?
-
-    // Coldest outside temperature while driving in Range
     @Query("""
         SELECT MIN(minOutsideTemp) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun minOutsideTempDrivingInRange(carId: Int, startDate: String, endDate: String): Double?
+    suspend fun minOutsideTempDriving(carId: Int, startDate: String, endDate: String): Double?
 
+    // Drive with coldest temperature
     @Query("""
         SELECT a.* FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
@@ -172,117 +128,78 @@ interface AggregateDao {
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.minOutsideTemp ASC LIMIT 1
     """)
-    suspend fun coldestDriveInRange(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun coldestDrive(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
 
-    // Hottest cabin temperature in Range
+    // Hottest cabin temperature
     @Query("""
         SELECT MAX(maxInsideTemp) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun maxInsideTempInRange(carId: Int, startDate: String, endDate: String): Double?
+    suspend fun maxInsideTemp(carId: Int, startDate: String, endDate: String): Double?
 
-    // Coldest cabin temperature in Range
+    // Coldest cabin temperature
     @Query("""
         SELECT MIN(minInsideTemp) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun minInsideTempInRange(carId: Int, startDate: String, endDate: String): Double?
-
-    // Coldest outside temperature while charging in Range
-    @Query("""
-        SELECT MIN(minOutsideTemp) FROM charge_detail_aggregates a
-        JOIN charges_summary c ON a.chargeId = c.chargeId
-        WHERE a.carId = :carId
-        AND c.startDate >= :startDate AND c.startDate < :endDate
-    """)
-    suspend fun minOutsideTempChargingInRange(carId: Int, startDate: String, endDate: String): Double?
-
-    // Hottest cabin temperature
-    @Query("SELECT MAX(maxInsideTemp) FROM drive_detail_aggregates WHERE carId = :carId")
-    suspend fun maxInsideTemp(carId: Int): Double?
-
-    // Coldest cabin temperature
-    @Query("SELECT MIN(minInsideTemp) FROM drive_detail_aggregates WHERE carId = :carId")
-    suspend fun minInsideTemp(carId: Int): Double?
+    suspend fun minInsideTemp(carId: Int, startDate: String, endDate: String): Double?
 
     // === Deep Stats: Temperature (Charging) ===
 
     // Hottest outside temperature while charging
-    @Query("SELECT MAX(maxOutsideTemp) FROM charge_detail_aggregates WHERE carId = :carId")
-    suspend fun maxOutsideTempCharging(carId: Int): Double?
-
     @Query("""
         SELECT MAX(maxOutsideTemp) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun maxOutsideTempChargingInRange(carId: Int, startDate: String, endDate: String): Double?
+    suspend fun maxOutsideTempCharging(carId: Int, startDate: String, endDate: String): Double?
+
+    // Coldest outside temperature while charging
+    @Query("""
+        SELECT MIN(minOutsideTemp) FROM charge_detail_aggregates a
+        JOIN charges_summary c ON a.chargeId = c.chargeId
+        WHERE a.carId = :carId
+        AND c.startDate >= :startDate AND c.startDate < :endDate
+    """)
+    suspend fun minOutsideTempCharging(carId: Int, startDate: String, endDate: String): Double?
 
     // Charge with hottest temperature
     @Query("""
         SELECT a.* FROM charge_detail_aggregates a
-        WHERE a.carId = :carId AND a.maxOutsideTemp IS NOT NULL
-        ORDER BY a.maxOutsideTemp DESC LIMIT 1
-    """)
-    suspend fun hottestCharge(carId: Int): ChargeDetailAggregate?
-
-    @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.maxOutsideTemp IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.maxOutsideTemp DESC LIMIT 1
     """)
-    suspend fun hottestChargeInRange(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
-
-    // Coldest outside temperature while charging
-    @Query("SELECT MIN(minOutsideTemp) FROM charge_detail_aggregates WHERE carId = :carId")
-    suspend fun minOutsideTempCharging(carId: Int): Double?
+    suspend fun hottestCharge(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
 
     // Charge with coldest temperature
     @Query("""
         SELECT a.* FROM charge_detail_aggregates a
-        WHERE a.carId = :carId AND a.minOutsideTemp IS NOT NULL
-        ORDER BY a.minOutsideTemp ASC LIMIT 1
-    """)
-    suspend fun coldestCharge(carId: Int): ChargeDetailAggregate?
-
-    @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.minOutsideTemp IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.minOutsideTemp ASC LIMIT 1
     """)
-    suspend fun coldestChargeInRange(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
+    suspend fun coldestCharge(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
 
     // === Deep Stats: Charging Power ===
 
-    // Max charge power ever achieved
-    @Query("SELECT MAX(maxChargerPower) FROM charge_detail_aggregates WHERE carId = :carId")
-    suspend fun maxChargerPower(carId: Int): Int?
-
+    // Max charge power achieved
     @Query("""
         SELECT MAX(maxChargerPower) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun maxChargerPowerInRange(carId: Int, startDate: String, endDate: String): Int?
+    suspend fun maxChargerPower(carId: Int, startDate: String, endDate: String): Int?
 
     // Charge with max power
-    @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
-        WHERE a.carId = :carId AND a.maxChargerPower IS NOT NULL
-        ORDER BY a.maxChargerPower DESC LIMIT 1
-    """)
-    suspend fun chargeWithMaxPower(carId: Int): ChargeDetailAggregate?
-
     @Query("""
         SELECT a.* FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
@@ -290,33 +207,27 @@ interface AggregateDao {
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.maxChargerPower DESC LIMIT 1
     """)
-    suspend fun chargeWithMaxPowerInRange(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
+    suspend fun chargeWithMaxPower(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
 
     // === Deep Stats: AC/DC Ratio ===
 
     // Count of AC charges
-    @Query("SELECT COUNT(*) FROM charge_detail_aggregates WHERE carId = :carId AND isFastCharger = 0")
-    suspend fun countAcCharges(carId: Int): Int
-
     @Query("""
         SELECT COUNT(*) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.isFastCharger = 0
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun countAcChargesInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun countAcCharges(carId: Int, startDate: String, endDate: String): Int
 
     // Count of DC charges
-    @Query("SELECT COUNT(*) FROM charge_detail_aggregates WHERE carId = :carId AND isFastCharger = 1")
-    suspend fun countDcCharges(carId: Int): Int
-
     @Query("""
         SELECT COUNT(*) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.isFastCharger = 1
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun countDcChargesInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun countDcCharges(carId: Int, startDate: String, endDate: String): Int
 
     // Get set of DC charge IDs (for UI badges)
     @Query("SELECT chargeId FROM charge_detail_aggregates WHERE carId = :carId AND isFastCharger = 1")
@@ -327,32 +238,18 @@ interface AggregateDao {
         SELECT COALESCE(SUM(c.energyAdded), 0.0) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.isFastCharger = 0
-    """)
-    suspend fun sumAcChargeEnergy(carId: Int): Double
-
-    @Query("""
-        SELECT COALESCE(SUM(c.energyAdded), 0.0) FROM charge_detail_aggregates a
-        JOIN charges_summary c ON a.chargeId = c.chargeId
-        WHERE a.carId = :carId AND a.isFastCharger = 0
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun sumAcChargeEnergyInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumAcChargeEnergy(carId: Int, startDate: String, endDate: String): Double
 
     // Sum of energy added for DC charges
     @Query("""
         SELECT COALESCE(SUM(c.energyAdded), 0.0) FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.isFastCharger = 1
-    """)
-    suspend fun sumDcChargeEnergy(carId: Int): Double
-
-    @Query("""
-        SELECT COALESCE(SUM(c.energyAdded), 0.0) FROM charge_detail_aggregates a
-        JOIN charges_summary c ON a.chargeId = c.chargeId
-        WHERE a.carId = :carId AND a.isFastCharger = 1
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun sumDcChargeEnergyInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumDcChargeEnergy(carId: Int, startDate: String, endDate: String): Double
 
     // Get all processed charge IDs (for checking if we have aggregate data)
     @Query("SELECT chargeId FROM charge_detail_aggregates WHERE carId = :carId")
@@ -383,50 +280,14 @@ interface AggregateDao {
 
     // Count unique countries visited
     @Query("""
-        SELECT COUNT(DISTINCT startCountryCode) FROM drive_detail_aggregates
-        WHERE carId = :carId AND startCountryCode IS NOT NULL
-    """)
-    suspend fun countUniqueCountries(carId: Int): Int
-
-    @Query("""
         SELECT COUNT(DISTINCT a.startCountryCode) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.startCountryCode IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun countUniqueCountriesInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun countUniqueCountries(carId: Int, startDate: String, endDate: String): Int
 
     // Get countries visited with aggregated data (drives + charges)
-    @Query("""
-        SELECT
-            drive_stats.countryCode,
-            drive_stats.countryName,
-            drive_stats.firstVisitDate,
-            drive_stats.lastVisitDate,
-            drive_stats.driveCount,
-            drive_stats.totalDistanceKm,
-            COALESCE(charge_stats.totalChargeEnergyKwh, 0.0) as totalChargeEnergyKwh,
-            COALESCE(charge_stats.chargeCount, 0) as chargeCount
-        FROM (
-            SELECT a.startCountryCode as countryCode, a.startCountryName as countryName,
-                   MIN(d.startDate) as firstVisitDate, MAX(d.startDate) as lastVisitDate,
-                   COUNT(*) as driveCount, SUM(d.distance) as totalDistanceKm
-            FROM drive_detail_aggregates a
-            JOIN drives_summary d ON a.driveId = d.driveId
-            WHERE a.carId = :carId AND a.startCountryCode IS NOT NULL
-            GROUP BY a.startCountryCode
-        ) drive_stats
-        LEFT JOIN (
-            SELECT ca.countryCode, SUM(cs.energyAdded) as totalChargeEnergyKwh, COUNT(*) as chargeCount
-            FROM charge_detail_aggregates ca
-            JOIN charges_summary cs ON ca.chargeId = cs.chargeId
-            WHERE ca.carId = :carId AND ca.countryCode IS NOT NULL
-            GROUP BY ca.countryCode
-        ) charge_stats ON drive_stats.countryCode = charge_stats.countryCode
-        ORDER BY drive_stats.firstVisitDate ASC
-    """)
-    suspend fun getCountriesVisited(carId: Int): List<CountryVisitResult>
-
     @Query("""
         SELECT
             drive_stats.countryCode,
@@ -457,7 +318,7 @@ interface AggregateDao {
         ) charge_stats ON drive_stats.countryCode = charge_stats.countryCode
         ORDER BY drive_stats.firstVisitDate ASC
     """)
-    suspend fun getCountriesVisitedInRange(carId: Int, startDate: String, endDate: String): List<CountryVisitResult>
+    suspend fun getCountriesVisited(carId: Int, startDate: String, endDate: String): List<CountryVisitResult>
 
     // === Deep Stats: Regions Visited (within a country) ===
 
@@ -479,36 +340,6 @@ interface AggregateDao {
             FROM drive_detail_aggregates a
             JOIN drives_summary d ON a.driveId = d.driveId
             WHERE a.carId = :carId AND a.startCountryCode = :countryCode AND a.startRegionName IS NOT NULL
-            GROUP BY a.startRegionName
-        ) drive_stats
-        LEFT JOIN (
-            SELECT ca.regionName, SUM(cs.energyAdded) as totalChargeEnergyKwh, COUNT(*) as chargeCount
-            FROM charge_detail_aggregates ca
-            JOIN charges_summary cs ON ca.chargeId = cs.chargeId
-            WHERE ca.carId = :carId AND ca.countryCode = :countryCode AND ca.regionName IS NOT NULL
-            GROUP BY ca.regionName
-        ) charge_stats ON drive_stats.regionName = charge_stats.regionName
-        ORDER BY drive_stats.firstVisitDate ASC
-    """)
-    suspend fun getRegionsVisited(carId: Int, countryCode: String): List<RegionVisitResult>
-
-    @Query("""
-        SELECT
-            drive_stats.regionName,
-            drive_stats.countryCode,
-            drive_stats.firstVisitDate,
-            drive_stats.lastVisitDate,
-            drive_stats.driveCount,
-            drive_stats.totalDistanceKm,
-            COALESCE(charge_stats.totalChargeEnergyKwh, 0.0) as totalChargeEnergyKwh,
-            COALESCE(charge_stats.chargeCount, 0) as chargeCount
-        FROM (
-            SELECT a.startRegionName as regionName, a.startCountryCode as countryCode,
-                   MIN(d.startDate) as firstVisitDate, MAX(d.startDate) as lastVisitDate,
-                   COUNT(*) as driveCount, SUM(d.distance) as totalDistanceKm
-            FROM drive_detail_aggregates a
-            JOIN drives_summary d ON a.driveId = d.driveId
-            WHERE a.carId = :carId AND a.startCountryCode = :countryCode AND a.startRegionName IS NOT NULL
             AND d.startDate >= :startDate AND d.startDate < :endDate
             GROUP BY a.startRegionName
         ) drive_stats
@@ -522,7 +353,7 @@ interface AggregateDao {
         ) charge_stats ON drive_stats.regionName = charge_stats.regionName
         ORDER BY drive_stats.firstVisitDate ASC
     """)
-    suspend fun getRegionsVisitedInRange(carId: Int, countryCode: String, startDate: String, endDate: String): List<RegionVisitResult>
+    suspend fun getRegionsVisited(carId: Int, countryCode: String, startDate: String, endDate: String): List<RegionVisitResult>
 
     // Count unique regions in a country
     @Query("""
@@ -534,18 +365,12 @@ interface AggregateDao {
     // === Deep Stats: Cities Visited (Drives) ===
 
     @Query("""
-        SELECT COUNT(DISTINCT startCity) FROM drive_detail_aggregates
-        WHERE carId = :carId AND startCity IS NOT NULL
-    """)
-    suspend fun countUniqueDriveCities(carId: Int): Int
-
-    @Query("""
         SELECT COUNT(DISTINCT a.startCity) FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.startCity IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
     """)
-    suspend fun countUniqueDriveCitiesInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun countUniqueDriveCities(carId: Int, startDate: String, endDate: String): Int
 
     // === Deep Stats: Cities/Countries for Charges ===
 
@@ -707,20 +532,7 @@ interface AggregateDao {
 
     // === Charge Locations for Country Map ===
 
-    // Get all charge locations for a specific country (for map display)
-    @Query("""
-        SELECT c.chargeId, c.latitude, c.longitude, c.energyAdded, c.startDate,
-               a.isFastCharger, c.address
-        FROM charges_summary c
-        JOIN charge_detail_aggregates a ON c.chargeId = a.chargeId
-        WHERE a.carId = :carId
-        AND a.countryCode = :countryCode
-        AND c.latitude IS NOT NULL
-        AND c.longitude IS NOT NULL
-    """)
-    suspend fun getChargeLocationsForCountry(carId: Int, countryCode: String): List<ChargeLocationResult>
-
-    // Get all charge locations for a specific country within a date range
+    // Get all charge locations for a specific country within a date range (for map display)
     @Query("""
         SELECT c.chargeId, c.latitude, c.longitude, c.energyAdded, c.startDate,
                a.isFastCharger, c.address
@@ -732,7 +544,7 @@ interface AggregateDao {
         AND c.longitude IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
     """)
-    suspend fun getChargeLocationsForCountryInRange(
+    suspend fun getChargeLocationsForCountry(
         carId: Int,
         countryCode: String,
         startDate: String,
@@ -741,21 +553,7 @@ interface AggregateDao {
 
     // === Drive Locations for Country Map ===
 
-    // Get all drive start locations for a specific country (for map display)
-    @Query("""
-        SELECT a.driveId, a.startLatitude as latitude, a.startLongitude as longitude,
-               d.distance, d.startDate, d.startAddress as address
-        FROM drive_detail_aggregates a
-        JOIN drives_summary d ON a.driveId = d.driveId
-        WHERE a.carId = :carId
-        AND a.startCountryCode = :countryCode
-        AND a.startLatitude IS NOT NULL
-        AND a.startLongitude IS NOT NULL
-        ORDER BY d.startDate DESC
-    """)
-    suspend fun getDriveLocationsForCountry(carId: Int, countryCode: String): List<DriveLocationResult>
-
-    // Get drive start locations for a country within a date range
+    // Get drive start locations for a country within a date range (for map display)
     @Query("""
         SELECT a.driveId, a.startLatitude as latitude, a.startLongitude as longitude,
                d.distance, d.startDate, d.startAddress as address
@@ -768,7 +566,7 @@ interface AggregateDao {
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY d.startDate DESC
     """)
-    suspend fun getDriveLocationsForCountryInRange(
+    suspend fun getDriveLocationsForCountry(
         carId: Int,
         countryCode: String,
         startDate: String,

--- a/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/ChargeSummaryDao.kt
@@ -6,6 +6,10 @@ import androidx.room.Upsert
 import com.matedroid.data.local.entity.ChargeSummary
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Range-parameterized queries: callers wanting all-time results pass
+ * [DateBounds.MIN] / [DateBounds.MAX] as the date bounds.
+ */
 @Dao
 interface ChargeSummaryDao {
 
@@ -26,107 +30,70 @@ interface ChargeSummaryDao {
     // === Quick Stats Queries ===
 
     // Total count
-    @Query("SELECT COUNT(*) FROM charges_summary WHERE carId = :carId")
-    suspend fun count(carId: Int): Int
-
-    // Flow-based count for real-time progress updates
-    @Query("SELECT COUNT(*) FROM charges_summary WHERE carId = :carId")
-    fun observeCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
-
     @Query("""
         SELECT COUNT(*) FROM charges_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun countInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun count(carId: Int, startDate: String, endDate: String): Int
+
+    // Flow-based count for real-time progress updates
+    @Query("SELECT COUNT(*) FROM charges_summary WHERE carId = :carId")
+    fun observeCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
 
     // Total energy added
-    @Query("SELECT COALESCE(SUM(energyAdded), 0) FROM charges_summary WHERE carId = :carId")
-    suspend fun sumEnergyAdded(carId: Int): Double
-
     @Query("""
         SELECT COALESCE(SUM(energyAdded), 0) FROM charges_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun sumEnergyAddedInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumEnergyAdded(carId: Int, startDate: String, endDate: String): Double
 
     // Total cost
-    @Query("SELECT COALESCE(SUM(cost), 0) FROM charges_summary WHERE carId = :carId")
-    suspend fun sumCost(carId: Int): Double
-
     @Query("""
         SELECT COALESCE(SUM(cost), 0) FROM charges_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun sumCostInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumCost(carId: Int, startDate: String, endDate: String): Double
 
     // Average cost per kWh
     @Query("""
         SELECT COALESCE(SUM(cost) / NULLIF(SUM(energyAdded), 0), 0)
-        FROM charges_summary WHERE carId = :carId AND cost IS NOT NULL
-    """)
-    suspend fun avgCostPerKwh(carId: Int): Double
-
-    // Average cost per kWh in range
-    @Query("""
-        SELECT COALESCE(SUM(cost) / NULLIF(SUM(energyAdded), 0), 0)
-        FROM charges_summary 
-        WHERE carId = :carId 
-        AND startDate >= :startDate 
+        FROM charges_summary
+        WHERE carId = :carId
+        AND startDate >= :startDate
         AND startDate < :endDate
         AND cost IS NOT NULL
     """)
-    suspend fun avgCostPerKwhInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun avgCostPerKwh(carId: Int, startDate: String, endDate: String): Double
 
     // Biggest single charge (by energy added)
     @Query("""
         SELECT * FROM charges_summary
         WHERE carId = :carId
-        ORDER BY energyAdded DESC LIMIT 1
-    """)
-    suspend fun biggestCharge(carId: Int): ChargeSummary?
-
-    @Query("""
-        SELECT * FROM charges_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY energyAdded DESC LIMIT 1
     """)
-    suspend fun biggestChargeInRange(carId: Int, startDate: String, endDate: String): ChargeSummary?
+    suspend fun biggestCharge(carId: Int, startDate: String, endDate: String): ChargeSummary?
 
     // Most expensive single charge
     @Query("""
         SELECT * FROM charges_summary
         WHERE carId = :carId AND cost IS NOT NULL
-        ORDER BY cost DESC LIMIT 1
-    """)
-    suspend fun mostExpensiveCharge(carId: Int): ChargeSummary?
-
-    @Query("""
-        SELECT * FROM charges_summary
-        WHERE carId = :carId AND cost IS NOT NULL
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY cost DESC LIMIT 1
     """)
-    suspend fun mostExpensiveChargeInRange(carId: Int, startDate: String, endDate: String): ChargeSummary?
+    suspend fun mostExpensiveCharge(carId: Int, startDate: String, endDate: String): ChargeSummary?
 
     // Most expensive per kWh charge
     @Query("""
         SELECT * FROM charges_summary
         WHERE carId = :carId AND cost IS NOT NULL AND energyAdded > 0
-        ORDER BY (cost / energyAdded) DESC LIMIT 1
-    """)
-    suspend fun mostExpensivePerKwhCharge(carId: Int): ChargeSummary?
-
-    @Query("""
-        SELECT * FROM charges_summary
-        WHERE carId = :carId AND cost IS NOT NULL AND energyAdded > 0
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY (cost / energyAdded) DESC LIMIT 1
     """)
-    suspend fun mostExpensivePerKwhChargeInRange(carId: Int, startDate: String, endDate: String): ChargeSummary?
+    suspend fun mostExpensivePerKwhCharge(carId: Int, startDate: String, endDate: String): ChargeSummary?
 
     // Average charge duration
     @Query("SELECT AVG(durationMin) FROM charges_summary WHERE carId = :carId")
@@ -170,36 +137,6 @@ interface ChargeSummaryDao {
     // === Range Records Queries ===
 
     /**
-     * Find the maximum distance traveled between two consecutive charges.
-     * Sums actual logged drives between charges (not odometer diff, which can include unlogged drives).
-     */
-    @Query("""
-        SELECT
-            prev.chargeId as fromChargeId,
-            curr.chargeId as toChargeId,
-            COALESCE((
-                SELECT SUM(d.distance)
-                FROM drives_summary d
-                WHERE d.carId = curr.carId
-                  AND d.startDate > prev.startDate
-                  AND d.startDate < curr.startDate
-            ), 0) as distance,
-            prev.startDate as fromDate,
-            curr.startDate as toDate
-        FROM charges_summary curr
-        INNER JOIN charges_summary prev ON prev.carId = curr.carId
-            AND prev.startDate = (
-                SELECT MAX(p.startDate)
-                FROM charges_summary p
-                WHERE p.carId = curr.carId AND p.startDate < curr.startDate
-            )
-        WHERE curr.carId = :carId
-        ORDER BY distance DESC
-        LIMIT 1
-    """)
-    suspend fun maxDistanceBetweenCharges(carId: Int): MaxDistanceBetweenChargesResult?
-
-    /**
      * Find the maximum distance traveled between two consecutive charges within a date range.
      * Both charges must be within the range.
      * Sums actual logged drives between charges (not odometer diff, which can include unlogged drives).
@@ -230,7 +167,7 @@ interface ChargeSummaryDao {
         ORDER BY distance DESC
         LIMIT 1
     """)
-    suspend fun maxDistanceBetweenChargesInRange(
+    suspend fun maxDistanceBetweenCharges(
         carId: Int,
         startDate: String,
         endDate: String
@@ -238,27 +175,8 @@ interface ChargeSummaryDao {
 
     /**
      * Find the longest gap (in days) between two consecutive charges.
+     * Both charges must be within the date range.
      */
-    @Query("""
-        SELECT
-            prev.chargeId as fromChargeId,
-            curr.chargeId as toChargeId,
-            CAST(julianday(curr.startDate) - julianday(prev.startDate) AS REAL) as gapDays,
-            prev.startDate as fromDate,
-            curr.startDate as toDate
-        FROM charges_summary curr
-        INNER JOIN charges_summary prev ON prev.carId = curr.carId
-            AND prev.startDate = (
-                SELECT MAX(p.startDate)
-                FROM charges_summary p
-                WHERE p.carId = curr.carId AND p.startDate < curr.startDate
-            )
-        WHERE curr.carId = :carId
-        ORDER BY gapDays DESC
-        LIMIT 1
-    """)
-    suspend fun longestGapBetweenCharges(carId: Int): GapBetweenChargesResult?
-
     @Query("""
         SELECT
             prev.chargeId as fromChargeId,
@@ -279,7 +197,7 @@ interface ChargeSummaryDao {
         ORDER BY gapDays DESC
         LIMIT 1
     """)
-    suspend fun longestGapBetweenChargesInRange(
+    suspend fun longestGapBetweenCharges(
         carId: Int,
         startDate: String,
         endDate: String
@@ -291,19 +209,11 @@ interface ChargeSummaryDao {
     @Query("""
         SELECT * FROM charges_summary
         WHERE carId = :carId
-        ORDER BY (endBatteryLevel - startBatteryLevel) DESC
-        LIMIT 1
-    """)
-    suspend fun biggestBatteryGainCharge(carId: Int): ChargeSummary?
-
-    @Query("""
-        SELECT * FROM charges_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY (endBatteryLevel - startBatteryLevel) DESC
         LIMIT 1
     """)
-    suspend fun biggestBatteryGainChargeInRange(
+    suspend fun biggestBatteryGainCharge(
         carId: Int,
         startDate: String,
         endDate: String

--- a/app/src/main/java/com/matedroid/data/local/dao/DateBounds.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/DateBounds.kt
@@ -1,0 +1,20 @@
+package com.matedroid.data.local.dao
+
+/**
+ * Sentinel date bounds for running range-parameterized DAO queries over all time.
+ *
+ * All date columns in the local database are non-null ISO-8601 TEXT
+ * (e.g. "2024-12-07T00:00:00Z"), so SQLite compares them lexicographically.
+ * `startDate >= '' AND startDate < '￿'` is therefore true for every row:
+ * the empty string sorts before any date, and U+FFFF sorts after any ASCII text.
+ *
+ * This lets every "X vs XInRange" DAO query pair collapse into a single
+ * range-parameterized query; all-time callers simply pass [MIN] and [MAX].
+ */
+object DateBounds {
+    /** Lower bound matching all rows: the empty string sorts before any date. */
+    const val MIN = ""
+
+    /** Upper (exclusive) bound matching all rows: U+FFFF sorts after any ASCII date. */
+    const val MAX = "￿"
+}

--- a/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/DriveSummaryDao.kt
@@ -6,6 +6,10 @@ import androidx.room.Upsert
 import com.matedroid.data.local.entity.DriveSummary
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Range-parameterized queries: callers wanting all-time results pass
+ * [DateBounds.MIN] / [DateBounds.MAX] as the date bounds.
+ */
 @Dao
 interface DriveSummaryDao {
 
@@ -30,131 +34,85 @@ interface DriveSummaryDao {
     // === Quick Stats Queries ===
 
     // Total count
-    @Query("SELECT COUNT(*) FROM drives_summary WHERE carId = :carId")
-    suspend fun count(carId: Int): Int
-
-    // Flow-based count for real-time progress updates
-    @Query("SELECT COUNT(*) FROM drives_summary WHERE carId = :carId")
-    fun observeCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
-
     @Query("""
         SELECT COUNT(*) FROM drives_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun countInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun count(carId: Int, startDate: String, endDate: String): Int
+
+    // Flow-based count for real-time progress updates
+    @Query("SELECT COUNT(*) FROM drives_summary WHERE carId = :carId")
+    fun observeCount(carId: Int): kotlinx.coroutines.flow.Flow<Int>
 
     // Total distance
-    @Query("SELECT COALESCE(SUM(distance), 0) FROM drives_summary WHERE carId = :carId")
-    suspend fun sumDistance(carId: Int): Double
-
     @Query("""
         SELECT COALESCE(SUM(distance), 0) FROM drives_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun sumDistanceInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumDistance(carId: Int, startDate: String, endDate: String): Double
 
     // Total energy consumed
-    @Query("SELECT COALESCE(SUM(energyConsumed), 0) FROM drives_summary WHERE carId = :carId")
-    suspend fun sumEnergyConsumed(carId: Int): Double
-
     @Query("""
         SELECT COALESCE(SUM(energyConsumed), 0) FROM drives_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun sumEnergyConsumedInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun sumEnergyConsumed(carId: Int, startDate: String, endDate: String): Double
 
     // Average efficiency
-    @Query("""
-        SELECT COALESCE(SUM(energyConsumed) * 1000 / NULLIF(SUM(distance), 0), 0)
-        FROM drives_summary WHERE carId = :carId
-    """)
-    suspend fun avgEfficiency(carId: Int): Double
-
     @Query("""
         SELECT COALESCE(SUM(energyConsumed) * 1000 / NULLIF(SUM(distance), 0), 0)
         FROM drives_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun avgEfficiencyInRange(carId: Int, startDate: String, endDate: String): Double
+    suspend fun avgEfficiency(carId: Int, startDate: String, endDate: String): Double
 
-    // Max speed ever
-    @Query("SELECT MAX(speedMax) FROM drives_summary WHERE carId = :carId")
-    suspend fun maxSpeed(carId: Int): Int?
-
+    // Max speed
     @Query("""
         SELECT MAX(speedMax) FROM drives_summary
         WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
     """)
-    suspend fun maxSpeedInRange(carId: Int, startDate: String, endDate: String): Int?
+    suspend fun maxSpeed(carId: Int, startDate: String, endDate: String): Int?
 
     // Longest drive (by distance)
     @Query("""
         SELECT * FROM drives_summary
         WHERE carId = :carId
-        ORDER BY distance DESC LIMIT 1
-    """)
-    suspend fun longestDrive(carId: Int): DriveSummary?
-
-    @Query("""
-        SELECT * FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY distance DESC LIMIT 1
     """)
-    suspend fun longestDriveInRange(carId: Int, startDate: String, endDate: String): DriveSummary?
+    suspend fun longestDrive(carId: Int, startDate: String, endDate: String): DriveSummary?
 
     // Drive with max speed
     @Query("""
         SELECT * FROM drives_summary
         WHERE carId = :carId
-        ORDER BY speedMax DESC LIMIT 1
-    """)
-    suspend fun fastestDrive(carId: Int): DriveSummary?
-
-    @Query("""
-        SELECT * FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY speedMax DESC LIMIT 1
     """)
-    suspend fun fastestDriveInRange(carId: Int, startDate: String, endDate: String): DriveSummary?
+    suspend fun fastestDrive(carId: Int, startDate: String, endDate: String): DriveSummary?
 
     // Best efficiency (lowest Wh/km, excluding very short drives)
     @Query("""
         SELECT * FROM drives_summary
         WHERE carId = :carId AND efficiency > 0 AND distance > 5
-        ORDER BY efficiency ASC LIMIT 1
-    """)
-    suspend fun mostEfficientDrive(carId: Int): DriveSummary?
-
-    @Query("""
-        SELECT * FROM drives_summary
-        WHERE carId = :carId AND efficiency > 0 AND distance > 5
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY efficiency ASC LIMIT 1
     """)
-    suspend fun mostEfficientDriveInRange(carId: Int, startDate: String, endDate: String): DriveSummary?
+    suspend fun mostEfficientDrive(carId: Int, startDate: String, endDate: String): DriveSummary?
 
     // Worst efficiency (highest Wh/km)
     @Query("""
         SELECT * FROM drives_summary
         WHERE carId = :carId AND efficiency > 0 AND distance > 5
-        ORDER BY efficiency DESC LIMIT 1
-    """)
-    suspend fun leastEfficientDrive(carId: Int): DriveSummary?
-
-    @Query("""
-        SELECT * FROM drives_summary
-        WHERE carId = :carId AND efficiency > 0 AND distance > 5
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY efficiency DESC LIMIT 1
     """)
-    suspend fun leastEfficientDriveInRange(carId: Int, startDate: String, endDate: String): DriveSummary?
+    suspend fun leastEfficientDrive(carId: Int, startDate: String, endDate: String): DriveSummary?
 
     // Average drive duration
     @Query("SELECT AVG(durationMin) FROM drives_summary WHERE carId = :carId")
@@ -169,47 +127,26 @@ interface DriveSummaryDao {
         SELECT DATE(startDate) as day, COUNT(*) as count
         FROM drives_summary
         WHERE carId = :carId
-        GROUP BY DATE(startDate)
-        ORDER BY count DESC LIMIT 1
-    """)
-    suspend fun busiestDay(carId: Int): BusiestDayResult?
-
-    @Query("""
-        SELECT DATE(startDate) as day, COUNT(*) as count
-        FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         GROUP BY DATE(startDate)
         ORDER BY count DESC LIMIT 1
     """)
-    suspend fun busiestDayInRange(carId: Int, startDate: String, endDate: String): BusiestDayResult?
+    suspend fun busiestDay(carId: Int, startDate: String, endDate: String): BusiestDayResult?
 
     // Count of unique driving days
-    @Query("SELECT COUNT(DISTINCT DATE(startDate)) FROM drives_summary WHERE carId = :carId")
-    suspend fun countDrivingDays(carId: Int): Int
-
     @Query("SELECT COUNT(DISTINCT DATE(startDate)) FROM drives_summary WHERE carId = :carId AND startDate >= :startDate AND startDate < :endDate")
-    suspend fun countDrivingDaysInRange(carId: Int, startDate: String, endDate: String): Int
+    suspend fun countDrivingDays(carId: Int, startDate: String, endDate: String): Int
 
     // Most distance in a single day
     @Query("""
         SELECT DATE(startDate) as day, SUM(distance) as totalDistance
         FROM drives_summary
         WHERE carId = :carId
-        GROUP BY DATE(startDate)
-        ORDER BY totalDistance DESC LIMIT 1
-    """)
-    suspend fun mostDistanceDay(carId: Int): MostDistanceDayResult?
-
-    @Query("""
-        SELECT DATE(startDate) as day, SUM(distance) as totalDistance
-        FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         GROUP BY DATE(startDate)
         ORDER BY totalDistance DESC LIMIT 1
     """)
-    suspend fun mostDistanceDayInRange(carId: Int, startDate: String, endDate: String): MostDistanceDayResult?
+    suspend fun mostDistanceDay(carId: Int, startDate: String, endDate: String): MostDistanceDayResult?
 
     // === Queries for Detail Sync ===
 
@@ -259,27 +196,8 @@ interface DriveSummaryDao {
 
     /**
      * Find the longest gap (in days) between two consecutive drives.
+     * Both drives must be within the date range.
      */
-    @Query("""
-        SELECT
-            prev.driveId as fromDriveId,
-            curr.driveId as toDriveId,
-            CAST(julianday(curr.startDate) - julianday(prev.startDate) AS REAL) as gapDays,
-            prev.startDate as fromDate,
-            curr.startDate as toDate
-        FROM drives_summary curr
-        INNER JOIN drives_summary prev ON prev.carId = curr.carId
-            AND prev.startDate = (
-                SELECT MAX(p.startDate)
-                FROM drives_summary p
-                WHERE p.carId = curr.carId AND p.startDate < curr.startDate
-            )
-        WHERE curr.carId = :carId
-        ORDER BY gapDays DESC
-        LIMIT 1
-    """)
-    suspend fun longestGapBetweenDrives(carId: Int): GapBetweenDrivesResult?
-
     @Query("""
         SELECT
             prev.driveId as fromDriveId,
@@ -300,7 +218,7 @@ interface DriveSummaryDao {
         ORDER BY gapDays DESC
         LIMIT 1
     """)
-    suspend fun longestGapBetweenDrivesInRange(
+    suspend fun longestGapBetweenDrives(
         carId: Int,
         startDate: String,
         endDate: String
@@ -312,19 +230,11 @@ interface DriveSummaryDao {
     @Query("""
         SELECT * FROM drives_summary
         WHERE carId = :carId
-        ORDER BY (startBatteryLevel - endBatteryLevel) DESC
-        LIMIT 1
-    """)
-    suspend fun biggestBatteryDrainDrive(carId: Int): DriveSummary?
-
-    @Query("""
-        SELECT * FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY (startBatteryLevel - endBatteryLevel) DESC
         LIMIT 1
     """)
-    suspend fun biggestBatteryDrainDriveInRange(
+    suspend fun biggestBatteryDrainDrive(
         carId: Int,
         startDate: String,
         endDate: String
@@ -337,18 +247,10 @@ interface DriveSummaryDao {
         SELECT DISTINCT DATE(startDate) as day
         FROM drives_summary
         WHERE carId = :carId
-        ORDER BY day ASC
-    """)
-    suspend fun getDistinctDrivingDays(carId: Int): List<String>
-
-    @Query("""
-        SELECT DISTINCT DATE(startDate) as day
-        FROM drives_summary
-        WHERE carId = :carId
         AND startDate >= :startDate AND startDate < :endDate
         ORDER BY day ASC
     """)
-    suspend fun getDistinctDrivingDaysInRange(carId: Int, startDate: String, endDate: String): List<String>
+    suspend fun getDistinctDrivingDays(carId: Int, startDate: String, endDate: String): List<String>
 }
 
 data class BusiestDayResult(

--- a/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
@@ -2,6 +2,7 @@ package com.matedroid.data.repository
 
 import com.matedroid.data.local.dao.AggregateDao
 import com.matedroid.data.local.dao.ChargeSummaryDao
+import com.matedroid.data.local.dao.DateBounds
 import com.matedroid.data.local.dao.DriveSummaryDao
 import com.matedroid.data.local.entity.SchemaVersion
 import com.matedroid.data.sync.SyncManager
@@ -63,118 +64,38 @@ class StatsRepository @Inject constructor(
      * Get quick stats (from summary tables, instant).
      */
     suspend fun getQuickStats(carId: Int, yearFilter: YearFilter): QuickStats {
-        return when (yearFilter) {
-            is YearFilter.AllTime -> getQuickStatsAllTime(carId)
-            is YearFilter.Year -> getQuickStatsForYear(carId, yearFilter.year)
-        }
-    }
-
-    private suspend fun getQuickStatsAllTime(carId: Int): QuickStats {
-        return QuickStats(
-            totalDrives = driveSummaryDao.count(carId),
-            totalDistanceKm = driveSummaryDao.sumDistance(carId),
-            totalEnergyConsumedKwh = driveSummaryDao.sumEnergyConsumed(carId),
-            avgEfficiencyWhKm = driveSummaryDao.avgEfficiency(carId),
-            maxSpeedKmh = driveSummaryDao.maxSpeed(carId),
-            avgDriveMinutes = driveSummaryDao.avgDuration(carId),
-            totalDrivingDays = driveSummaryDao.countDrivingDays(carId),
-
-            totalCharges = chargeSummaryDao.count(carId),
-            totalEnergyAddedKwh = chargeSummaryDao.sumEnergyAdded(carId),
-            totalCost = chargeSummaryDao.sumCost(carId).takeIf { it > 0 },
-            avgCostPerKwh = chargeSummaryDao.avgCostPerKwh(carId).takeIf { it > 0 },
-            avgChargeMinutes = chargeSummaryDao.avgDuration(carId),
-
-            longestDrive = driveSummaryDao.longestDrive(carId),
-            fastestDrive = driveSummaryDao.fastestDrive(carId),
-            mostEfficientDrive = driveSummaryDao.mostEfficientDrive(carId),
-            leastEfficientDrive = driveSummaryDao.leastEfficientDrive(carId),
-            biggestCharge = chargeSummaryDao.biggestCharge(carId),
-            mostExpensiveCharge = chargeSummaryDao.mostExpensiveCharge(carId),
-            mostExpensivePerKwhCharge = chargeSummaryDao.mostExpensivePerKwhCharge(carId),
-
-            firstDriveDate = driveSummaryDao.firstDriveDate(carId),
-            firstChargeDate = chargeSummaryDao.firstChargeDate(carId),
-            busiestDay = driveSummaryDao.busiestDay(carId),
-            mostDistanceDay = driveSummaryDao.mostDistanceDay(carId),
-
-            maxDistanceBetweenCharges = chargeSummaryDao.maxDistanceBetweenCharges(carId)?.let {
-                MaxDistanceBetweenChargesRecord(
-                    distance = it.distance,
-                    fromChargeId = it.fromChargeId,
-                    toChargeId = it.toChargeId,
-                    fromDate = it.fromDate,
-                    toDate = it.toDate
-                )
-            },
-
-            longestGapWithoutCharging = chargeSummaryDao.longestGapBetweenCharges(carId)?.let {
-                GapRecord(gapDays = it.gapDays, fromDate = it.fromDate, toDate = it.toDate)
-            },
-            longestGapWithoutDriving = driveSummaryDao.longestGapBetweenDrives(carId)?.let {
-                GapRecord(gapDays = it.gapDays, fromDate = it.fromDate, toDate = it.toDate)
-            },
-
-            longestDrivingStreak = computeLongestStreak(
-                driveSummaryDao.getDistinctDrivingDays(carId)
-            ),
-
-            biggestBatteryGainCharge = chargeSummaryDao.biggestBatteryGainCharge(carId)?.let {
-                BatteryChangeRecord(
-                    percentChange = it.endBatteryLevel - it.startBatteryLevel,
-                    startLevel = it.startBatteryLevel,
-                    endLevel = it.endBatteryLevel,
-                    recordId = it.chargeId,
-                    date = it.startDate,
-                    isCharge = true
-                )
-            },
-            biggestBatteryDrainDrive = driveSummaryDao.biggestBatteryDrainDrive(carId)?.let {
-                BatteryChangeRecord(
-                    percentChange = it.startBatteryLevel - it.endBatteryLevel,
-                    startLevel = it.startBatteryLevel,
-                    endLevel = it.endBatteryLevel,
-                    recordId = it.driveId,
-                    date = it.startDate,
-                    isCharge = false
-                )
-            }
-        )
-    }
-
-    private suspend fun getQuickStatsForYear(carId: Int, year: Int): QuickStats {
-        val startDate = "$year-01-01T00:00:00"
-        val endDate = "${year + 1}-01-01T00:00:00"
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        val allTime = yearFilter is YearFilter.AllTime
 
         return QuickStats(
-            totalDrives = driveSummaryDao.countInRange(carId, startDate, endDate),
-            totalDistanceKm = driveSummaryDao.sumDistanceInRange(carId, startDate, endDate),
-            totalEnergyConsumedKwh = driveSummaryDao.sumEnergyConsumedInRange(carId, startDate, endDate),
-            avgEfficiencyWhKm = driveSummaryDao.avgEfficiencyInRange(carId, startDate, endDate),
-            maxSpeedKmh = driveSummaryDao.maxSpeedInRange(carId, startDate, endDate),
-            avgDriveMinutes = null, // Not critical for year view
-            totalDrivingDays = driveSummaryDao.countDrivingDaysInRange(carId, startDate, endDate),
+            totalDrives = driveSummaryDao.count(carId, startDate, endDate),
+            totalDistanceKm = driveSummaryDao.sumDistance(carId, startDate, endDate),
+            totalEnergyConsumedKwh = driveSummaryDao.sumEnergyConsumed(carId, startDate, endDate),
+            avgEfficiencyWhKm = driveSummaryDao.avgEfficiency(carId, startDate, endDate),
+            maxSpeedKmh = driveSummaryDao.maxSpeed(carId, startDate, endDate),
+            avgDriveMinutes = if (allTime) driveSummaryDao.avgDuration(carId) else null, // Not critical for year view
+            totalDrivingDays = driveSummaryDao.countDrivingDays(carId, startDate, endDate),
 
-            totalCharges = chargeSummaryDao.countInRange(carId, startDate, endDate),
-            totalEnergyAddedKwh = chargeSummaryDao.sumEnergyAddedInRange(carId, startDate, endDate),
-            totalCost = chargeSummaryDao.sumCostInRange(carId, startDate, endDate).takeIf { it > 0 },
-            avgCostPerKwh = chargeSummaryDao.avgCostPerKwhInRange(carId, startDate, endDate).takeIf { it > 0 },
-            avgChargeMinutes = null, // Not critical for year view
+            totalCharges = chargeSummaryDao.count(carId, startDate, endDate),
+            totalEnergyAddedKwh = chargeSummaryDao.sumEnergyAdded(carId, startDate, endDate),
+            totalCost = chargeSummaryDao.sumCost(carId, startDate, endDate).takeIf { it > 0 },
+            avgCostPerKwh = chargeSummaryDao.avgCostPerKwh(carId, startDate, endDate).takeIf { it > 0 },
+            avgChargeMinutes = if (allTime) chargeSummaryDao.avgDuration(carId) else null, // Not critical for year view
 
-            longestDrive = driveSummaryDao.longestDriveInRange(carId, startDate, endDate),
-            fastestDrive = driveSummaryDao.fastestDriveInRange(carId, startDate, endDate),
-            mostEfficientDrive = driveSummaryDao.mostEfficientDriveInRange(carId, startDate, endDate),
-            leastEfficientDrive = driveSummaryDao.leastEfficientDriveInRange(carId, startDate, endDate),
-            biggestCharge = chargeSummaryDao.biggestChargeInRange(carId, startDate, endDate),
-            mostExpensiveCharge = chargeSummaryDao.mostExpensiveChargeInRange(carId, startDate, endDate),
-            mostExpensivePerKwhCharge = chargeSummaryDao.mostExpensivePerKwhChargeInRange(carId, startDate, endDate),
+            longestDrive = driveSummaryDao.longestDrive(carId, startDate, endDate),
+            fastestDrive = driveSummaryDao.fastestDrive(carId, startDate, endDate),
+            mostEfficientDrive = driveSummaryDao.mostEfficientDrive(carId, startDate, endDate),
+            leastEfficientDrive = driveSummaryDao.leastEfficientDrive(carId, startDate, endDate),
+            biggestCharge = chargeSummaryDao.biggestCharge(carId, startDate, endDate),
+            mostExpensiveCharge = chargeSummaryDao.mostExpensiveCharge(carId, startDate, endDate),
+            mostExpensivePerKwhCharge = chargeSummaryDao.mostExpensivePerKwhCharge(carId, startDate, endDate),
 
             firstDriveDate = driveSummaryDao.firstDriveDate(carId), // Always show first ever
             firstChargeDate = chargeSummaryDao.firstChargeDate(carId), // Always show first ever
-            busiestDay = driveSummaryDao.busiestDayInRange(carId, startDate, endDate),
-            mostDistanceDay = driveSummaryDao.mostDistanceDayInRange(carId, startDate, endDate),
+            busiestDay = driveSummaryDao.busiestDay(carId, startDate, endDate),
+            mostDistanceDay = driveSummaryDao.mostDistanceDay(carId, startDate, endDate),
 
-            maxDistanceBetweenCharges = chargeSummaryDao.maxDistanceBetweenChargesInRange(carId, startDate, endDate)?.let {
+            maxDistanceBetweenCharges = chargeSummaryDao.maxDistanceBetweenCharges(carId, startDate, endDate)?.let {
                 MaxDistanceBetweenChargesRecord(
                     distance = it.distance,
                     fromChargeId = it.fromChargeId,
@@ -184,18 +105,18 @@ class StatsRepository @Inject constructor(
                 )
             },
 
-            longestGapWithoutCharging = chargeSummaryDao.longestGapBetweenChargesInRange(carId, startDate, endDate)?.let {
+            longestGapWithoutCharging = chargeSummaryDao.longestGapBetweenCharges(carId, startDate, endDate)?.let {
                 GapRecord(gapDays = it.gapDays, fromDate = it.fromDate, toDate = it.toDate)
             },
-            longestGapWithoutDriving = driveSummaryDao.longestGapBetweenDrivesInRange(carId, startDate, endDate)?.let {
+            longestGapWithoutDriving = driveSummaryDao.longestGapBetweenDrives(carId, startDate, endDate)?.let {
                 GapRecord(gapDays = it.gapDays, fromDate = it.fromDate, toDate = it.toDate)
             },
 
             longestDrivingStreak = computeLongestStreak(
-                driveSummaryDao.getDistinctDrivingDaysInRange(carId, startDate, endDate)
+                driveSummaryDao.getDistinctDrivingDays(carId, startDate, endDate)
             ),
 
-            biggestBatteryGainCharge = chargeSummaryDao.biggestBatteryGainChargeInRange(carId, startDate, endDate)?.let {
+            biggestBatteryGainCharge = chargeSummaryDao.biggestBatteryGainCharge(carId, startDate, endDate)?.let {
                 BatteryChangeRecord(
                     percentChange = it.endBatteryLevel - it.startBatteryLevel,
                     startLevel = it.startBatteryLevel,
@@ -205,7 +126,7 @@ class StatsRepository @Inject constructor(
                     isCharge = true
                 )
             },
-            biggestBatteryDrainDrive = driveSummaryDao.biggestBatteryDrainDriveInRange(carId, startDate, endDate)?.let {
+            biggestBatteryDrainDrive = driveSummaryDao.biggestBatteryDrainDrive(carId, startDate, endDate)?.let {
                 BatteryChangeRecord(
                     percentChange = it.startBatteryLevel - it.endBatteryLevel,
                     startLevel = it.startBatteryLevel,
@@ -231,32 +152,28 @@ class StatsRepository @Inject constructor(
             return null
         }
 
-        return when (yearFilter) {
-            is YearFilter.AllTime -> getDeepStatsAllTime(carId, driveAggregates, chargeAggregates)
-            is YearFilter.Year -> getDeepStatsForYear(carId, yearFilter.year, driveAggregates, chargeAggregates)
-        }
-    }
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        val allTime = yearFilter is YearFilter.AllTime
 
-    private suspend fun getDeepStatsAllTime(carId: Int, driveCount: Int, chargeCount: Int): DeepStats {
         // Elevation records
-        val driveWithMaxElev = aggregateDao.driveWithMaxElevation(carId)
-        val driveWithMinElev = aggregateDao.driveWithMinElevation(carId)
-        val driveWithMostGain = aggregateDao.driveWithMostElevationGain(carId)
+        val driveWithMaxElev = aggregateDao.driveWithMaxElevation(carId, startDate, endDate)
+        val driveWithMinElev = if (allTime) aggregateDao.driveWithMinElevation(carId) else null // Not shown in year view
+        val driveWithMostGain = aggregateDao.driveWithMostElevationGain(carId, startDate, endDate)
 
         // Temperature records (driving)
-        val hottestDriveAgg = aggregateDao.hottestDrive(carId)
-        val coldestDriveAgg = aggregateDao.coldestDrive(carId)
+        val hottestDriveAgg = aggregateDao.hottestDrive(carId, startDate, endDate)
+        val coldestDriveAgg = aggregateDao.coldestDrive(carId, startDate, endDate)
 
         // Temperature records (charging)
-        val hottestChargeAgg = aggregateDao.hottestCharge(carId)
-        val coldestChargeAgg = aggregateDao.coldestCharge(carId)
+        val hottestChargeAgg = aggregateDao.hottestCharge(carId, startDate, endDate)
+        val coldestChargeAgg = aggregateDao.coldestCharge(carId, startDate, endDate)
 
         // Power record
-        val chargeWithMaxPowerAgg = aggregateDao.chargeWithMaxPower(carId)
+        val chargeWithMaxPowerAgg = aggregateDao.chargeWithMaxPower(carId, startDate, endDate)
 
         return DeepStats(
-            maxElevationM = aggregateDao.maxElevation(carId),
-            minElevationM = aggregateDao.minElevation(carId),
+            maxElevationM = aggregateDao.maxElevation(carId, startDate, endDate),
+            minElevationM = if (allTime) aggregateDao.minElevation(carId) else null, // Not shown in year view
             driveWithMaxElevation = driveWithMaxElev?.let { agg ->
                 val drive = driveSummaryDao.get(agg.driveId)
                 DriveElevationRecord(
@@ -285,10 +202,10 @@ class StatsRepository @Inject constructor(
                 )
             },
 
-            maxOutsideTempDrivingC = aggregateDao.maxOutsideTempDriving(carId),
-            minOutsideTempDrivingC = aggregateDao.minOutsideTempDriving(carId),
-            maxCabinTempC = aggregateDao.maxInsideTemp(carId),
-            minCabinTempC = aggregateDao.minInsideTemp(carId),
+            maxOutsideTempDrivingC = aggregateDao.maxOutsideTempDriving(carId, startDate, endDate),
+            minOutsideTempDrivingC = aggregateDao.minOutsideTempDriving(carId, startDate, endDate),
+            maxCabinTempC = aggregateDao.maxInsideTemp(carId, startDate, endDate),
+            minCabinTempC = aggregateDao.minInsideTemp(carId, startDate, endDate),
             hottestDrive = hottestDriveAgg?.let { agg ->
                 val drive = driveSummaryDao.get(agg.driveId)
                 DriveTempRecord(
@@ -306,8 +223,8 @@ class StatsRepository @Inject constructor(
                 )
             },
 
-            maxOutsideTempChargingC = aggregateDao.maxOutsideTempCharging(carId),
-            minOutsideTempChargingC = aggregateDao.minOutsideTempCharging(carId),
+            maxOutsideTempChargingC = aggregateDao.maxOutsideTempCharging(carId, startDate, endDate),
+            minOutsideTempChargingC = aggregateDao.minOutsideTempCharging(carId, startDate, endDate),
             hottestCharge = hottestChargeAgg?.let { agg ->
                 val charge = chargeSummaryDao.get(agg.chargeId)
                 ChargeTempRecord(
@@ -325,7 +242,7 @@ class StatsRepository @Inject constructor(
                 )
             },
 
-            maxChargerPowerKw = aggregateDao.maxChargerPower(carId),
+            maxChargerPowerKw = aggregateDao.maxChargerPower(carId, startDate, endDate),
             chargeWithMaxPower = chargeWithMaxPowerAgg?.let { agg ->
                 val charge = chargeSummaryDao.get(agg.chargeId)
                 ChargePowerRecord(
@@ -335,122 +252,15 @@ class StatsRepository @Inject constructor(
                 )
             },
 
-            acChargeCount = aggregateDao.countAcCharges(carId),
-            dcChargeCount = aggregateDao.countDcCharges(carId),
-            acChargeEnergyKwh = aggregateDao.sumAcChargeEnergy(carId),
-            dcChargeEnergyKwh = aggregateDao.sumDcChargeEnergy(carId),
+            acChargeCount = aggregateDao.countAcCharges(carId, startDate, endDate),
+            dcChargeCount = aggregateDao.countDcCharges(carId, startDate, endDate),
+            acChargeEnergyKwh = aggregateDao.sumAcChargeEnergy(carId, startDate, endDate),
+            dcChargeEnergyKwh = aggregateDao.sumDcChargeEnergy(carId, startDate, endDate),
 
-            countriesVisitedCount = aggregateDao.countUniqueCountries(carId).takeIf { it > 0 },
+            countriesVisitedCount = aggregateDao.countUniqueCountries(carId, startDate, endDate).takeIf { it > 0 },
 
-            driveDetailsProcessed = driveCount,
-            chargeDetailsProcessed = chargeCount
-        )
-    }
-
-    private suspend fun getDeepStatsForYear(
-        carId: Int,
-        year: Int,
-        driveCount: Int,
-        chargeCount: Int
-    ): DeepStats {
-        val startDate = "$year-01-01T00:00:00"
-        val endDate = "${year + 1}-01-01T00:00:00"
-
-        // Elevation records for year
-        val driveWithMaxElev = aggregateDao.driveWithMaxElevationInRange(carId, startDate, endDate)
-        val driveWithMostGain = aggregateDao.driveWithMostElevationGainInRange(carId, startDate, endDate)
-
-        // Temperature records for year
-        val hottestDriveAgg = aggregateDao.hottestDriveInRange(carId, startDate, endDate)
-        val coldestDriveAgg = aggregateDao.coldestDriveInRange(carId, startDate, endDate)
-        val hottestChargeAgg = aggregateDao.hottestChargeInRange(carId, startDate, endDate)
-        val coldestChargeAgg = aggregateDao.coldestChargeInRange(carId, startDate, endDate)
-
-        // Power record for year
-        val chargeWithMaxPowerAgg = aggregateDao.chargeWithMaxPowerInRange(carId, startDate, endDate)
-
-        return DeepStats(
-            maxElevationM = aggregateDao.maxElevationInRange(carId, startDate, endDate),
-            minElevationM = null, // Not shown in UI
-            driveWithMaxElevation = driveWithMaxElev?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveElevationRecord(
-                    driveId = agg.driveId,
-                    elevationM = agg.maxElevation ?: 0,
-                    elevationGainM = agg.elevationGain,
-                    date = drive?.startDate
-                )
-            },
-            driveWithMinElevation = null, // Not shown in UI
-            driveWithMostClimbing = driveWithMostGain?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveElevationRecord(
-                    driveId = agg.driveId,
-                    elevationM = agg.maxElevation ?: 0,
-                    elevationGainM = agg.elevationGain,
-                    date = drive?.startDate
-                )
-            },
-
-            maxOutsideTempDrivingC = aggregateDao.maxOutsideTempDrivingInRange(carId, startDate, endDate),
-            minOutsideTempDrivingC = aggregateDao.minOutsideTempDrivingInRange(carId, startDate, endDate),
-            maxCabinTempC = aggregateDao.maxInsideTempInRange(carId, startDate, endDate),
-            minCabinTempC = aggregateDao.minInsideTempInRange(carId, startDate, endDate),
-            hottestDrive = hottestDriveAgg?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveTempRecord(
-                    driveId = agg.driveId,
-                    tempC = agg.maxOutsideTemp ?: 0.0,
-                    date = drive?.startDate
-                )
-            },
-            coldestDrive = coldestDriveAgg?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveTempRecord(
-                    driveId = agg.driveId,
-                    tempC = agg.minOutsideTemp ?: 0.0,
-                    date = drive?.startDate
-                )
-            },
-
-            maxOutsideTempChargingC = aggregateDao.maxOutsideTempChargingInRange(carId, startDate, endDate),
-            minOutsideTempChargingC = aggregateDao.minOutsideTempChargingInRange(carId, startDate, endDate),
-            hottestCharge = hottestChargeAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargeTempRecord(
-                    chargeId = agg.chargeId,
-                    tempC = agg.maxOutsideTemp ?: 0.0,
-                    date = charge?.startDate
-                )
-            },
-            coldestCharge = coldestChargeAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargeTempRecord(
-                    chargeId = agg.chargeId,
-                    tempC = agg.minOutsideTemp ?: 0.0,
-                    date = charge?.startDate
-                )
-            },
-
-            maxChargerPowerKw = aggregateDao.maxChargerPowerInRange(carId, startDate, endDate),
-            chargeWithMaxPower = chargeWithMaxPowerAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargePowerRecord(
-                    chargeId = agg.chargeId,
-                    powerKw = agg.maxChargerPower ?: 0,
-                    date = charge?.startDate
-                )
-            },
-
-            acChargeCount = aggregateDao.countAcChargesInRange(carId, startDate, endDate),
-            dcChargeCount = aggregateDao.countDcChargesInRange(carId, startDate, endDate),
-            acChargeEnergyKwh = aggregateDao.sumAcChargeEnergyInRange(carId, startDate, endDate),
-            dcChargeEnergyKwh = aggregateDao.sumDcChargeEnergyInRange(carId, startDate, endDate),
-
-            countriesVisitedCount = aggregateDao.countUniqueCountriesInRange(carId, startDate, endDate).takeIf { it > 0 },
-
-            driveDetailsProcessed = driveCount,
-            chargeDetailsProcessed = chargeCount
+            driveDetailsProcessed = driveAggregates,
+            chargeDetailsProcessed = chargeAggregates
         )
     }
 
@@ -467,7 +277,8 @@ class StatsRepository @Inject constructor(
      * Check if any data is available for stats.
      */
     suspend fun hasData(carId: Int): Boolean {
-        return driveSummaryDao.count(carId) > 0 || chargeSummaryDao.count(carId) > 0
+        return driveSummaryDao.count(carId, DateBounds.MIN, DateBounds.MAX) > 0 ||
+                chargeSummaryDao.count(carId, DateBounds.MIN, DateBounds.MAX) > 0
     }
 
     /**
@@ -498,8 +309,8 @@ class StatsRepository @Inject constructor(
             return 1f
         }
 
-        val totalDrives = driveSummaryDao.count(carId)
-        val totalCharges = chargeSummaryDao.count(carId)
+        val totalDrives = driveSummaryDao.count(carId, DateBounds.MIN, DateBounds.MAX)
+        val totalCharges = chargeSummaryDao.count(carId, DateBounds.MIN, DateBounds.MAX)
         // Only count aggregates with current schema version
         val processedDrives = aggregateDao.countDriveAggregatesWithSchema(carId, SchemaVersion.CURRENT)
         val processedCharges = aggregateDao.countChargeAggregatesWithSchema(carId, SchemaVersion.CURRENT)
@@ -533,30 +344,18 @@ class StatsRepository @Inject constructor(
      * Get countries visited with aggregated data.
      */
     suspend fun getCountriesVisited(carId: Int, yearFilter: YearFilter): List<CountryRecord> {
-        val results = when (yearFilter) {
-            is YearFilter.AllTime -> aggregateDao.getCountriesVisited(carId)
-            is YearFilter.Year -> {
-                val startDate = "${yearFilter.year}-01-01T00:00:00"
-                val endDate = "${yearFilter.year + 1}-01-01T00:00:00"
-                aggregateDao.getCountriesVisitedInRange(carId, startDate, endDate)
-            }
-        }
-        return results.map { it.toCountryRecord() }
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        return aggregateDao.getCountriesVisited(carId, startDate, endDate)
+            .map { it.toCountryRecord() }
     }
 
     /**
      * Get regions visited within a specific country with aggregated data.
      */
     suspend fun getRegionsVisited(carId: Int, countryCode: String, yearFilter: YearFilter): List<RegionRecord> {
-        val results = when (yearFilter) {
-            is YearFilter.AllTime -> aggregateDao.getRegionsVisited(carId, countryCode)
-            is YearFilter.Year -> {
-                val startDate = "${yearFilter.year}-01-01T00:00:00"
-                val endDate = "${yearFilter.year + 1}-01-01T00:00:00"
-                aggregateDao.getRegionsVisitedInRange(carId, countryCode, startDate, endDate)
-            }
-        }
-        return results.map { it.toRegionRecord() }
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        return aggregateDao.getRegionsVisited(carId, countryCode, startDate, endDate)
+            .map { it.toRegionRecord() }
     }
 
     /**
@@ -575,15 +374,9 @@ class StatsRepository @Inject constructor(
         countryCode: String,
         yearFilter: YearFilter
     ): List<ChargeLocation> {
-        val results = when (yearFilter) {
-            is YearFilter.AllTime -> aggregateDao.getChargeLocationsForCountry(carId, countryCode)
-            is YearFilter.Year -> {
-                val startDate = "${yearFilter.year}-01-01T00:00:00"
-                val endDate = "${yearFilter.year + 1}-01-01T00:00:00"
-                aggregateDao.getChargeLocationsForCountryInRange(carId, countryCode, startDate, endDate)
-            }
-        }
-        return results.map { it.toChargeLocation() }
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        return aggregateDao.getChargeLocationsForCountry(carId, countryCode, startDate, endDate)
+            .map { it.toChargeLocation() }
     }
 
     /**
@@ -601,16 +394,19 @@ class StatsRepository @Inject constructor(
         countryCode: String,
         yearFilter: YearFilter
     ): List<DriveLocation> {
-        val results = when (yearFilter) {
-            is YearFilter.AllTime -> aggregateDao.getDriveLocationsForCountry(carId, countryCode)
-            is YearFilter.Year -> {
-                val startDate = "${yearFilter.year}-01-01T00:00:00"
-                val endDate = "${yearFilter.year + 1}-01-01T00:00:00"
-                aggregateDao.getDriveLocationsForCountryInRange(carId, countryCode, startDate, endDate)
-            }
-        }
-        return results.map { it.toDriveLocation() }
+        val (startDate, endDate) = yearFilter.toDateBounds()
+        return aggregateDao.getDriveLocationsForCountry(carId, countryCode, startDate, endDate)
+            .map { it.toDriveLocation() }
     }
+}
+
+/**
+ * Map a [YearFilter] to (startDate, endDate) query bounds.
+ * All-time uses the [DateBounds] sentinels, which match every row.
+ */
+private fun YearFilter.toDateBounds(): Pair<String, String> = when (this) {
+    is YearFilter.AllTime -> DateBounds.MIN to DateBounds.MAX
+    is YearFilter.Year -> "$year-01-01T00:00:00" to "${year + 1}-01-01T00:00:00"
 }
 
 /**


### PR DESCRIPTION
Tenth cluster from the code review — the single highest-value data-layer refactor.

Every `fooInRange(carId, startDate, endDate)` DAO method was a verbatim copy of `foo(carId)` plus a date predicate (including a ~60-line SQL block duplicated in full), and `StatsRepository` mirrored the duplication with ~150-line `AllTime`/`ForYear` clone pairs.

- All-time is now the range query with sentinel bounds (`DateBounds.MIN = ""`, `MAX = "￿"` — safe lexicographic bounds for the non-null ISO-8601 TEXT date columns).
- **50 query pairs merged**: AggregateDao 25, DriveSummaryDao 15, ChargeSummaryDao 10. Pairs without a true twin were left alone.
- `StatsRepository.getQuickStats`/`getDeepStats` collapsed to single bodies driven by a `YearFilter.toDateBounds()` helper; the four fields the year view never computed stay gated on `AllTime` so behavior is bit-identical. Public API unchanged — no UI files touched.
- Net **−574 lines**.
- One semantic note: the merged all-time aggregate queries now JOIN the summary table to reach `startDate`; identical results because aggregates are only ever created from summary rows.

`compileDebugKotlin`, `lintDebug`, `testDebugUnitTest` all pass; grep confirms no stale references to removed names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)