### PR TITLE
Shared RouteMapView component for all embedded maps

### DIFF
--- a/app/src/main/java/com/matedroid/ui/components/RouteMapView.kt
+++ b/app/src/main/java/com/matedroid/ui/components/RouteMapView.kt
@@ -1,0 +1,140 @@
+package com.matedroid.ui.components
+
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.delay
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.BoundingBox
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.CustomZoomButtonsController
+import org.osmdroid.views.MapView
+
+/** How an embedded osmdroid map responds to touch. */
+enum class MapGestureMode {
+    /** One finger scrolls the surrounding page; two fingers pan/zoom the map. */
+    TWO_FINGER_PAN,
+
+    /** Fully inert — no pan, no zoom. Taps are handled by Compose overlays above the map. */
+    INERT,
+
+    /** Regular osmdroid gestures, single-finger pan included (fullscreen maps). */
+    FULL
+}
+
+/**
+ * Shared osmdroid [MapView] wrapper: MAPNIK tiles, gesture handling per [gestureMode], optional
+ * tile dimming, optional deferred mount, and the mandatory `onDetach()` on release (without it
+ * every visit to the screen leaks a tile provider).
+ *
+ * Screen-specific content stays at the call site: [onMapReady] runs once inside the view factory
+ * (markers, polylines, zoom/center), [update] runs on every recomposition-driven update pass.
+ */
+@Composable
+fun RouteMapView(
+    modifier: Modifier = Modifier,
+    gestureMode: MapGestureMode = MapGestureMode.TWO_FINGER_PAN,
+    dimTiles: Boolean = false,
+    deferMount: Boolean = false,
+    onMapReady: ((MapView) -> Unit)? = null,
+    update: ((MapView) -> Unit)? = null
+) {
+    val isDark = isSystemInDarkTheme()
+
+    // Defer MapView instantiation by a short delay so the first frame paints before osmdroid's
+    // synchronous MapView constructor runs on the main thread.
+    var mapMounted by remember { mutableStateOf(!deferMount) }
+    if (deferMount) {
+        LaunchedEffect(Unit) {
+            delay(120)
+            mapMounted = true
+        }
+    }
+    if (!mapMounted) return
+
+    AndroidView(
+        factory = { ctx ->
+            MapView(ctx).apply {
+                setTileSource(TileSourceFactory.MAPNIK)
+                when (gestureMode) {
+                    MapGestureMode.TWO_FINGER_PAN -> {
+                        setMultiTouchControls(true)
+                        setOnTouchListener { v, event ->
+                            v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
+                            false
+                        }
+                    }
+                    MapGestureMode.INERT -> {
+                        setMultiTouchControls(false)
+                        zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
+                        isClickable = false
+                        isFocusable = false
+                        setOnTouchListener { _, _ -> true }
+                    }
+                    MapGestureMode.FULL -> setMultiTouchControls(true)
+                }
+                if (dimTiles) {
+                    overlayManager.tilesOverlay.setColorFilter(mapDimFilter(isDark))
+                }
+                onMapReady?.invoke(this)
+            }
+        },
+        update = { mapView -> update?.invoke(mapView) },
+        // onDetach() shuts down osmdroid's tile-loader threads and cache.
+        onRelease = { it.onDetach() },
+        modifier = modifier
+    )
+}
+
+// Dim + desaturate map tiles so overlaid data stays legible. Route polylines and markers
+// are separate overlays and are unaffected by this tile-only filter.
+fun mapDimFilter(isDark: Boolean): ColorMatrixColorFilter {
+    val matrix = ColorMatrix().apply { setSaturation(if (isDark) 0.35f else 0.55f) }
+    val toneScale = if (isDark) 0.60f else 0.92f
+    val toneLift = if (isDark) 0f else 18f
+    matrix.postConcat(
+        ColorMatrix(
+            floatArrayOf(
+                toneScale, 0f, 0f, 0f, toneLift,
+                0f, toneScale, 0f, 0f, toneLift,
+                0f, 0f, toneScale, 0f, toneLift,
+                0f, 0f, 0f, 1f, 0f
+            )
+        )
+    )
+    return ColorMatrixColorFilter(matrix)
+}
+
+/**
+ * Bounding box around [points] with fractional padding on each side, and a minimum absolute
+ * padding so single points (or degenerate routes) still get a sensible viewport.
+ * [points] must be non-empty.
+ */
+fun boundingBoxOf(
+    points: List<GeoPoint>,
+    paddingFraction: Double = 0.15,
+    minPadding: Double = 0.01
+): BoundingBox {
+    val minLat = points.minOf { it.latitude }
+    val maxLat = points.maxOf { it.latitude }
+    val minLon = points.minOf { it.longitude }
+    val maxLon = points.maxOf { it.longitude }
+
+    val latPadding = maxOf((maxLat - minLat) * paddingFraction, minPadding)
+    val lonPadding = maxOf((maxLon - minLon) * paddingFraction, minPadding)
+
+    return BoundingBox(
+        maxLat + latPadding,  // north
+        maxLon + lonPadding,  // east
+        minLat - latPadding,  // south
+        minLon - lonPadding   // west
+    )
+}

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargeDetailScreen.kt
@@ -74,7 +74,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlin.math.roundToInt
 import com.matedroid.R
