### PR TITLE
Parallelize deep-stats queries; record dates via JOIN

### DIFF
--- a/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
+++ b/app/src/main/java/com/matedroid/data/local/dao/AggregateDao.kt
@@ -53,13 +53,14 @@ interface AggregateDao {
 
     // Drive with highest altitude
     @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
+        SELECT a.driveId, a.maxElevation AS elevation, a.elevationGain, d.startDate
+        FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.hasElevationData = 1
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.maxElevation DESC LIMIT 1
     """)
-    suspend fun driveWithMaxElevation(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun driveWithMaxElevation(carId: Int, startDate: String, endDate: String): DriveElevationResult?
 
     // Lowest altitude ever reached
     @Query("""
@@ -68,24 +69,29 @@ interface AggregateDao {
     """)
     suspend fun minElevation(carId: Int): Int?
 
-    // Drive with lowest altitude
+    // Drive with lowest altitude (all-time only).
+    // LEFT JOIN: the record must survive even without a matching summary row
+    // (date is simply null then), matching the old follow-up-lookup behavior.
     @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
+        SELECT a.driveId, a.minElevation AS elevation, a.elevationGain, d.startDate
+        FROM drive_detail_aggregates a
+        LEFT JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.hasElevationData = 1
         ORDER BY a.minElevation ASC LIMIT 1
     """)
-    suspend fun driveWithMinElevation(carId: Int): DriveDetailAggregate?
+    suspend fun driveWithMinElevation(carId: Int): DriveElevationResult?
 
     // Drive with most accumulated elevation gain (total meters climbed)
     @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
+        SELECT a.driveId, a.maxElevation AS elevation, a.elevationGain, d.startDate
+        FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId
         AND a.elevationGain IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.elevationGain DESC LIMIT 1
     """)
-    suspend fun driveWithMostElevationGain(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun driveWithMostElevationGain(carId: Int, startDate: String, endDate: String): DriveElevationResult?
 
     // === Deep Stats: Temperature (Driving) ===
 
@@ -100,13 +106,14 @@ interface AggregateDao {
 
     // Drive with hottest temperature
     @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
+        SELECT a.driveId, a.maxOutsideTemp AS outsideTemp, d.startDate
+        FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.maxOutsideTemp IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.maxOutsideTemp DESC LIMIT 1
     """)
