### PR TITLE
Extract shared chart scrub/tooltip interaction

### DIFF
--- a/app/src/main/java/com/matedroid/ui/components/ChartInteraction.kt
+++ b/app/src/main/java/com/matedroid/ui/components/ChartInteraction.kt
@@ -1,0 +1,231 @@
+package com.matedroid.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+/**
+ * Shared tap/scrub/tooltip interaction plumbing for the native canvas line charts
+ * ([OptimizedLineChart], [DualAxisLineChart], [PowerSocOverlayChart]).
+ *
+ * Each chart keeps its own drawing and data mapping; the gesture handling, crosshair
+ * fraction<->index math, cross-chart selection sync and tooltip positioning live here
+ * so the three charts cannot drift apart.
+ */
+
+// ---------------------------------------------------------------------------
+// Crosshair fraction <-> display-point index math
+// ---------------------------------------------------------------------------
+
+/** Snaps a 0..1 crosshair fraction to the nearest display-point index. */
+internal fun fractionToIndex(fraction: Float, pointCount: Int): Int =
+    (fraction * (pointCount - 1)).roundToInt().coerceIn(0, (pointCount - 1).coerceAtLeast(0))
+
+/** The normalized 0..1 X fraction of a display-point index (index-snapped crosshair position). */
+internal fun indexToFraction(index: Int, pointCount: Int): Float =
+    if (pointCount > 1) index.toFloat() / (pointCount - 1) else 0f
+
+/** X pixel position of a display-point index across [plotWidth]. */
+internal fun indexToX(index: Int, pointCount: Int, plotWidth: Float): Float =
+    index * (plotWidth / (pointCount - 1).coerceAtLeast(1))
+
+// ---------------------------------------------------------------------------
+// Selection state with cross-chart sync
+// ---------------------------------------------------------------------------
+
+/**
+ * Holds a chart's own tap/scrub selection plus the "is the user actively scrubbing"
+ * flag used to arbitrate between the local selection and an external (sibling-chart)
+ * crosshair position.
+ */
+@Stable
+internal class ChartSelectionState<T> {
+    /** Point selected by tapping/scrubbing this chart, or null when dismissed. */
+    var selected: T? by mutableStateOf(null)
+
+    /** True while a horizontal scrub drag is in progress on this chart. */
+    var isUserInteracting: Boolean by mutableStateOf(false)
+
+    /**
+     * The point to display: while the user is not interacting with this chart and a
+     * sibling chart reports a crosshair fraction, the externally derived point wins;
+     * otherwise this chart's own selection shows.
+     */
+    fun displayed(externalSelectedFraction: Float?, externalPoint: T?): T? =
+        if (!isUserInteracting && externalSelectedFraction != null) externalPoint else selected
+}
+
+/**
+ * Remembers a [ChartSelectionState] and clears the local selection when the sibling
+ * chart dismisses its crosshair ([externalSelectedFraction] goes null) — but only when
+ * cross-chart sync is active ([clearOnExternalDismiss]) and the user is not currently
+ * scrubbing this chart.
+ */
+@Composable
+internal fun <T> rememberChartSelectionState(
+    externalSelectedFraction: Float?,
+    clearOnExternalDismiss: Boolean,
+): ChartSelectionState<T> {
+    val state = remember { ChartSelectionState<T>() }
+    LaunchedEffect(externalSelectedFraction) {
+        if (externalSelectedFraction == null && clearOnExternalDismiss && !state.isUserInteracting) {
+            state.selected = null
+        }
+    }
+    return state
+}
+
+// ---------------------------------------------------------------------------
+// Gesture handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Tap + horizontal-scrub gesture handling for a chart canvas.
+ *
+ * A tap reports its position via [onTap]; a horizontal drag scrubs via [onScrub].
+ * Both report the normalized 0..1 fraction across the plot width (canvas width minus
+ * [endInsetPx]) plus the raw Y pixel position. Only HORIZONTAL drags are claimed, so
+ * vertical swipes fall through to the enclosing scroll container and the page still
+ * scrolls.
+ *
+ * [keys] restart the pointer handlers exactly like [pointerInput] keys; [enabled] and
+ * the callbacks are captured when the handlers (re)start, so derive them from the same
+ * data as [keys].
+ *
+ * @param enabled When false no gestures are handled (e.g. not enough points).
+ * @param endInsetPx Width reserved at the end of the canvas that is not part of the
+ *   plot (e.g. a right-axis label strip).
+ * @param activeHeightPx Taps and drag starts below this Y are ignored (e.g. the
+ *   time-label strip under the plot). Unbounded by default.
+ * @param scrubOnDragStart Whether the drag-start position itself already scrubs; when
+ *   false only subsequent drag events do.
+ * @param onScrubbingChange Reports true while a scrub drag is in progress.
+ */
+internal fun Modifier.chartScrubber(
+    vararg keys: Any?,
+    enabled: Boolean = true,
+    endInsetPx: Float = 0f,
+    activeHeightPx: Float = Float.POSITIVE_INFINITY,
+    scrubOnDragStart: Boolean = true,
+    onScrubbingChange: ((Boolean) -> Unit)? = null,
+    onTap: (fraction: Float, y: Float) -> Unit,
+    onScrub: (fraction: Float, y: Float) -> Unit,
+): Modifier = this
+    // Tap toggles/moves the crosshair at the nearest point.
+    .pointerInput(keys = keys) {
+        if (!enabled) return@pointerInput
+        detectTapGestures { offset ->
+            if (offset.y > activeHeightPx) return@detectTapGestures
+            onTap(plotFraction(offset.x, endInsetPx), offset.y)
+        }
+    }
+    // Only claim HORIZONTAL drags (scrubbing the crosshair); vertical swipes fall
+    // through to the enclosing scroll container so the page still scrolls.
+    .pointerInput(keys = keys) {
+        if (!enabled) return@pointerInput
+        detectHorizontalDragGestures(
+            onDragStart = { offset ->
+                if (offset.y <= activeHeightPx) {
+                    onScrubbingChange?.invoke(true)
+                    if (scrubOnDragStart) onScrub(plotFraction(offset.x, endInsetPx), offset.y)
+                }
+            },
+            onDragEnd = { onScrubbingChange?.invoke(false) },
+            onDragCancel = { onScrubbingChange?.invoke(false) },
+            onHorizontalDrag = { change, _ ->
+                onScrub(plotFraction(change.position.x, endInsetPx), change.position.y)
+            }
+        )
+    }
+
+private fun PointerInputScope.plotFraction(x: Float, endInsetPx: Float): Float {
+    val plotWidth = (size.width - endInsetPx).coerceAtLeast(1f)
+    return (x / plotWidth).coerceIn(0f, 1f)
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip
+// ---------------------------------------------------------------------------
+
+private val TooltipShape = RoundedCornerShape(8.dp)
+
+/**
+ * Theme-aware chart tooltip chip on the shared inverseSurface style, horizontally
+ * centered on the crosshair and clamped so it stays fully on the canvas.
+ *
+ * Anchor and width are lambdas read inside the deferred offset block, so scrubbing
+ * moves the tooltip without recomposing it.
+ *
+ * @param anchorX Crosshair X in container pixels; the tooltip centers on it.
+ * @param containerWidthPx Container width used to clamp the tooltip on screen.
+ * @param anchorY Selected point Y; the tooltip floats 24px above it (clamped to the
+ *   top). Null pins the tooltip 4.dp from the top instead.
+ * @param elevated True draws a 4.dp shadow; false just clips (no shadow).
+ */
+@Composable
+internal fun ChartTooltip(
+    anchorX: () -> Float,
+    containerWidthPx: () -> Float,
+    modifier: Modifier = Modifier,
+    anchorY: (() -> Float)? = null,
+    elevated: Boolean = true,
+    verticalPadding: Dp = 6.dp,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    var tooltipSize by remember { mutableStateOf(IntSize.Zero) }
+    val tooltipBg = MaterialTheme.colorScheme.inverseSurface
+    Column(
+        modifier = modifier
+            .offset {
+                val maxX = (containerWidthPx() - tooltipSize.width).coerceAtLeast(0f)
+                val x = (anchorX() - tooltipSize.width / 2f).coerceIn(0f, maxX)
+                val y = if (anchorY != null) {
+                    (anchorY() - tooltipSize.height - 24f).coerceAtLeast(0f)
+                } else {
+                    4.dp.toPx()
+                }
+                IntOffset(x.roundToInt(), y.roundToInt())
+            }
+            .onSizeChanged { tooltipSize = it }
+            .then(
+                if (elevated) {
+                    Modifier
+                        .shadow(4.dp, TooltipShape)
+                        .background(tooltipBg, TooltipShape)
+                } else {
+                    Modifier
+                        .clip(TooltipShape)
+                        .background(tooltipBg)
+                }
+            )
+            .padding(horizontal = 10.dp, vertical = verticalPadding),
+        verticalArrangement = verticalArrangement,
+        content = content
+    )
+}

--- a/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/DualAxisLineChart.kt
@@ -5,20 +5,14 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,19 +23,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlin.math.roundToInt
 
 /**
  * A dual-axis line chart showing two data series with independent Y axes.
@@ -99,7 +89,6 @@ fun DualAxisLineChart(
         }
     }
     val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
-    val tooltipBg = MaterialTheme.colorScheme.inverseSurface
     val tooltipFg = MaterialTheme.colorScheme.inverseOnSurface
 
     val chartDataLeft = remember(dataLeft) { prepareChartData(dataLeft, fixedMinMax = null) { it } }
@@ -138,24 +127,24 @@ fun DualAxisLineChart(
         animProgress.animateTo(1f, tween(800, easing = FastOutSlowInEasing))
     }
 
-    var selectedPoint by remember { mutableStateOf<DualSelectedPoint?>(null) }
-    var isUserInteracting by remember { mutableStateOf(false) }
+    val selection = rememberChartSelectionState<DualSelectedPoint>(
+        externalSelectedFraction = externalSelectedFraction,
+        clearOnExternalDismiss = onXSelected != null
+    )
 
     val timeLabelHeightDp = if (timeLabels.isNotEmpty()) 20.dp else 0.dp
     val totalHeightDp = chartHeight + timeLabelHeightDp
 
-    val externalPoint: DualSelectedPoint? = remember(externalSelectedFraction, chartDataLeft, chartDataRight, canvasWidthPx) {
-        if (externalSelectedFraction == null || canvasWidthPx == 0f) return@remember null
-        val index = (externalSelectedFraction * (dataSize - 1)).roundToInt().coerceIn(0, dataSize - 1)
-        val cWidth = canvasWidthPx - rightLabelWidth
-        val stepX = cWidth / (dataSize - 1).coerceAtLeast(1)
-        val pointX = index * stepX
-        val fraction = if (dataSize > 1) index.toFloat() / (dataSize - 1) else 0f
+    // Builds the selected point at a display-point index. [fallbackY] anchors the
+    // crosshair when the left series has no value at that X.
+    fun pointAt(index: Int, fallbackY: Float): DualSelectedPoint {
+        val pointX = indexToX(index, dataSize, canvasWidthPx - rightLabelWidth)
+        val fraction = indexToFraction(index, dataSize)
         val leftVal = valueAtFraction(chartDataLeft.displayPoints, fraction)
         val leftY = if (leftVal != null) {
             chartHeightPx * (1 - (leftVal - chartDataLeft.minValue) / chartDataLeft.range)
-        } else chartHeightPx / 2
-        DualSelectedPoint(
+        } else fallbackY
+        return DualSelectedPoint(
             index = index,
             valueLeft = leftVal,
             valueRight = valueAtFraction(chartDataRight.displayPoints, fraction),
@@ -163,17 +152,12 @@ fun DualAxisLineChart(
         )
     }
 
-    LaunchedEffect(externalSelectedFraction) {
-        if (externalSelectedFraction == null && onXSelected != null && !isUserInteracting) {
-            selectedPoint = null
-        }
+    val externalPoint: DualSelectedPoint? = remember(externalSelectedFraction, chartDataLeft, chartDataRight, canvasWidthPx) {
+        if (externalSelectedFraction == null || canvasWidthPx == 0f) return@remember null
+        pointAt(fractionToIndex(externalSelectedFraction, dataSize), fallbackY = chartHeightPx / 2)
     }
 
-    val displayedPoint = if (!isUserInteracting && externalSelectedFraction != null) {
-        externalPoint
-    } else {
-        selectedPoint
-    }
+    val displayedPoint = selection.displayed(externalSelectedFraction, externalPoint)
 
     Box(modifier = modifier) {
         Canvas(
@@ -181,68 +165,30 @@ fun DualAxisLineChart(
                 .fillMaxWidth()
                 .height(totalHeightDp)
                 .onSizeChanged { canvasWidthPx = it.width.toFloat() }
-                // Tap toggles the tooltip at the nearest point (ignoring the time-label strip below the chart).
-                .pointerInput(chartDataLeft, chartDataRight) {
-                    if (dataSize < 2) return@pointerInput
-                    detectTapGestures { offset ->
-                        if (offset.y > chartHeightPx) return@detectTapGestures
-                        val cWidth = size.width.toFloat() - rightLabelWidth
-                        val stepX = cWidth / (dataSize - 1).coerceAtLeast(1)
-                        val index = (offset.x / stepX).roundToInt().coerceIn(0, dataSize - 1)
-                        if (selectedPoint?.index == index) {
-                            selectedPoint = null
+                // Taps/drag-starts in the time-label strip below the chart are ignored
+                // (activeHeightPx); the right axis label strip is outside the plot (endInsetPx).
+                .chartScrubber(
+                    chartDataLeft, chartDataRight,
+                    enabled = dataSize >= 2,
+                    endInsetPx = rightLabelWidth,
+                    activeHeightPx = chartHeightPx,
+                    onScrubbingChange = { selection.isUserInteracting = it },
+                    onTap = { fraction, y ->
+                        val index = fractionToIndex(fraction, dataSize)
+                        if (selection.selected?.index == index) {
+                            selection.selected = null
                             onXSelected?.invoke(null)
                         } else {
-                            val fraction = if (dataSize > 1) index.toFloat() / (dataSize - 1) else 0f
-                            val pointX = index * stepX
-                            val leftVal = valueAtFraction(chartDataLeft.displayPoints, fraction)
-                            val rightVal = valueAtFraction(chartDataRight.displayPoints, fraction)
-                            val leftY = if (leftVal != null) {
-                                chartHeightPx * (1 - (leftVal - chartDataLeft.minValue) / chartDataLeft.range)
-                            } else offset.y
-                            selectedPoint = DualSelectedPoint(index, leftVal, rightVal, Offset(pointX, leftY))
-                            onXSelected?.invoke(fraction)
+                            selection.selected = pointAt(index, fallbackY = y)
+                            onXSelected?.invoke(indexToFraction(index, dataSize))
                         }
+                    },
+                    onScrub = { fraction, y ->
+                        val index = fractionToIndex(fraction, dataSize)
+                        selection.selected = pointAt(index, fallbackY = y)
+                        onXSelected?.invoke(indexToFraction(index, dataSize))
                     }
-                }
-                // Only claim HORIZONTAL drags (scrubbing the crosshair); vertical swipes fall
-                // through to the enclosing scroll container so the page still scrolls.
-                .pointerInput(chartDataLeft, chartDataRight) {
-                    if (dataSize < 2) return@pointerInput
-
-                    fun updateSelection(xOffset: Float, yOffset: Float) {
-                        val width = size.width.toFloat()
-                        val cWidth = width - rightLabelWidth
-                        val stepX = cWidth / (dataSize - 1).coerceAtLeast(1)
-                        val index = ((xOffset / stepX).roundToInt()).coerceIn(0, dataSize - 1)
-                        val fraction = if (dataSize > 1) index.toFloat() / (dataSize - 1) else 0f
-                        val pointX = index * stepX
-                        val leftVal = valueAtFraction(chartDataLeft.displayPoints, fraction)
-                        val rightVal = valueAtFraction(chartDataRight.displayPoints, fraction)
-                        val leftY = if (leftVal != null) {
-                            chartHeightPx * (1 - (leftVal - chartDataLeft.minValue) / chartDataLeft.range)
-                        } else yOffset
-                        selectedPoint = DualSelectedPoint(
-                            index = index,
-                            valueLeft = leftVal,
-                            valueRight = rightVal,
-                            position = Offset(pointX, leftY)
-                        )
-                        onXSelected?.invoke(fraction)
-                    }
-
-                    detectHorizontalDragGestures(
-                        onDragStart = { offset ->
-                            if (offset.y <= chartHeightPx) {
-                                isUserInteracting = true
-                                updateSelection(offset.x, offset.y)
-                            }
-                        },
-                        onDragEnd = { isUserInteracting = false },
-                        onDragCancel = { isUserInteracting = false },
-                        onHorizontalDrag = { change, _ -> updateSelection(change.position.x, change.position.y) }
-                    )
-                }
+                )
         ) {
             val width = size.width
             val timeLabelHeightPx = timeLabelHeightDp.toPx()
@@ -279,8 +225,7 @@ fun DualAxisLineChart(
 
             // Selection indicators
             displayedPoint?.let { point ->
-                val stepX = (width - rLabelWidth) / (dataSize - 1).coerceAtLeast(1)
-                val pointX = point.index * stepX
+                val pointX = indexToX(point.index, dataSize, width - rLabelWidth)
 
                 // Vertical crosshair
                 drawCrosshair(surfaceColor, pointX, chartHeightPx)
@@ -297,8 +242,7 @@ fun DualAxisLineChart(
 
                 // Floating time chip
                 if (fractionToTimeLabel != null && timeLabelHeightPx > 0) {
-                    val fraction = if (dataSize > 1) point.index.toFloat() / (dataSize - 1) else 0f
-                    val timeStr = fractionToTimeLabel(fraction)
+                    val timeStr = fractionToTimeLabel(indexToFraction(point.index, dataSize))
                     drawFloatingTimeChip(timeStr, pointX, colorLeft, chartHeightPx, timeLabelHeightPx, width - rLabelWidth, chipTextSizePx)
                 }
             }
@@ -306,25 +250,14 @@ fun DualAxisLineChart(
 
         // Theme-aware tooltip with colored dot prefixes
         displayedPoint?.let { point ->
-            var tooltipWidth by remember { mutableStateOf(0) }
-            var tooltipHeight by remember { mutableStateOf(0) }
-
-            val xPx = (point.position.x - tooltipWidth / 2f)
-                .coerceIn(0f, (canvasWidthPx - tooltipWidth).coerceAtLeast(0f))
-            val yPx = (point.position.y - tooltipHeight - 24f).coerceAtLeast(0f)
-
-            Column(
-                modifier = Modifier
-                    .offset { IntOffset(xPx.roundToInt(), yPx.roundToInt()) }
-                    .onSizeChanged { tooltipWidth = it.width; tooltipHeight = it.height }
-                    .shadow(4.dp, RoundedCornerShape(8.dp))
-                    .background(tooltipBg, RoundedCornerShape(8.dp))
-                    .padding(horizontal = 10.dp, vertical = 6.dp)
+            ChartTooltip(
+                anchorX = { point.position.x },
+                anchorY = { point.position.y },
+                containerWidthPx = { canvasWidthPx }
             ) {
                 // Time label at top if available
                 if (fractionToTimeLabel != null) {
-                    val fraction = if (dataSize > 1) point.index.toFloat() / (dataSize - 1) else 0f
-                    val timeStr = fractionToTimeLabel(fraction)
+                    val timeStr = fractionToTimeLabel(indexToFraction(point.index, dataSize))
                     Text(
                         text = timeStr,
                         style = MaterialTheme.typography.labelSmall,
@@ -380,5 +313,5 @@ fun DualAxisLineChart(
  */
 private fun valueAtFraction(points: List<Float>, fraction: Float): Float? {
     if (points.isEmpty()) return null
-    return points.getOrNull((fraction * (points.size - 1)).roundToInt())
+    return points[fractionToIndex(fraction, points.size)]
 }

--- a/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/OptimizedLineChart.kt
@@ -4,15 +4,9 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,19 +16,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlin.math.roundToInt
 
 /**
  * An optimized line chart component with premium visuals:
@@ -84,7 +74,6 @@ fun OptimizedLineChart(
         }
     }
     val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
-    val tooltipBg = MaterialTheme.colorScheme.inverseSurface
     val tooltipFg = MaterialTheme.colorScheme.inverseOnSurface
 
     val chartData = remember(data, fixedMinMax, convertValue) {
@@ -110,35 +99,30 @@ fun OptimizedLineChart(
         animProgress.animateTo(1f, tween(800, easing = FastOutSlowInEasing))
     }
 
-    var selectedPoint by remember { mutableStateOf<SelectedPoint?>(null) }
-    var isUserInteracting by remember { mutableStateOf(false) }
+    val selection = rememberChartSelectionState<SelectedPoint>(
+        externalSelectedFraction = externalSelectedFraction,
+        clearOnExternalDismiss = onXSelected != null
+    )
 
     val timeLabelHeightDp = if (timeLabels.isNotEmpty()) 20.dp else 0.dp
     val timeLabelHeightPx = with(density) { timeLabelHeightDp.toPx() }
     val totalHeightDp = chartHeight + timeLabelHeightDp
 
+    // Builds the selected point at a display-point index (position in canvas pixels).
+    fun pointAt(index: Int): SelectedPoint {
+        val points = chartData.displayPoints
+        val pointX = indexToX(index, points.size, canvasWidthPx)
+        val pointY = chartHeightPx * (1 - (points[index] - chartData.minValue) / chartData.range)
+        return SelectedPoint(index, points[index], Offset(pointX, pointY))
+    }
+
     val externalPoint: SelectedPoint? = remember(externalSelectedFraction, chartData, canvasWidthPx) {
         if (externalSelectedFraction == null || canvasWidthPx == 0f) return@remember null
-        val points = chartData.displayPoints
-        if (points.isEmpty()) return@remember null
-        val index = (externalSelectedFraction * (points.size - 1)).roundToInt().coerceIn(0, points.lastIndex)
-        val stepX = canvasWidthPx / (points.size - 1).coerceAtLeast(1)
-        val pointX = index * stepX
-        val pointY = chartHeightPx * (1 - (points[index] - chartData.minValue) / chartData.range)
-        SelectedPoint(index, points[index], Offset(pointX, pointY))
+        if (chartData.displayPoints.isEmpty()) return@remember null
+        pointAt(fractionToIndex(externalSelectedFraction, chartData.displayPoints.size))
     }
 
-    LaunchedEffect(externalSelectedFraction) {
-        if (externalSelectedFraction == null && onXSelected != null && !isUserInteracting) {
-            selectedPoint = null
-        }
-    }
-
-    val displayedPoint = if (!isUserInteracting && externalSelectedFraction != null) {
-        externalPoint
-    } else {
-        selectedPoint
-    }
+    val displayedPoint = selection.displayed(externalSelectedFraction, externalPoint)
 
     Box(modifier = modifier) {
         Canvas(
@@ -146,50 +130,26 @@ fun OptimizedLineChart(
                 .fillMaxWidth()
                 .height(totalHeightDp)
                 .onSizeChanged { canvasWidthPx = it.width.toFloat() }
-                // Tap toggles the tooltip at the nearest point.
-                .pointerInput(chartData) {
-                    val points = chartData.displayPoints
-                    if (points.isEmpty()) return@pointerInput
-                    detectTapGestures { offset ->
-                        val width = size.width.toFloat()
-                        val stepX = width / (points.size - 1).coerceAtLeast(1)
-                        val index = (offset.x / stepX).roundToInt().coerceIn(0, points.lastIndex)
-                        if (selectedPoint?.index == index) {
-                            selectedPoint = null
+                .chartScrubber(
+                    chartData,
+                    enabled = chartData.displayPoints.isNotEmpty(),
+                    onScrubbingChange = { selection.isUserInteracting = it },
+                    onTap = { fraction, _ ->
+                        val index = fractionToIndex(fraction, chartData.displayPoints.size)
+                        if (selection.selected?.index == index) {
+                            selection.selected = null
                             onXSelected?.invoke(null)
                         } else {
-                            val fraction = if (points.size > 1) index.toFloat() / (points.size - 1) else 0f
-                            val pointX = index * stepX
-                            val pointY = chartHeightPx * (1 - (points[index] - chartData.minValue) / chartData.range)
-                            selectedPoint = SelectedPoint(index, points[index], Offset(pointX, pointY))
-                            onXSelected?.invoke(fraction)
+                            selection.selected = pointAt(index)
+                            onXSelected?.invoke(indexToFraction(index, chartData.displayPoints.size))
                         }
+                    },
+                    onScrub = { fraction, _ ->
+                        val index = fractionToIndex(fraction, chartData.displayPoints.size)
+                        selection.selected = pointAt(index)
+                        onXSelected?.invoke(indexToFraction(index, chartData.displayPoints.size))
                     }
-                }
-                // Only claim HORIZONTAL drags (scrubbing the crosshair); vertical swipes fall
-                // through to the enclosing scroll container so the page still scrolls.
-                .pointerInput(chartData) {
-                    val points = chartData.displayPoints
-                    if (points.isEmpty()) return@pointerInput
-
-                    fun updateSelection(xOffset: Float) {
-                        val width = size.width.toFloat()
-                        val stepX = width / (points.size - 1).coerceAtLeast(1)
-                        val index = ((xOffset / stepX).roundToInt()).coerceIn(0, points.lastIndex)
-                        val fraction = if (points.size > 1) index.toFloat() / (points.size - 1) else 0f
-                        val pointX = index * stepX
-                        val pointY = chartHeightPx * (1 - (points[index] - chartData.minValue) / chartData.range)
-                        selectedPoint = SelectedPoint(index, points[index], Offset(pointX, pointY))
-                        onXSelected?.invoke(fraction)
-                    }
-
-                    detectHorizontalDragGestures(
-                        onDragStart = { offset -> isUserInteracting = true; updateSelection(offset.x) },
-                        onDragEnd = { isUserInteracting = false },
-                        onDragCancel = { isUserInteracting = false },
-                        onHorizontalDrag = { change, _ -> updateSelection(change.position.x) }
-                    )
-                }
+                )
         ) {
             val width = size.width
             val progress = animProgress.value
@@ -235,9 +195,7 @@ fun OptimizedLineChart(
 
                 // Floating time chip
                 if (fractionToTimeLabel != null && timeLabelHeightPx > 0) {
-                    val pts = chartData.displayPoints
-                    val fraction = if (pts.size > 1) point.index.toFloat() / (pts.size - 1) else 0f
-                    val timeStr = fractionToTimeLabel(fraction)
+                    val timeStr = fractionToTimeLabel(indexToFraction(point.index, chartData.displayPoints.size))
                     drawFloatingTimeChip(timeStr, point.position.x, color, chartHeightPx, timeLabelHeightPx, width, chipTextSizePx)
                 }
             }
@@ -245,34 +203,26 @@ fun OptimizedLineChart(
 
         // Theme-aware tooltip
         displayedPoint?.let { point ->
-            var tooltipWidth by remember { mutableStateOf(0) }
-            var tooltipHeight by remember { mutableStateOf(0) }
-
             val tooltipText = if (fractionToTimeLabel != null) {
-                val pts = chartData.displayPoints
-                val fraction = if (pts.size > 1) point.index.toFloat() / (pts.size - 1) else 0f
-                val timeStr = fractionToTimeLabel(fraction)
+                val timeStr = fractionToTimeLabel(indexToFraction(point.index, chartData.displayPoints.size))
                 "$timeStr  \u2022  ${"%.1f".format(point.value)} $unit"
             } else {
                 "${"%.1f".format(point.value)} $unit"
             }
 
-            val xPx = (point.position.x - tooltipWidth / 2f)
-                .coerceIn(0f, (canvasWidthPx - tooltipWidth).coerceAtLeast(0f))
-            val yPx = (point.position.y - tooltipHeight - 24f).coerceAtLeast(0f)
-
-            Text(
-                text = tooltipText,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Bold,
-                color = tooltipFg,
-                modifier = Modifier
-                    .offset { IntOffset(xPx.roundToInt(), yPx.roundToInt()) }
-                    .onSizeChanged { tooltipWidth = it.width; tooltipHeight = it.height }
-                    .shadow(4.dp, RoundedCornerShape(8.dp))
-                    .background(tooltipBg, RoundedCornerShape(8.dp))
-                    .padding(horizontal = 10.dp, vertical = 4.dp)
-            )
+            ChartTooltip(
+                anchorX = { point.position.x },
+                anchorY = { point.position.y },
+                containerWidthPx = { canvasWidthPx },
+                verticalPadding = 4.dp
+            ) {
+                Text(
+                    text = tooltipText,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = tooltipFg
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
+++ b/app/src/main/java/com/matedroid/ui/components/PowerSocOverlayChart.kt
@@ -2,20 +2,15 @@ package com.matedroid.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,9 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,7 +33,6 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -108,9 +100,8 @@ fun PowerSocOverlayChart(
     val topPad = with(density) { 6.dp.toPx() }
 
     var selectedSoc by remember { mutableStateOf<Float?>(null) }
-    // Track the container + tooltip widths so the tooltip can follow the crosshair X (clamped on screen).
+    // Track the container width so the tooltip can follow the crosshair X (clamped on screen).
     var containerWidthPx by remember { mutableStateOf(0) }
-    var tooltipWidthPx by remember { mutableStateOf(0) }
 
     // Parent bumps dismissKey (on an outside tap or a scroll) to clear the tooltip.
     LaunchedEffect(dismissKey) { selectedSoc = null }
@@ -165,21 +156,14 @@ fun PowerSocOverlayChart(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(chartHeight + 18.dp)
-                // Tap sets the crosshair at that SoC.
-                .pointerInput(valid, socMin, socMax) {
-                    detectTapGestures { offset ->
-                        selectedSoc = socMin + (offset.x / size.width).coerceIn(0f, 1f) * socRange
-                    }
-                }
-                // Only claim HORIZONTAL drags (scrubbing); vertical swipes fall through to the
-                // enclosing scroll container so the page still scrolls.
-                .pointerInput(valid, socMin, socMax) {
-                    detectHorizontalDragGestures(
-                        onHorizontalDrag = { change, _ ->
-                            selectedSoc = socMin + (change.position.x / size.width).coerceIn(0f, 1f) * socRange
-                        }
-                    )
-                }
+                // Tap or scrub sets the crosshair at that SoC (continuous, no index snapping
+                // and no tap-to-dismiss toggle: dismissal comes from the parent's dismissKey).
+                .chartScrubber(
+                    valid, socMin, socMax,
+                    scrubOnDragStart = false,
+                    onTap = { fraction, _ -> selectedSoc = socMin + fraction * socRange },
+                    onScrub = { fraction, _ -> selectedSoc = socMin + fraction * socRange }
+                )
         ) {
             val w = size.width
             val plotH = chartHeightPx - topPad
@@ -248,23 +232,16 @@ fun PowerSocOverlayChart(
         selectedSoc?.let { soc ->
             val rows = renderCurves.mapNotNull { c -> interpolatePower(c.points, soc)?.let { c to it } }
             if (rows.isNotEmpty()) {
-                val tooltipBg = MaterialTheme.colorScheme.inverseSurface
                 val tooltipFg = MaterialTheme.colorScheme.inverseOnSurface
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .offset {
-                            val crosshairX = if (containerWidthPx > 0) {
-                                ((soc - socMin) / socRange) * containerWidthPx
-                            } else 0f
-                            val maxX = (containerWidthPx - tooltipWidthPx).coerceAtLeast(0)
-                            val x = (crosshairX - tooltipWidthPx / 2f).coerceIn(0f, maxX.toFloat())
-                            IntOffset(x.roundToInt(), 4.dp.roundToPx())
-                        }
-                        .onSizeChanged { tooltipWidthPx = it.width }
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(tooltipBg)
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                ChartTooltip(
+                    anchorX = {
+                        if (containerWidthPx > 0) {
+                            ((soc - socMin) / socRange) * containerWidthPx
+                        } else 0f
+                    },
+                    containerWidthPx = { containerWidthPx.toFloat() },
+                    anchorY = null, // pinned near the top of the chart
+                    elevated = false,
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     Text(


### PR DESCRIPTION
Part of the final review cluster. The tap/scrub/tooltip interaction logic was triplicated across `OptimizedLineChart`, `DualAxisLineChart` and `PowerSocOverlayChart` — the drift class that already produced the tooltip bug fixed in 47228bc.

New `ui/components/ChartInteraction.kt`:
- `Modifier.chartScrubber(...)` — tap + horizontal-drag scrubbing (vertical swipes still scroll the page), clamped 0..1 fraction reporting, per-chart knobs for plot-area gating/right-axis inset/drag-start behavior.
- `ChartSelectionState` + `rememberChartSelectionState()` — local selection, external-dismiss effect, external-fraction arbitration for cross-synced charts.
- `ChartTooltip(...)` — the shared inverse-surface chip with center-on-crosshair + on-screen clamping (PowerSoc keeps its pinned-top placement via `anchorY = null`).
- Shared fraction↔index↔pixel math.

Net −240 lines across the three charts; every per-chart quirk was preserved rather than silently aligned (details in the component's KDoc): DualAxis gates gestures to the plot area and excludes the right-axis strip; PowerSoc has no tap-toggle, no index snapping, and an unshadowed pinned tooltip. Whether to unify the tooltip styling is left as a deliberate follow-up decision.

`compileDebugKotlin` + `lintDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)