@@ -85,13 +84,12 @@ import com.matedroid.domain.ChargeComparison
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.screens.trips.displayName
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import com.matedroid.util.formatDurationCompact
 import com.matedroid.util.formatMedium
@@ -817,35 +815,23 @@ private fun ChargeMapCard(latitude: Double, longitude: Double, accent: Color) {
             ) {
                 val primaryColor = accent.toArgb()
 
-                AndroidView(
-                    factory = { ctx ->
-                        MapView(ctx).apply {
-                            setTileSource(TileSourceFactory.MAPNIK)
-                            setMultiTouchControls(true)
-                            // One finger scrolls the surrounding page; two fingers pan/zoom the map.
-                            setOnTouchListener { v, event ->
-                                v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
-                                false
-                            }
+                RouteMapView(
+                    onMapReady = { mapView ->
+                        val geoPoint = GeoPoint(latitude, longitude)
 
-                            val geoPoint = GeoPoint(latitude, longitude)
-
-                            // Add marker at charge location
-                            val marker = Marker(this).apply {
-                                position = geoPoint
-                                setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-                                title = chargeLocationMarker
-                                icon = createPinMarkerDrawable(ctx.resources, primaryColor)
-                            }
-                            overlays.add(marker)
-
-                            // Center on the location
-                            controller.setZoom(16.0)
-                            controller.setCenter(geoPoint)
+                        // Add marker at charge location
+                        val marker = Marker(mapView).apply {
+                            position = geoPoint
+                            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                            title = chargeLocationMarker
+                            icon = createPinMarkerDrawable(mapView.context.resources, primaryColor)
                         }
+                        mapView.overlays.add(marker)
+
+                        // Center on the location
+                        mapView.controller.setZoom(16.0)
+                        mapView.controller.setCenter(geoPoint)
                     },
-                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
-                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -147,19 +147,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.local.CarImageOverride
 import com.matedroid.ui.components.CarImagePickerDialog
+import com.matedroid.ui.components.MapGestureMode
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
 import com.matedroid.util.formatDuration
 import com.matedroid.util.formatShortNoYear
 import com.matedroid.util.formatTime
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.CustomZoomButtonsController
-import org.osmdroid.views.MapView
 import com.matedroid.data.api.models.BatteryDetails
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarExterior
@@ -2031,48 +2029,41 @@ private fun LocationCard(
             )
 
             if (latitude != null && longitude != null) {
-                AndroidView(
-                    factory = { ctx ->
-                        MapView(ctx).apply {
-                            setTileSource(TileSourceFactory.MAPNIK)
-                            setMultiTouchControls(false)
-                            zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
-                            isClickable = false
-                            isFocusable = false
-                            // Mute the basemap so roads/labels recede behind the scrim
-                            // and pin. Dark theme: grayscale + darken. Light theme:
-                            // grayscale + lift toward white to soften the detail.
-                            val matrix = ColorMatrix().apply { setSaturation(0f) }
-                            matrix.postConcat(
-                                if (dark) {
-                                    ColorMatrix(
-                                        floatArrayOf(
-                                            0.55f, 0f, 0f, 0f, 0f,
-                                            0f, 0.55f, 0f, 0f, 0f,
-                                            0f, 0f, 0.60f, 0f, 0f,
-                                            0f, 0f, 0f, 1f, 0f
-                                        )
+                RouteMapView(
+                    gestureMode = MapGestureMode.INERT,
+                    onMapReady = { mapView ->
+                        // Mute the basemap so roads/labels recede behind the scrim
+                        // and pin. Dark theme: grayscale + darken. Light theme:
+                        // grayscale + lift toward white to soften the detail.
+                        // (Deliberately not the shared dim filter — this mini-map
+                        // mutes harder than the detail-screen hero maps.)
+                        val matrix = ColorMatrix().apply { setSaturation(0f) }
+                        matrix.postConcat(
+                            if (dark) {
+                                ColorMatrix(
+                                    floatArrayOf(
+                                        0.55f, 0f, 0f, 0f, 0f,
+                                        0f, 0.55f, 0f, 0f, 0f,
+                                        0f, 0f, 0.60f, 0f, 0f,
+                                        0f, 0f, 0f, 1f, 0f
                                     )
-                                } else {
-                                    ColorMatrix(
-                                        floatArrayOf(
-                                            0.92f, 0f, 0f, 0f, 18f,
-                                            0f, 0.92f, 0f, 0f, 18f,
-                                            0f, 0f, 0.92f, 0f, 18f,
-                                            0f, 0f, 0f, 1f, 0f
-                                        )
+                                )
+                            } else {
+                                ColorMatrix(
+                                    floatArrayOf(
+                                        0.92f, 0f, 0f, 0f, 18f,
+                                        0f, 0.92f, 0f, 0f, 18f,
+                                        0f, 0f, 0.92f, 0f, 18f,
+                                        0f, 0f, 0f, 1f, 0f
                                     )
-                                }
-                            )
-                            overlayManager.tilesOverlay.setColorFilter(ColorMatrixColorFilter(matrix))
-                            controller.setZoom(15.0)
-                            controller.setCenter(GeoPoint(latitude, longitude))
-                            // Fully inert — no pan, no zoom. Taps are handled by the
-                            // Compose overlay above the map.
-                            setOnTouchListener { _, _ -> true }
-                        }
+                                )
+                            }
+                        )
+                        mapView.overlayManager.tilesOverlay.setColorFilter(ColorMatrixColorFilter(matrix))
+                        mapView.controller.setZoom(15.0)
+                        mapView.controller.setCenter(GeoPoint(latitude, longitude))
                     },
-                    // factory only runs once — without this the map stays centered on
+                    // onMapReady only runs once — without this the map stays centered on
                     // wherever the car was at first composition while the status polls on.
                     update = { map ->
                         val center = GeoPoint(latitude, longitude)
@@ -2082,8 +2073,6 @@ private fun LocationCard(
                             map.controller.setCenter(center)
                         }
                     },
-                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
-                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlin.math.roundToInt
 import com.matedroid.R
@@ -85,13 +84,12 @@ import com.matedroid.domain.DriveComparison
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.FullscreenLineChart
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
+import com.matedroid.ui.components.boundingBoxOf
 import com.matedroid.ui.screens.trips.displayName
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
-import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Polyline
 import com.matedroid.util.formatDurationCompact
 import com.matedroid.util.formatMedium
@@ -741,56 +739,29 @@ private fun DriveMapCard(positions: List<DrivePosition>, routeColor: Color) {
                     .height(250.dp)
                     .clip(RoundedCornerShape(8.dp))
             ) {
-                AndroidView(
-                    factory = { ctx ->
-                        MapView(ctx).apply {
-                            setTileSource(TileSourceFactory.MAPNIK)
-                            setMultiTouchControls(true)
-                            // One finger scrolls the surrounding page; two fingers pan/zoom the map.
-                            setOnTouchListener { v, event ->
-                                v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
-                                false
-                            }
+                RouteMapView(
+                    onMapReady = { mapView ->
+                        val geoPoints = validPositions.map { pos ->
+                            GeoPoint(pos.latitude!!, pos.longitude!!)
+                        }
 
-                            val geoPoints = validPositions.map { pos ->
-                                GeoPoint(pos.latitude!!, pos.longitude!!)
-                            }
+                        val polyline = Polyline().apply {
+                            setPoints(geoPoints)
+                            outlinePaint.color = routeColorArgb
+                            outlinePaint.strokeWidth = 8f
+                            outlinePaint.strokeCap = Paint.Cap.ROUND
+                            outlinePaint.strokeJoin = Paint.Join.ROUND
+                        }
+                        mapView.overlays.add(polyline)
 
-                            val polyline = Polyline().apply {
-                                setPoints(geoPoints)
-                                outlinePaint.color = routeColorArgb
-                                outlinePaint.strokeWidth = 8f
-                                outlinePaint.strokeCap = Paint.Cap.ROUND
-                                outlinePaint.strokeJoin = Paint.Join.ROUND
-                            }
-                            overlays.add(polyline)
-
-                            if (geoPoints.isNotEmpty()) {
-                                val north = geoPoints.maxOf { it.latitude }
-                                val south = geoPoints.minOf { it.latitude }
-                                val east = geoPoints.maxOf { it.longitude }
-                                val west = geoPoints.minOf { it.longitude }
-
-                                val latPadding = (north - south) * 0.15
-                                val lonPadding = (east - west) * 0.15
-
-                                val boundingBox = BoundingBox(
-                                    north + latPadding,
-                                    east + lonPadding,
-                                    south - latPadding,
-                                    west - lonPadding
-                                )
-
-                                post {
-                                    zoomToBoundingBox(boundingBox, false)
-                                    invalidate()
-                                }
+                        if (geoPoints.isNotEmpty()) {
+                            val boundingBox = boundingBoxOf(geoPoints)
+                            mapView.post {
+                                mapView.zoomToBoundingBox(boundingBox, false)
+                                mapView.invalidate()
                             }
                         }
                     },
-                    // onDetach() shuts down osmdroid's tile-loader threads and cache;
-                    // without it every visit to this screen leaks a tile provider.
-                    onRelease = { it.onDetach() },
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/stats/RegionsVisitedScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.repository.CountryBoundary
@@ -68,14 +67,13 @@ import com.matedroid.domain.model.RegionRecord
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.domain.model.YearFilter
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
+import com.matedroid.ui.components.boundingBoxOf
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.ui.theme.BoundaryColor
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
-import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Polygon
 import com.matedroid.util.formatMedium
@@ -507,21 +505,23 @@ private fun CountryMapCard(
                     .padding(start = 12.dp, end = 12.dp, bottom = 12.dp)
                     .clip(RoundedCornerShape(16.dp))
             ) {
-                AndroidView(
-                    factory = { ctx ->
-                        MapView(ctx).apply {
-                            setTileSource(TileSourceFactory.MAPNIK)
-                            setMultiTouchControls(true)
-                            // One finger scrolls the surrounding page; two fingers pan/zoom the map.
-                            setOnTouchListener { v, event ->
-                                v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
-                                false
-                            }
-                        }
-                    },
-                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
-                    onRelease = { it.onDetach() },
+                // Track the last applied data so unrelated update passes don't rebuild
+                // hundreds of markers.
+                val lastApplied = remember { arrayOfNulls<Any>(4) }
+
+                RouteMapView(
                     update = { mapView ->
+                        // Skip the expensive marker rebuild when the inputs haven't changed.
+                        if (lastApplied[0] == mapViewMode &&
+                            lastApplied[1] == chargeLocations &&
+                            lastApplied[2] == driveLocations &&
+                            lastApplied[3] == countryBoundary
+                        ) return@RouteMapView
+                        lastApplied[0] = mapViewMode
+                        lastApplied[1] = chargeLocations
+                        lastApplied[2] = driveLocations
+                        lastApplied[3] = countryBoundary
+
                         // Clear all overlays except keep any info windows
                         mapView.overlays.clear()
 
@@ -557,7 +557,9 @@ private fun CountryMapCard(
 
                                 // Only zoom on initial load
                                 if (!hasInitialZoom && chargeLocations.isNotEmpty()) {
-                                    val boundingBox = calculateChargeBoundingBox(chargeLocations)
+                                    val boundingBox = boundingBoxOf(
+                                        chargeLocations.map { GeoPoint(it.latitude, it.longitude) }
+                                    )
                                     mapView.post {
                                         mapView.zoomToBoundingBox(boundingBox, false, 60)
                                         hasInitialZoom = true
@@ -587,7 +589,9 @@ private fun CountryMapCard(
 
                                 // Only zoom on initial load
                                 if (!hasInitialZoom && driveLocations.isNotEmpty()) {
-                                    val boundingBox = calculateDriveBoundingBox(driveLocations)
+                                    val boundingBox = boundingBoxOf(
+                                        driveLocations.map { GeoPoint(it.latitude, it.longitude) }
+                                    )
                                     mapView.post {
                                         mapView.zoomToBoundingBox(boundingBox, false, 60)
                                         hasInitialZoom = true
@@ -798,71 +802,6 @@ private fun MapModeToggle(
             }
         }
     }
-}
-
-/**
- * Calculate bounding box that contains all charge locations with some padding.
- */
-private fun calculateChargeBoundingBox(chargeLocations: List<ChargeLocation>): BoundingBox {
-    if (chargeLocations.isEmpty()) {
-        // Default to Europe if no locations
-        return BoundingBox(55.0, 15.0, 35.0, -10.0)
-    }
-
-    // Note: Double.MIN_VALUE is the smallest POSITIVE double, not the most negative —
-    // seeding max with it breaks for all-negative coordinates (southern/western hemispheres).
-    val minLat = chargeLocations.minOf { it.latitude }
-    val maxLat = chargeLocations.maxOf { it.latitude }
-    val minLon = chargeLocations.minOf { it.longitude }
-    val maxLon = chargeLocations.maxOf { it.longitude }
-
-    // Add some padding (about 10% on each side)
-    val latPadding = (maxLat - minLat) * 0.15
-    val lonPadding = (maxLon - minLon) * 0.15
-
-    // Ensure minimum padding for single point
-    val minPadding = 0.01
-    val effectiveLatPadding = maxOf(latPadding, minPadding)
-    val effectiveLonPadding = maxOf(lonPadding, minPadding)
-
-    return BoundingBox(
-        maxLat + effectiveLatPadding,  // north
-        maxLon + effectiveLonPadding,  // east
-        minLat - effectiveLatPadding,  // south
-        minLon - effectiveLonPadding   // west
-    )
-}
-
-/**
- * Calculate bounding box that contains all drive locations with some padding.
- */
-private fun calculateDriveBoundingBox(driveLocations: List<DriveLocation>): BoundingBox {
-    if (driveLocations.isEmpty()) {
-        // Default to Europe if no locations
-        return BoundingBox(55.0, 15.0, 35.0, -10.0)
-    }
-
-    // See calculateChargeBoundingBox — Double.MIN_VALUE seeding broke negative coordinates.
-    val minLat = driveLocations.minOf { it.latitude }
-    val maxLat = driveLocations.maxOf { it.latitude }
-    val minLon = driveLocations.minOf { it.longitude }
-    val maxLon = driveLocations.maxOf { it.longitude }
-
-    // Add some padding (about 10% on each side)
-    val latPadding = (maxLat - minLat) * 0.15
-    val lonPadding = (maxLon - minLon) * 0.15
-
-    // Ensure minimum padding for single point
-    val minPadding = 0.01
-    val effectiveLatPadding = maxOf(latPadding, minPadding)
-    val effectiveLonPadding = maxOf(lonPadding, minPadding)
-
-    return BoundingBox(
-        maxLat + effectiveLatPadding,  // north
-        maxLon + effectiveLonPadding,  // east
-        minLat - effectiveLatPadding,  // south
-        minLon - effectiveLonPadding   // west
-    )
 }
 
 /**

--- a/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/trips/TripDetailScreen.kt
@@ -1,7 +1,5 @@
 package com.matedroid.ui.screens.trips
 
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import android.view.MotionEvent
 import androidx.compose.foundation.Canvas
@@ -88,7 +86,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.activity.compose.BackHandler
@@ -100,7 +97,9 @@ import com.matedroid.domain.model.Trip
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.ui.components.CostDonutStop
+import com.matedroid.ui.components.MapGestureMode
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
 import com.matedroid.ui.components.TripCostDonut
 import com.matedroid.ui.components.computeCostShades
 import com.matedroid.ui.components.TripEditActions
@@ -116,10 +115,8 @@ import com.matedroid.ui.theme.StatusSuccess
 import com.matedroid.util.formatDuration
 import com.matedroid.util.formatMedium
 import com.matedroid.util.formatMediumNoYear
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Polyline
 
@@ -1075,8 +1072,6 @@ private fun TripMapCard(
     currencySymbol: String,
     onChargeClick: (chargeId: Int) -> Unit = {}
 ) {
-    val isDark = isSystemInDarkTheme()
-
     val mapColors = remember(palette) {
         MapColors(
             start = StatusSuccess.toArgb(),
@@ -1129,7 +1124,6 @@ private fun TripMapCard(
             preparedRoute = preparedRoute,
             markers = markers,
             mapColors = mapColors,
-            isDark = isDark,
             isMapLoading = isMapLoading,
             trip = trip,
             units = units,
@@ -1156,7 +1150,6 @@ private fun TripMapCard(
             preparedRoute = preparedRoute,
             markers = markers,
             mapColors = mapColors,
-            isDark = isDark,
             isMapLoading = isMapLoading,
             trip = trip,
             units = units,
@@ -1176,7 +1169,6 @@ private fun TripMapContent(
     preparedRoute: PreparedRoute?,
     markers: List<TripMapMarker>,
     mapColors: MapColors,
-    isDark: Boolean,
     isMapLoading: Boolean,
     trip: Trip,
     units: Units?,
@@ -1194,7 +1186,6 @@ private fun TripMapContent(
             preparedRoute = preparedRoute,
             markers = markers,
             mapColors = mapColors,
-            isDark = isDark,
             isMapLoading = isMapLoading,
             singleFingerScrollsPage = singleFingerScrollsPage,
             onChargeClick = onChargeClick,
@@ -1229,7 +1220,6 @@ private fun TripMapAndroidView(
     preparedRoute: PreparedRoute?,
     markers: List<TripMapMarker>,
     mapColors: MapColors,
-    isDark: Boolean,
     isMapLoading: Boolean,
     singleFingerScrollsPage: Boolean,
     onChargeClick: (chargeId: Int) -> Unit,
@@ -1253,41 +1243,22 @@ private fun TripMapAndroidView(
     // Track the last applied data so we can skip redrawing overlays when nothing changed.
     val lastApplied = remember { arrayOfNulls<Any>(3) }
 
-    // Defer MapView instantiation by a short delay so the first frame paints before osmdroid's
-    // synchronous MapView constructor runs on the main thread.
-    var mapMounted by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        kotlinx.coroutines.delay(120)
-        mapMounted = true
-    }
-
     Box(modifier = modifier) {
-        if (mapMounted) AndroidView(
-            factory = { mapCtx ->
-                MapView(mapCtx).apply {
-                    setTileSource(TileSourceFactory.MAPNIK)
-                    setMultiTouchControls(true)
-                    // Dim + desaturate the tiles so the accent route and the docked vitals bar
-                    // read as a deliberate hero rather than raw map data.
-                    overlayManager.tilesOverlay.setColorFilter(mapDimFilter(isDark))
-                    if (singleFingerScrollsPage) {
-                        // Inline hero: one finger scrolls the surrounding page; two fingers
-                        // pan/zoom the map (we hold the parent off only with a second finger).
-                        setOnTouchListener { v, event ->
-                            v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
-                            false
-                        }
-                    }
-                }
-            },
+        RouteMapView(
+            gestureMode = if (singleFingerScrollsPage) MapGestureMode.TWO_FINGER_PAN
+            else MapGestureMode.FULL,
+            // Dim + desaturate the tiles so the accent route and the docked vitals bar
+            // read as a deliberate hero rather than raw map data.
+            dimTiles = true,
+            deferMount = true,
             update = { mapView ->
-                val prep = preparedRoute ?: return@AndroidView
+                val prep = preparedRoute ?: return@RouteMapView
 
                 // Skip the expensive overlay rebuild when the inputs haven't changed.
                 if (lastApplied[0] == prep &&
                     lastApplied[1] == markers &&
                     lastApplied[2] == mapColors
-                ) return@AndroidView
+                ) return@RouteMapView
                 lastApplied[0] = prep
                 lastApplied[1] = markers
                 lastApplied[2] = mapColors
@@ -1381,8 +1352,6 @@ private fun TripMapAndroidView(
                     }
                 }
             },
-            // onDetach() shuts down osmdroid's tile-loader threads and cache.
-            onRelease = { it.onDetach() },
             modifier = Modifier.fillMaxSize()
         )
 
@@ -1415,7 +1384,6 @@ private fun TripMapFullscreen(
     preparedRoute: PreparedRoute?,
     markers: List<TripMapMarker>,
     mapColors: MapColors,
-    isDark: Boolean,
     isMapLoading: Boolean,
     trip: Trip,
     units: Units?,
@@ -1440,7 +1408,6 @@ private fun TripMapFullscreen(
             preparedRoute = preparedRoute,
             markers = markers,
             mapColors = mapColors,
-            isDark = isDark,
             isMapLoading = isMapLoading,
             trip = trip,
             units = units,
@@ -1486,25 +1453,6 @@ private fun BoxScope.MapCornerButton(
             tint = MaterialTheme.colorScheme.onSurface
         )
     }
-}
-
-// Dim + desaturate map tiles so overlaid data stays legible. The route polyline and markers
-// are separate overlays and are unaffected by this tile-only filter.
-private fun mapDimFilter(isDark: Boolean): ColorMatrixColorFilter {
-    val matrix = ColorMatrix().apply { setSaturation(if (isDark) 0.35f else 0.55f) }
-    val toneScale = if (isDark) 0.60f else 0.92f
-    val toneLift = if (isDark) 0f else 18f
-    matrix.postConcat(
-        ColorMatrix(
-            floatArrayOf(
-                toneScale, 0f, 0f, 0f, toneLift,
-                0f, toneScale, 0f, 0f, toneLift,
-                0f, 0f, toneScale, 0f, toneLift,
-                0f, 0f, 0f, 1f, 0f
-            )
-        )
-    )
-    return ColorMatrixColorFilter(matrix)
 }
 
 // Docked vitals bar — the two figures you compare trips by (consumption, cost/100), sitting on

--- a/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/wherewasi/WhereWasIScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.matedroid.R
 import com.matedroid.data.repository.WeatherCondition
@@ -67,11 +66,10 @@ import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.icons.CustomIcons
 import com.matedroid.util.formatDuration
 import com.matedroid.ui.components.MateDroidLoadingPlaceholder
+import com.matedroid.ui.components.RouteMapView
 import com.matedroid.ui.components.createPinMarkerDrawable
 import com.matedroid.ui.theme.CarColorPalettes
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -212,28 +210,17 @@ fun WhereWasIScreen(
                                     .height(250.dp)
                                     .clip(RoundedCornerShape(12.dp))
                             ) {
-                                AndroidView(
-                                    factory = { ctx ->
-                                        MapView(ctx).apply {
-                                            setTileSource(TileSourceFactory.MAPNIK)
-                                            setMultiTouchControls(true)
-                                            // One finger scrolls the surrounding page; two fingers pan/zoom the map.
-                                            setOnTouchListener { v, event ->
-                                                v.parent?.requestDisallowInterceptTouchEvent(event.pointerCount >= 2)
-                                                false
-                                            }
-                                            controller.setZoom(15.0)
-                                            controller.setCenter(GeoPoint(lat, lon))
-                                            val marker = org.osmdroid.views.overlay.Marker(this)
-                                            marker.position = GeoPoint(lat, lon)
-                                            marker.setAnchor(org.osmdroid.views.overlay.Marker.ANCHOR_CENTER, org.osmdroid.views.overlay.Marker.ANCHOR_BOTTOM)
-                                            marker.icon = createPinMarkerDrawable(ctx.resources, accentArgb)
-                                            marker.title = youWereHere
-                                            overlays.add(marker)
-                                        }
+                                RouteMapView(
+                                    onMapReady = { mapView ->
+                                        mapView.controller.setZoom(15.0)
+                                        mapView.controller.setCenter(GeoPoint(lat, lon))
+                                        val marker = org.osmdroid.views.overlay.Marker(mapView)
+                                        marker.position = GeoPoint(lat, lon)
+                                        marker.setAnchor(org.osmdroid.views.overlay.Marker.ANCHOR_CENTER, org.osmdroid.views.overlay.Marker.ANCHOR_BOTTOM)
+                                        marker.icon = createPinMarkerDrawable(mapView.context.resources, accentArgb)
+                                        marker.title = youWereHere
+                                        mapView.overlays.add(marker)
                                     },
-                                    // onDetach() shuts down osmdroid's tile-loader threads and cache.
-                                    onRelease = { it.onDetach() },
                                     modifier = Modifier.fillMaxSize()
                                 )
                                 FilledIconButton(

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,6 +51,10 @@ if (uiState.isLoading) {
 
 If the screen has a car palette in scope pass `palette.accent`; otherwise leave the default (Material primary). Keep small inline progress (button spinners, sub-section card loaders, weather card) on `CircularProgressIndicator` — the MD spinner is too visually heavy at that scale.
 
+### Embedded maps
+
+Never instantiate an osmdroid `MapView` inside a raw `AndroidView` — use `RouteMapView` (in `ui/components/RouteMapView.kt`). It owns the shared boilerplate: MAPNIK tile source, gesture handling (`MapGestureMode.TWO_FINGER_PAN` for maps embedded in scrollable pages, `INERT` for tap-through mini-maps, `FULL` for fullscreen), the optional dim/desaturate tile filter (`dimTiles`), an optional 120 ms deferred mount (`deferMount`) so the first frame paints before osmdroid's synchronous constructor runs, and the mandatory `onDetach()` on release. Screen-specific content goes through `onMapReady` (one-time setup: markers, polylines, zoom/center) and `update` (change-driven passes — guard expensive overlay rebuilds against unchanged inputs, see `TripDetailScreen`/`RegionsVisitedScreen`). The same file exports `mapDimFilter(isDark)` and `boundingBoxOf(points)` for padded route viewports.
+
 ### Localization (i18n)
 
 The app supports multiple languages using Android's standard resource-based localization system. Currently supported languages:


### PR DESCRIPTION
Eleventh cluster from the code review.

The osmdroid `MapView` setup (MAPNIK tiles, multitouch, the two-finger-pan trick, tile dimming, bounding-box math, `onDetach` teardown) was reimplemented with drift across six screens. This extracts one `RouteMapView` composable (`ui/components/RouteMapView.kt`) owning the common setup, gesture modes (`TWO_FINGER_PAN` / `INERT` / `FULL`), the shared dim filter, optional 120 ms deferred mount, and teardown — screen-specific content (polylines, markers, zoom/center, boundary overlays) stays at the call sites via `onMapReady`/`update` hooks. Shared `boundingBoxOf()` replaces the per-screen copies.

All six screens migrated with no visual change: trip detail keeps its mature internals (route cache, `lastApplied` guard, vitals overlay); RegionsVisited gains a change-guard so unrelated update passes stop rebuilding hundreds of markers; the dashboard keeps its own stronger mute filter and re-centering update. `docs/DEVELOPMENT.md` gained an "Embedded maps" section.

Minor deliberate deviations: DriveDetail's bounding box now gets the shared 0.01 minimum padding (only observable for zero-extent routes, where it's a fix); RegionsVisited's dead Europe-default box branch removed (both call sites guard non-empty).

`compileDebugKotlin` + `lintDebug` pass on the branch; full lint+tests re-run on main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)