-    suspend fun hottestDrive(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun hottestDrive(carId: Int, startDate: String, endDate: String): DriveTempResult?
 
     // Coldest outside temperature while driving
     @Query("""
@@ -119,13 +126,14 @@ interface AggregateDao {
 
     // Drive with coldest temperature
     @Query("""
-        SELECT a.* FROM drive_detail_aggregates a
+        SELECT a.driveId, a.minOutsideTemp AS outsideTemp, d.startDate
+        FROM drive_detail_aggregates a
         JOIN drives_summary d ON a.driveId = d.driveId
         WHERE a.carId = :carId AND a.minOutsideTemp IS NOT NULL
         AND d.startDate >= :startDate AND d.startDate < :endDate
         ORDER BY a.minOutsideTemp ASC LIMIT 1
     """)
-    suspend fun coldestDrive(carId: Int, startDate: String, endDate: String): DriveDetailAggregate?
+    suspend fun coldestDrive(carId: Int, startDate: String, endDate: String): DriveTempResult?
 
     // Hottest cabin temperature
     @Query("""
@@ -167,23 +175,25 @@ interface AggregateDao {
 
     // Charge with hottest temperature
     @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
+        SELECT a.chargeId, a.maxOutsideTemp AS outsideTemp, c.startDate
+        FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.maxOutsideTemp IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.maxOutsideTemp DESC LIMIT 1
     """)
-    suspend fun hottestCharge(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
+    suspend fun hottestCharge(carId: Int, startDate: String, endDate: String): ChargeTempResult?
 
     // Charge with coldest temperature
     @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
+        SELECT a.chargeId, a.minOutsideTemp AS outsideTemp, c.startDate
+        FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.minOutsideTemp IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.minOutsideTemp ASC LIMIT 1
     """)
-    suspend fun coldestCharge(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
+    suspend fun coldestCharge(carId: Int, startDate: String, endDate: String): ChargeTempResult?
 
     // === Deep Stats: Charging Power ===
 
@@ -198,13 +208,14 @@ interface AggregateDao {
 
     // Charge with max power
     @Query("""
-        SELECT a.* FROM charge_detail_aggregates a
+        SELECT a.chargeId, a.maxChargerPower, c.startDate
+        FROM charge_detail_aggregates a
         JOIN charges_summary c ON a.chargeId = c.chargeId
         WHERE a.carId = :carId AND a.maxChargerPower IS NOT NULL
         AND c.startDate >= :startDate AND c.startDate < :endDate
         ORDER BY a.maxChargerPower DESC LIMIT 1
     """)
-    suspend fun chargeWithMaxPower(carId: Int, startDate: String, endDate: String): ChargeDetailAggregate?
+    suspend fun chargeWithMaxPower(carId: Int, startDate: String, endDate: String): ChargePowerResult?
 
     // === Deep Stats: AC/DC Ratio ===
 
@@ -533,6 +544,47 @@ interface AggregateDao {
     """)
     suspend fun getDriveEdgeCoordinates(driveIds: List<Int>): List<DriveEdgeCoordinateResult>
 }
+
+/**
+ * Elevation record row: aggregate extremes plus the drive date fetched in the
+ * same query (no follow-up drives_summary lookup needed).
+ * [elevation] is maxElevation or minElevation depending on the query.
+ */
+data class DriveElevationResult(
+    val driveId: Int,
+    val elevation: Int?,
+    val elevationGain: Int?,
+    val startDate: String?
+)
+
+/**
+ * Temperature record row for a drive; [temp] is the max or min outside
+ * temperature depending on the query.
+ */
+data class DriveTempResult(
+    val driveId: Int,
+    val outsideTemp: Double?,
+    val startDate: String?
+)
+
+/**
+ * Temperature record row for a charge; [temp] is the max or min outside
+ * temperature depending on the query.
+ */
+data class ChargeTempResult(
+    val chargeId: Int,
+    val outsideTemp: Double?,
+    val startDate: String?
+)
+
+/**
+ * Peak-power record row for a charge.
+ */
+data class ChargePowerResult(
+    val chargeId: Int,
+    val maxChargerPower: Int?,
+    val startDate: String?
+)
 
 /**
  * Result of drive locations query for map display.

--- a/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/StatsRepository.kt
@@ -24,6 +24,7 @@ import com.matedroid.domain.model.StreakRecord
 import com.matedroid.domain.model.YearFilter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -143,121 +144,118 @@ class StatsRepository @Inject constructor(
      * Get deep stats (from aggregate tables, requires sync).
      * Returns null if no aggregates exist yet.
      */
-    suspend fun getDeepStats(carId: Int, yearFilter: YearFilter): DeepStats? {
-        val driveAggregates = aggregateDao.countDriveAggregates(carId)
-        val chargeAggregates = aggregateDao.countChargeAggregates(carId)
+    suspend fun getDeepStats(carId: Int, yearFilter: YearFilter): DeepStats? = coroutineScope {
+        // Existence gate: everything below is pointless without aggregates.
+        val driveAggregatesDeferred = async { aggregateDao.countDriveAggregates(carId) }
+        val chargeAggregatesDeferred = async { aggregateDao.countChargeAggregates(carId) }
+        val driveAggregates = driveAggregatesDeferred.await()
+        val chargeAggregates = chargeAggregatesDeferred.await()
 
         // Return null if no aggregates exist at all
         if (driveAggregates == 0 && chargeAggregates == 0) {
-            return null
+            return@coroutineScope null
         }
 
         val (startDate, endDate) = yearFilter.toDateBounds()
         val allTime = yearFilter is YearFilter.AllTime
 
-        // Elevation records
-        val driveWithMaxElev = aggregateDao.driveWithMaxElevation(carId, startDate, endDate)
-        val driveWithMinElev = if (allTime) aggregateDao.driveWithMinElevation(carId) else null // Not shown in year view
-        val driveWithMostGain = aggregateDao.driveWithMostElevationGain(carId, startDate, endDate)
+        // All queries below are independent; Room suspend queries run on Room's
+        // query executor, so launching them under async fans them out in parallel
+        // instead of paying ~23 sequential round trips.
 
-        // Temperature records (driving)
-        val hottestDriveAgg = aggregateDao.hottestDrive(carId, startDate, endDate)
-        val coldestDriveAgg = aggregateDao.coldestDrive(carId, startDate, endDate)
+        // Elevation
+        val maxElevation = async { aggregateDao.maxElevation(carId, startDate, endDate) }
+        val minElevation = async { if (allTime) aggregateDao.minElevation(carId) else null } // Not shown in year view
+        val driveWithMaxElev = async { aggregateDao.driveWithMaxElevation(carId, startDate, endDate) }
+        val driveWithMinElev = async { if (allTime) aggregateDao.driveWithMinElevation(carId) else null } // Not shown in year view
+        val driveWithMostGain = async { aggregateDao.driveWithMostElevationGain(carId, startDate, endDate) }
 
-        // Temperature records (charging)
-        val hottestChargeAgg = aggregateDao.hottestCharge(carId, startDate, endDate)
-        val coldestChargeAgg = aggregateDao.coldestCharge(carId, startDate, endDate)
+        // Temperature (driving)
+        val maxOutsideTempDriving = async { aggregateDao.maxOutsideTempDriving(carId, startDate, endDate) }
+        val minOutsideTempDriving = async { aggregateDao.minOutsideTempDriving(carId, startDate, endDate) }
+        val maxInsideTemp = async { aggregateDao.maxInsideTemp(carId, startDate, endDate) }
+        val minInsideTemp = async { aggregateDao.minInsideTemp(carId, startDate, endDate) }
+        val hottestDrive = async { aggregateDao.hottestDrive(carId, startDate, endDate) }
+        val coldestDrive = async { aggregateDao.coldestDrive(carId, startDate, endDate) }
 
-        // Power record
-        val chargeWithMaxPowerAgg = aggregateDao.chargeWithMaxPower(carId, startDate, endDate)
+        // Temperature (charging)
+        val maxOutsideTempCharging = async { aggregateDao.maxOutsideTempCharging(carId, startDate, endDate) }
+        val minOutsideTempCharging = async { aggregateDao.minOutsideTempCharging(carId, startDate, endDate) }
+        val hottestCharge = async { aggregateDao.hottestCharge(carId, startDate, endDate) }
+        val coldestCharge = async { aggregateDao.coldestCharge(carId, startDate, endDate) }
 
-        return DeepStats(
-            maxElevationM = aggregateDao.maxElevation(carId, startDate, endDate),
-            minElevationM = if (allTime) aggregateDao.minElevation(carId) else null, // Not shown in year view
-            driveWithMaxElevation = driveWithMaxElev?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
+        // Charging power
+        val maxChargerPower = async { aggregateDao.maxChargerPower(carId, startDate, endDate) }
+        val chargeWithMaxPower = async { aggregateDao.chargeWithMaxPower(carId, startDate, endDate) }
+
+        // AC/DC split
+        val acChargeCount = async { aggregateDao.countAcCharges(carId, startDate, endDate) }
+        val dcChargeCount = async { aggregateDao.countDcCharges(carId, startDate, endDate) }
+        val acChargeEnergy = async { aggregateDao.sumAcChargeEnergy(carId, startDate, endDate) }
+        val dcChargeEnergy = async { aggregateDao.sumDcChargeEnergy(carId, startDate, endDate) }
+
+        // Countries
+        val uniqueCountries = async { aggregateDao.countUniqueCountries(carId, startDate, endDate) }
+
+        DeepStats(
+            maxElevationM = maxElevation.await(),
+            minElevationM = minElevation.await(),
+            driveWithMaxElevation = driveWithMaxElev.await()?.let {
                 DriveElevationRecord(
-                    driveId = agg.driveId,
-                    elevationM = agg.maxElevation ?: 0,
-                    elevationGainM = agg.elevationGain,
-                    date = drive?.startDate
+                    driveId = it.driveId,
+                    elevationM = it.elevation ?: 0,
+                    elevationGainM = it.elevationGain,
+                    date = it.startDate
                 )
             },
-            driveWithMinElevation = driveWithMinElev?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
+            driveWithMinElevation = driveWithMinElev.await()?.let {
                 DriveElevationRecord(
-                    driveId = agg.driveId,
-                    elevationM = agg.minElevation ?: 0,
-                    elevationGainM = agg.elevationGain,
-                    date = drive?.startDate
+                    driveId = it.driveId,
+                    elevationM = it.elevation ?: 0,
+                    elevationGainM = it.elevationGain,
+                    date = it.startDate
                 )
             },
-            driveWithMostClimbing = driveWithMostGain?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
+            driveWithMostClimbing = driveWithMostGain.await()?.let {
                 DriveElevationRecord(
-                    driveId = agg.driveId,
-                    elevationM = agg.maxElevation ?: 0,
-                    elevationGainM = agg.elevationGain,
-                    date = drive?.startDate
+                    driveId = it.driveId,
+                    elevationM = it.elevation ?: 0,
+                    elevationGainM = it.elevationGain,
+                    date = it.startDate
                 )
             },
 
-            maxOutsideTempDrivingC = aggregateDao.maxOutsideTempDriving(carId, startDate, endDate),
-            minOutsideTempDrivingC = aggregateDao.minOutsideTempDriving(carId, startDate, endDate),
-            maxCabinTempC = aggregateDao.maxInsideTemp(carId, startDate, endDate),
-            minCabinTempC = aggregateDao.minInsideTemp(carId, startDate, endDate),
-            hottestDrive = hottestDriveAgg?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveTempRecord(
-                    driveId = agg.driveId,
-                    tempC = agg.maxOutsideTemp ?: 0.0,
-                    date = drive?.startDate
-                )
+            maxOutsideTempDrivingC = maxOutsideTempDriving.await(),
+            minOutsideTempDrivingC = minOutsideTempDriving.await(),
+            maxCabinTempC = maxInsideTemp.await(),
+            minCabinTempC = minInsideTemp.await(),
+            hottestDrive = hottestDrive.await()?.let {
+                DriveTempRecord(driveId = it.driveId, tempC = it.outsideTemp ?: 0.0, date = it.startDate)
             },
-            coldestDrive = coldestDriveAgg?.let { agg ->
-                val drive = driveSummaryDao.get(agg.driveId)
-                DriveTempRecord(
-                    driveId = agg.driveId,
-                    tempC = agg.minOutsideTemp ?: 0.0,
-                    date = drive?.startDate
-                )
+            coldestDrive = coldestDrive.await()?.let {
+                DriveTempRecord(driveId = it.driveId, tempC = it.outsideTemp ?: 0.0, date = it.startDate)
             },
 
-            maxOutsideTempChargingC = aggregateDao.maxOutsideTempCharging(carId, startDate, endDate),
-            minOutsideTempChargingC = aggregateDao.minOutsideTempCharging(carId, startDate, endDate),
-            hottestCharge = hottestChargeAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargeTempRecord(
-                    chargeId = agg.chargeId,
-                    tempC = agg.maxOutsideTemp ?: 0.0,
-                    date = charge?.startDate
-                )
+            maxOutsideTempChargingC = maxOutsideTempCharging.await(),
+            minOutsideTempChargingC = minOutsideTempCharging.await(),
+            hottestCharge = hottestCharge.await()?.let {
+                ChargeTempRecord(chargeId = it.chargeId, tempC = it.outsideTemp ?: 0.0, date = it.startDate)
             },
-            coldestCharge = coldestChargeAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargeTempRecord(
-                    chargeId = agg.chargeId,
-                    tempC = agg.minOutsideTemp ?: 0.0,
-                    date = charge?.startDate
-                )
+            coldestCharge = coldestCharge.await()?.let {
+                ChargeTempRecord(chargeId = it.chargeId, tempC = it.outsideTemp ?: 0.0, date = it.startDate)
             },
 
-            maxChargerPowerKw = aggregateDao.maxChargerPower(carId, startDate, endDate),
-            chargeWithMaxPower = chargeWithMaxPowerAgg?.let { agg ->
-                val charge = chargeSummaryDao.get(agg.chargeId)
-                ChargePowerRecord(
-                    chargeId = agg.chargeId,
-                    powerKw = agg.maxChargerPower ?: 0,
-                    date = charge?.startDate
-                )
+            maxChargerPowerKw = maxChargerPower.await(),
+            chargeWithMaxPower = chargeWithMaxPower.await()?.let {
+                ChargePowerRecord(chargeId = it.chargeId, powerKw = it.maxChargerPower ?: 0, date = it.startDate)
             },
 
-            acChargeCount = aggregateDao.countAcCharges(carId, startDate, endDate),
-            dcChargeCount = aggregateDao.countDcCharges(carId, startDate, endDate),
-            acChargeEnergyKwh = aggregateDao.sumAcChargeEnergy(carId, startDate, endDate),
-            dcChargeEnergyKwh = aggregateDao.sumDcChargeEnergy(carId, startDate, endDate),
+            acChargeCount = acChargeCount.await(),
+            dcChargeCount = dcChargeCount.await(),
+            acChargeEnergyKwh = acChargeEnergy.await(),
+            dcChargeEnergyKwh = dcChargeEnergy.await(),
 
-            countriesVisitedCount = aggregateDao.countUniqueCountries(carId, startDate, endDate).takeIf { it > 0 },
+            countriesVisitedCount = uniqueCountries.await().takeIf { it > 0 },
 
             driveDetailsProcessed = driveAggregates,
             chargeDetailsProcessed = chargeAggregates


### PR DESCRIPTION
Night batch, part 4.

- `StatsRepository.getDeepStats` ran ~25 DAO aggregate calls strictly sequentially plus 8 follow-up per-record date lookups (~33 serial round trips). The aggregate-count gate stays ordered (early return when no aggregates); everything else fans out under `async` (the `getStats` pattern), and all 8 record queries now return their date directly — 7 already INNER JOINed the summary table for range filtering (mechanical SELECT addition); `driveWithMinElevation` got a LEFT JOIN to preserve its `date = null` behavior for aggregates without a summary row.
- All result values/nullability reproduced exactly; slim projection classes added; Room's KSP query verifier validates the new SQL at compile time.

`compileDebugKotlin`, `lintDebug`, `testDebugUnitTest` pass under the build lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)