### PR TITLE
Widget: pre-render background off composition; local resize

### DIFF
--- a/app/src/androidTest/java/com/matedroid/widget/WidgetPreviewGeneratorTest.kt
+++ b/app/src/androidTest/java/com/matedroid/widget/WidgetPreviewGeneratorTest.kt
@@ -1,9 +1,6 @@
 package com.matedroid.widget
 
 import android.graphics.Bitmap
-import androidx.datastore.preferences.core.MutablePreferences
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.mutablePreferencesOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Test
@@ -27,44 +24,28 @@ class WidgetPreviewGeneratorTest {
     fun generatePreviewBitmap() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-        // Mock preferences: Legacy Model 3, Midnight Silver, Aero 18", AC charging at 72%
+        // Mock appearance: Legacy Model 3, Midnight Silver, Aero 18", AC charging
         // "MidnightSilver" → PMNG, "Pinwheel18CapKit" → W38B → car_images/m3_PMNG_W38B.png
-        val prefs: MutablePreferences = mutablePreferencesOf()
-        prefs[CarWidget.CAR_ID_KEY]              = 1
-        prefs[CarWidget.HAS_DATA_KEY]            = true
-        prefs[CarWidget.CAR_NAME_KEY]            = "Model 3"
-        prefs[CarWidget.EXTERIOR_COLOR_KEY]      = "MidnightSilver"
-        prefs[CarWidget.MODEL_KEY]               = "3"
-        prefs[CarWidget.TRIM_BADGING_KEY]        = "74D"
-        prefs[CarWidget.WHEEL_TYPE_KEY]          = "Pinwheel18CapKit"
-        prefs[CarWidget.STATE_KEY]               = "charging"
-        prefs[CarWidget.IS_LOCKED_KEY]           = true
-        prefs[CarWidget.SENTRY_MODE_KEY]         = false
-        prefs[CarWidget.PLUGGED_IN_KEY]          = true
-        prefs[CarWidget.OUTSIDE_TEMP_KEY]        = 18f
-        prefs[CarWidget.INSIDE_TEMP_KEY]         = 20f
-        prefs[CarWidget.IS_CLIMATE_ON_KEY]       = false
-        prefs[CarWidget.BATTERY_LEVEL_KEY]       = 72
-        prefs[CarWidget.RATED_RANGE_KEY]         = 340f
-        prefs[CarWidget.CHARGE_LIMIT_KEY]        = 80
-        prefs[CarWidget.IS_CHARGING_KEY]         = true
-        prefs[CarWidget.IS_DC_CHARGING_KEY]      = false
-        prefs[CarWidget.CHARGER_POWER_KEY]       = 11
-        prefs[CarWidget.CHARGE_ENERGY_ADDED_KEY] = 8.4f
-        prefs[CarWidget.TIME_TO_FULL_KEY]        = 0.5f
-        prefs[CarWidget.CHARGER_VOLTAGE_KEY]     = 230
-        prefs[CarWidget.CHARGER_CURRENT_KEY]     = 16
-        prefs[CarWidget.AC_PHASES_KEY]           = 3
+        val key = WidgetBackgroundCache.Key(
+            exteriorColor = "MidnightSilver",
+            model = "3",
+            trimBadging = "74D",
+            wheelType = "Pinwheel18CapKit",
+            overrideVariant = null,
+            overrideWheel = null,
+            isCharging = true,
+            isDcCharging = false
+        )
 
         // buildBackgroundBitmap is private — access it via reflection
         val method = CarWidget::class.java.getDeclaredMethod(
             "buildBackgroundBitmap",
             android.content.Context::class.java,
-            Preferences::class.java
+            WidgetBackgroundCache.Key::class.java
         )
         method.isAccessible = true
 
-        val bitmap = method.invoke(CarWidget(), context, prefs) as Bitmap
+        val bitmap = method.invoke(CarWidget(), context, key) as Bitmap
 
         val outFile = File(context.getExternalFilesDir(null), "widget_preview.png")
         FileOutputStream(outFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }

--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -13,6 +13,7 @@ import android.graphics.LinearGradient
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Shader
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,6 +64,8 @@ import com.matedroid.domain.model.CarImageResolver
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
 import com.matedroid.ui.util.GlowBitmapRenderer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import kotlin.math.roundToInt
 
@@ -252,8 +255,16 @@ class CarWidget : GlanceAppWidget() {
                                 isCharging = isCharging,
                                 isDcCharging = isDcCharging
                             )
-                            val bgBitmap = WidgetBackgroundCache.getOrCreate(ctx, bgKey) {
-                                buildBackgroundBitmap(ctx, prefs)
+                            // The cache is pre-warmed from updateWidget, so this is
+                            // normally an allocation-free memory-cache hit. The builder
+                            // only runs as a fallback (first composition before the
+                            // worker has run, or cache eviction); Glance composes on a
+                            // background dispatcher, so even a miss stays off the main
+                            // thread.
+                            val bgBitmap = remember(bgKey) {
+                                WidgetBackgroundCache.getOrCreate(ctx, bgKey) {
+                                    buildBackgroundBitmap(ctx, bgKey)
+                                }
                             }
                             Image(
                                 provider = ImageProvider(bgBitmap),
@@ -564,9 +575,13 @@ class CarWidget : GlanceAppWidget() {
 
                             // Progress bar at the very bottom
                             val barHeight = if (isCompact) 4.dp else 6.dp
-                            val progressBitmap = buildProgressBarBitmap(
+                            val progressBitmap = remember(
                                 batteryLevel, chargeLimit, isCharging, isDcCharging, palette
-                            )
+                            ) {
+                                buildProgressBarBitmap(
+                                    batteryLevel, chargeLimit, isCharging, isDcCharging, palette
+                                )
+                            }
                             Box(
                                 modifier = GlanceModifier.fillMaxSize(),
                                 contentAlignment = Alignment.BottomCenter
@@ -635,8 +650,35 @@ class CarWidget : GlanceAppWidget() {
                 }
             }
         }
+        // Pre-warm the background cache before triggering composition: a cache miss
+        // runs the full glow pipeline (~8-20 MB of transient bitmap allocations plus
+        // a PNG disk encode), which belongs here in the worker rather than inside
+        // Glance composition. The bitmap is size-independent (rendered at the car
+        // image's native resolution, shown with ContentScale.Crop), so no widget
+        // size information is needed. Failures fall back to rendering on demand
+        // during composition.
+        withContext(Dispatchers.Default) {
+            runCatching {
+                val key = backgroundKey(data)
+                WidgetBackgroundCache.getOrCreate(context, key) {
+                    buildBackgroundBitmap(context, key)
+                }
+            }
+        }
         update(context, glanceId)
     }
+
+    /** Background-cache key for [data] — must mirror the key built in [WidgetContent]. */
+    private fun backgroundKey(data: CarWidgetDisplayData) = WidgetBackgroundCache.Key(
+        exteriorColor = data.exteriorColor,
+        model = data.model,
+        trimBadging = data.trimBadging,
+        wheelType = data.wheelType,
+        overrideVariant = data.imageOverride?.variant,
+        overrideWheel = data.imageOverride?.wheelCode,
+        isCharging = data.isCharging,
+        isDcCharging = data.isDcCharging
+    )
 
     // -------------------------------------------------------------------------
     // Background bitmap — decorative only (car + glow + scrim)
@@ -656,20 +698,17 @@ class CarWidget : GlanceAppWidget() {
      */
     private fun buildBackgroundBitmap(
         context: Context,
-        prefs: Preferences,
+        key: WidgetBackgroundCache.Key,
     ): Bitmap {
-        val exteriorColor = prefs[EXTERIOR_COLOR_KEY]
-        val model = prefs[MODEL_KEY]
-        val trimBadging = prefs[TRIM_BADGING_KEY]
-        val wheelType = prefs[WHEEL_TYPE_KEY]
-        val overrideVariant = prefs[IMAGE_OVERRIDE_VARIANT_KEY]
-        val overrideWheel = prefs[IMAGE_OVERRIDE_WHEEL_KEY]
-        val isCharging = prefs[IS_CHARGING_KEY] ?: false
-        val isDcCharging = prefs[IS_DC_CHARGING_KEY] ?: false
+        val isCharging = key.isCharging
+        val isDcCharging = key.isDcCharging
 
-        val palette = CarColorPalettes.forExteriorColor(exteriorColor, darkTheme = true)
+        val palette = CarColorPalettes.forExteriorColor(key.exteriorColor, darkTheme = true)
 
-        val carBitmap = loadCarBitmap(context, model, exteriorColor, wheelType, trimBadging, overrideVariant, overrideWheel)
+        val carBitmap = loadCarBitmap(
+            context, key.model, key.exteriorColor, key.wheelType, key.trimBadging,
+            key.overrideVariant, key.overrideWheel
+        )
         val width = carBitmap?.width ?: FALLBACK_BG_W
         val height = carBitmap?.height ?: FALLBACK_BG_H
 

--- a/app/src/main/java/com/matedroid/widget/CarWidgetReceiver.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidgetReceiver.kt
@@ -1,8 +1,6 @@
 package com.matedroid.widget
 
-import android.appwidget.AppWidgetManager
 import android.content.Context
-import android.os.Bundle
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
@@ -26,14 +24,8 @@ class CarWidgetReceiver : GlanceAppWidgetReceiver() {
         CarWidgetUpdateWorker.cancelWork(context)
     }
 
-    override fun onAppWidgetOptionsChanged(
-        context: Context,
-        appWidgetManager: AppWidgetManager,
-        appWidgetId: Int,
-        newOptions: Bundle
-    ) {
-        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
-        // Re-fetch data immediately so the resized widget shows fresh content
-        CarWidgetUpdateWorker.scheduleImmediateUpdate(context)
-    }
+    // Note: onAppWidgetOptionsChanged is intentionally NOT overridden. The Glance
+    // base class already recomposes the widget locally with the new size on resize
+    // (goAsync + GlanceAppWidget.resize), so no network re-fetch is needed — resize
+    // is instant and works offline. Data stays fresh via the scheduled worker.
 }


### PR DESCRIPTION
Night batch, part 2.

- **Background bitmap pre-warmed from `updateWidget`**: the 3-layer glow render (+ synchronized PNG disk I/O) ran inside Glance composition on cache misses. The bitmap is size-independent (rendered at car-asset resolution, shown with `ContentScale.Crop`) and its key derives fully from `CarWidgetDisplayData`, so `updateWidget` now renders it under `Dispatchers.Default` before triggering the redraw; composition keeps a `remember`-wrapped fallback (which itself never blocks main — Glance composes in a CoroutineWorker).
- **Progress-bar bitmap memoized** keyed on (batteryLevel, chargeLimit, isCharging, isDcCharging, palette) — was rebuilt every recomposition.
- **Resize is now local and offline-friendly**: verified (decompiled Glance 1.1.1) that the base `GlanceAppWidgetReceiver.onAppWidgetOptionsChanged` already does a local `goAsync + resize` — so the override that forced a full network fetch was removed entirely.
- The reflection-based `WidgetPreviewGeneratorTest` updated to the new `buildBackgroundBitmap` signature.
- PNG-quality nit was already fine — skipped.

`compileDebugKotlin`, `compileDebugAndroidTestKotlin`, `lintDebug` pass (under the build lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)