### PR TITLE
Misc review leftovers: threading, state single-sourcing, naming

### DIFF
--- a/app/src/main/java/com/matedroid/data/local/SentryStateDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SentryStateDataStore.kt
@@ -39,18 +39,18 @@ class SentryStateDataStore @Inject constructor(
     private fun lastEventKey(carId: Int) = longPreferencesKey("sentry_last_event_$carId")
     private fun sessionStartedAtKey(carId: Int) = longPreferencesKey("sentry_session_started_$carId")
 
+    private fun Preferences.toSentryState(carId: Int) = SentryState(
+        sentryActive = this[activeKey(carId)] ?: false,
+        eventCount = this[eventCountKey(carId)] ?: 0,
+        lastEventAt = this[lastEventKey(carId)] ?: 0L,
+        sessionStartedAt = this[sessionStartedAtKey(carId)] ?: 0L
+    )
+
     /**
      * Get the current sentry state for a specific car.
      */
     suspend fun getState(carId: Int): SentryState {
-        return context.sentryDataStore.data.map { preferences ->
-            SentryState(
-                sentryActive = preferences[activeKey(carId)] ?: false,
-                eventCount = preferences[eventCountKey(carId)] ?: 0,
-                lastEventAt = preferences[lastEventKey(carId)] ?: 0L,
-                sessionStartedAt = preferences[sessionStartedAtKey(carId)] ?: 0L
-            )
-        }.first()
+        return context.sentryDataStore.data.map { it.toSentryState(carId) }.first()
     }
 
     /**
@@ -67,15 +67,16 @@ class SentryStateDataStore @Inject constructor(
 
     /**
      * Increment the event count and update lastEventAt for a specific car.
+     *
+     * The read-modify-write happens inside a single [DataStore.edit] transaction,
+     * so concurrent callers can't lose increments.
      */
     suspend fun incrementEventCount(carId: Int): SentryState {
-        val current = getState(carId)
-        val updated = current.copy(
-            eventCount = current.eventCount + 1,
-            lastEventAt = System.currentTimeMillis()
-        )
-        saveState(carId, updated)
-        return updated
+        val updated = context.sentryDataStore.edit { preferences ->
+            preferences[eventCountKey(carId)] = (preferences[eventCountKey(carId)] ?: 0) + 1
+            preferences[lastEventKey(carId)] = System.currentTimeMillis()
+        }
+        return updated.toSentryState(carId)
     }
 
     /**

--- a/app/src/main/java/com/matedroid/receiver/DebugEndpointReceiver.kt
+++ b/app/src/main/java/com/matedroid/receiver/DebugEndpointReceiver.kt
@@ -12,7 +12,10 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 /**
  * Debug-only receiver for switching the Teslamate API endpoint via ADB.
@@ -33,6 +36,9 @@ class DebugEndpointReceiver : BroadcastReceiver() {
     companion object {
         private const val TAG = "DebugEndpointReceiver"
         const val ACTION = "com.matedroid.SET_ENDPOINT"
+
+        // Stay well under the ~10 s budget the system grants a goAsync() receiver.
+        private const val TIMEOUT_MS = 8_000L
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -51,16 +57,23 @@ class DebugEndpointReceiver : BroadcastReceiver() {
         )
         val settingsDataStore = entryPoint.settingsDataStore()
 
+        // goAsync pattern: one short-lived scope per broadcast, always finished
+        // (finish + cancel) whether the write succeeds, fails or times out.
         val pendingResult = goAsync()
-        CoroutineScope(Dispatchers.IO).launch {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope.launch {
             try {
-                settingsDataStore.saveServerUrl(url)
+                withTimeout(TIMEOUT_MS) {
+                    settingsDataStore.saveServerUrl(url)
+                }
                 Log.i(TAG, "API endpoint switched to: $url")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to switch endpoint", e)
             } finally {
                 pendingResult.finish()
             }
+        }.invokeOnCompletion {
+            scope.cancel()
         }
     }
 }

--- a/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
+++ b/app/src/main/java/com/matedroid/service/ChargingMonitorService.kt
@@ -65,8 +65,13 @@ class ChargingMonitorService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var monitorJob: Job? = null
-    private var consecutiveFailures = 0
-    private val maxConsecutiveFailures = 3
+
+    // Consecutive checks that found no charging car. This deliberately lumps
+    // together "car really isn't charging" and "check errored" (API/network
+    // failure) — either way, after maxChecksWithoutCharging strikes (~90 s)
+    // there's nothing left for this service to monitor and it stops itself.
+    private var checksWithoutCharging = 0
+    private val maxChecksWithoutCharging = 3
     private var isMonitoring = false
     private val activeNotificationCarIds = mutableSetOf<Int>()
 
@@ -186,10 +191,10 @@ class ChargingMonitorService : Service() {
             // Initial check
             val initialResult = performChargingCheck()
             if (!initialResult) {
-                consecutiveFailures++
-                Log.d(TAG, "Initial check failed, failure count: $consecutiveFailures")
+                checksWithoutCharging++
+                Log.d(TAG, "Initial check found no charging car ($checksWithoutCharging/$maxChecksWithoutCharging)")
             } else {
-                consecutiveFailures = 0
+                checksWithoutCharging = 0
             }
 
             // Continue monitoring
@@ -198,14 +203,14 @@ class ChargingMonitorService : Service() {
 
                 val stillCharging = performChargingCheck()
                 if (stillCharging) {
-                    consecutiveFailures = 0
+                    checksWithoutCharging = 0
                     Log.d(TAG, "Updated charging notification")
                 } else {
-                    consecutiveFailures++
-                    Log.d(TAG, "Check returned no charging, failure count: $consecutiveFailures")
+                    checksWithoutCharging++
+                    Log.d(TAG, "Check found no charging car ($checksWithoutCharging/$maxChecksWithoutCharging)")
 
-                    if (consecutiveFailures >= maxConsecutiveFailures) {
-                        Log.d(TAG, "Too many failures, stopping service")
+                    if (checksWithoutCharging >= maxChecksWithoutCharging) {
+                        Log.d(TAG, "No charging car for $maxChecksWithoutCharging consecutive checks, stopping service")
                         stopSelf()
                         break
                     }
@@ -234,7 +239,8 @@ class ChargingMonitorService : Service() {
 
     /**
      * Check charging status and update notification.
-     * Returns true if any car is charging, false otherwise.
+     * Returns true if any car is charging; false when none is charging
+     * or the check itself failed (not configured, API error, exception).
      */
     private suspend fun performChargingCheck(): Boolean {
         try {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesScreen.kt
@@ -221,21 +221,13 @@ private fun ChargesContent(
         initialFirstVisibleItemScrollOffset = initialScrollOffset
     )
 
-    // Header items in render order: date chips, dropdowns, free hint (conditional),
-    // summary, charts (conditional), history header. Adjust if items are added.
+    // Single source of truth for the header rows preceding the charge list.
+    // The LazyColumn emits exactly these items (in order) before the charges,
+    // and MonthScrollIndicator's index math below uses headerItems.size — so
+    // adding/removing/conditionally-showing a header can't desync the two.
     val showFreeHint = freeSupercharging && selectedCostFilter == CostFilter.NO_COST
-    val headerCount = 4 +
-        (if (showFreeHint) 1 else 0) +
-        (if (chartData.isNotEmpty()) 1 else 0)
-
-    Box(modifier = Modifier.fillMaxSize()) {
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        item {
+    val headerItems: List<@Composable () -> Unit> = buildList {
+        add {
             DateFilterChips(
                 selectedFilter = selectedDateFilter,
                 customStartDate = customStartDate,
@@ -245,8 +237,7 @@ private fun ChargesContent(
                 onCustomRangeSelected = onCustomRangeSelected
             )
         }
-
-        item {
+        add {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -271,9 +262,8 @@ private fun ChargesContent(
                 )
             }
         }
-
-        if (freeSupercharging && selectedCostFilter == CostFilter.NO_COST) {
-            item {
+        if (showFreeHint) {
+            add {
                 Text(
                     text = stringResource(R.string.charges_free_supercharging_hint),
                     style = MaterialTheme.typography.bodySmall,
@@ -282,14 +272,12 @@ private fun ChargesContent(
                 )
             }
         }
-
-        item {
+        add {
             SummaryCard(summary = summary, currencySymbol = currencySymbol, palette = palette)
         }
-
         // Charges charts (daily/weekly/monthly based on date range) - swipeable
         if (chartData.isNotEmpty()) {
-            item {
+            add {
                 ChargesChartsPager(
                     chartData = chartData,
                     granularity = chartGranularity,
@@ -298,8 +286,7 @@ private fun ChargesContent(
                 )
             }
         }
-
-        item {
+        add {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(R.string.charge_history),
@@ -307,6 +294,17 @@ private fun ChargesContent(
                 fontWeight = FontWeight.Bold
             )
         }
+    }
+    val headerCount = headerItems.size
+
+    Box(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(headerCount) { index -> headerItems[index]() }
 
         if (charges.isEmpty()) {
             item {

--- a/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/charges/ChargesViewModel.kt
@@ -16,12 +16,14 @@ import android.content.Context
 import com.matedroid.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.util.Locale
 import java.time.temporal.ChronoUnit
@@ -238,7 +240,7 @@ class ChargesViewModel @Inject constructor(
     fun setCostFilter(filter: CostFilter) {
         _uiState.update { it.copy(costFilter = filter) }
         savedStateHandle[KEY_COST_FILTER] = filter.name
-        applyFiltersAndUpdateState()
+        viewModelScope.launch { applyFiltersAndUpdateState() }
     }
 
     fun setChargeTypeFilter(filter: ChargeTypeFilter) {
@@ -251,7 +253,7 @@ class ChargesViewModel @Inject constructor(
         }
         _uiState.update { it.copy(chargeTypeFilter = newFilter) }
         savedStateHandle[KEY_CHARGE_TYPE_FILTER] = newFilter.name
-        applyFiltersAndUpdateState()
+        viewModelScope.launch { applyFiltersAndUpdateState() }
     }
 
     fun setLocationFilter(location: String) {
@@ -259,13 +261,13 @@ class ChargesViewModel @Inject constructor(
         val updated = if (location in current) current - location else current + location
         _uiState.update { it.copy(selectedLocations = updated) }
         savedStateHandle[KEY_LOCATIONS] = ArrayList(updated)
-        applyFiltersAndUpdateState()
+        viewModelScope.launch { applyFiltersAndUpdateState() }
     }
 
     fun clearLocationFilter() {
         _uiState.update { it.copy(selectedLocations = emptySet()) }
         savedStateHandle[KEY_LOCATIONS] = ArrayList<String>()
-        applyFiltersAndUpdateState()
+        viewModelScope.launch { applyFiltersAndUpdateState() }
     }
 
     fun clearError() {
@@ -346,15 +348,50 @@ class ChargesViewModel @Inject constructor(
         }
     }
 
-    private fun applyFiltersAndUpdateState() {
+    /** Pure output of the filter pipeline, computed off the main thread. */
+    private data class FilteredChargesResult(
+        val displayCharges: List<ChargeData>,
+        val locations: List<String>,
+        val summary: ChargesSummary,
+        val chartData: List<ChargeChartData>
+    )
+
+    private suspend fun applyFiltersAndUpdateState() {
+        // Snapshot inputs on the caller context, then push the multi-pass
+        // filtering/aggregation to Dispatchers.Default (same pattern as
+        // MileageViewModel) so filter taps don't chew the main thread.
         val state = _uiState.value
+        val charges = allCharges
+        val includeShort = showShortDrivesCharges
+        val result = withContext(Dispatchers.Default) {
+            computeFilteredCharges(state, charges, includeShort)
+        }
+
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                isRefreshing = false,
+                isFilterLoading = false,
+                charges = result.displayCharges,
+                availableLocations = result.locations,
+                summary = result.summary,
+                chartData = result.chartData
+            )
+        }
+    }
+
+    private fun computeFilteredCharges(
+        state: ChargesUiState,
+        allCharges: List<ChargeData>,
+        showShortCharges: Boolean
+    ): FilteredChargesResult {
         val chargeTypeFilter = state.chargeTypeFilter
         val costFilter = state.costFilter
         val dcChargeIds = state.dcChargeIds
         val granularity = state.chartGranularity
 
         // First apply short charges filter (see ShortEntryFilter for the shared rule)
-        var filteredCharges = if (showShortDrivesCharges) {
+        var filteredCharges = if (showShortCharges) {
             allCharges
         } else {
             allCharges.filter { it.isSignificant() }
@@ -418,17 +455,12 @@ class ChargesViewModel @Inject constructor(
         val summary = calculateSummary(chargesForStatsFiltered)
         val chartData = calculateChartData(chargesForStatsFiltered, granularity, state.startDate, ::isDc)
 
-        _uiState.update {
-            it.copy(
-                isLoading = false,
-                isRefreshing = false,
-                isFilterLoading = false,
-                charges = displayChargesFiltered,
-                availableLocations = locations,
-                summary = summary,
-                chartData = chartData
-            )
-        }
+        return FilteredChargesResult(
+            displayCharges = displayChargesFiltered,
+            locations = locations,
+            summary = summary,
+            chartData = chartData
+        )
     }
 
     private fun determineGranularity(startDate: LocalDate?, endDate: LocalDate?): ChartGranularity {

--- a/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/sentry/SentryHistoryScreen.kt
@@ -75,16 +75,21 @@ import java.time.format.FormatStyle
 
 /**
  * Find the LazyColumn item index that corresponds to a given timestamp.
- * Returns the index of the first alert at or after that timestamp, or -1 if none found.
+ * Returns the absolute index (directly usable with `animateScrollToItem`, no further
+ * correction needed) of the first alert in the heatmap bucket starting at that
+ * timestamp, or -1 if none found.
+ *
+ * This mirrors the LazyColumn layout in [SentryHistoryScreen]:
+ * item 0 = heatmap, item 1 = "Current Session" header,
+ * then current session alerts (or empty card),
+ * then spacer + "Past Alerts" header + day groups.
+ * Keep in sync with that layout when adding items.
  */
 private fun findAlertIndexForTimestamp(
     uiState: SentryHistoryUiState,
     targetMillis: Long
 ): Int {
-    // Layout: item 0 = section header "Current Session"
-    // Then current session alerts or empty card
-    // Then past alerts section header + day groups
-    var index = 1 // skip "Current Session" header
+    var index = 2 // skip the heatmap (0) and the "Current Session" header (1)
 
     // Current session alerts
     if (uiState.currentSessionAlerts.isEmpty()) {
@@ -186,8 +191,7 @@ fun SentryHistoryScreen(
                             val itemIndex = findAlertIndexForTimestamp(uiState, targetMillis)
                             if (itemIndex >= 0) {
                                 coroutineScope.launch {
-                                    // +1 to account for the heatmap item itself at position 0
-                                    listState.animateScrollToItem(itemIndex + 1)
+                                    listState.animateScrollToItem(itemIndex)
                                 }
                             }
                         }

--- a/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/updates/SoftwareVersionsScreen.kt
@@ -43,9 +43,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -68,7 +66,12 @@ import kotlin.math.roundToInt
 enum class UpdatesDateFilter(val months: Int?) {
     LAST_6_MONTHS(6),
     LAST_YEAR(12),
-    ALL_TIME(null)
+    ALL_TIME(null);
+
+    companion object {
+        fun fromMonths(months: Int?): UpdatesDateFilter =
+            entries.firstOrNull { it.months == months } ?: ALL_TIME
+    }
 }
 
 @Composable
@@ -90,7 +93,9 @@ fun SoftwareVersionsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    var selectedFilter by remember { mutableStateOf(UpdatesDateFilter.ALL_TIME) }
+    // Single source of truth: the ViewModel's filterMonths drives the chips, so
+    // the UI can't disagree with the applied filter (e.g. after process death).
+    val selectedFilter = UpdatesDateFilter.fromMonths(uiState.filterMonths)
     val isDarkTheme = isSystemInDarkTheme()
     val palette = CarColorPalettes.forExteriorColor(exteriorColor, isDarkTheme)
 
@@ -103,11 +108,6 @@ fun SoftwareVersionsScreen(
             snackbarHostState.showSnackbar(error)
             viewModel.clearError()
         }
-    }
-
-    fun applyDateFilter(filter: UpdatesDateFilter) {
-        selectedFilter = filter
-        viewModel.setFilter(filter.months)
     }
 
     Scaffold(
@@ -143,7 +143,7 @@ fun SoftwareVersionsScreen(
                     uiState = uiState,
                     selectedFilter = selectedFilter,
                     palette = palette,
-                    onFilterSelected = { applyDateFilter(it) }
+                    onFilterSelected = { viewModel.setFilter(it.months) }
                 )
             }
         }


### PR DESCRIPTION
Night batch, part 3 — the remaining small findings, one commit each.

- **ChargesViewModel**: the 6+ full-list filter/aggregation passes now run under `Dispatchers.Default` (pure `computeFilteredCharges()` extracted; single state update back on the caller context).
- **SoftwareVersionsScreen**: the filter chip is single-sourced from `uiState.filterMonths` — the plain-`remember` duplicate that desynced after process death is gone.
- **ChargesScreen**: the six header rows are built as one list next to the LazyColumn, so `headerCount` can no longer drift from the layout (also removed a duplicated free-hint condition).
- **SentryHistoryScreen**: `findAlertIndexForTimestamp` now returns the absolute scroll index with a documented contract; the call-site `+1` correction and the stale header comment are gone.
- **ChargingMonitorService**: `consecutiveFailures` → `checksWithoutCharging` with honest logs — "not charging" is no longer called a failure. Behavior unchanged.
- **SentryStateDataStore**: `incrementEventCount` is a single atomic `edit {}` (was read-modify-write that could lose increments across the worker/service paths). Storage format identical.
- **DebugEndpointReceiver**: per-broadcast scope with `SupervisorJob`, 8 s timeout under the goAsync budget, guaranteed `finish()` + scope cancellation.

`compileDebugKotlin`, `lintDebug`, `testDebugUnitTest` (77/0) pass under the build lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)