### PR TITLE
Split settings into a category list with detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Settings are now split into sections** — instead of one long scrolling page, Settings opens a list of categories (Connection, Display, Notifications, Data & sync, About) that each open their own page. The new Notifications page links straight to Android's per-channel settings for charging, sentry and tire-pressure alerts, and the first-run setup now shows only the connection form. Connection settings still have an explicit Save; everything else applies as soon as you change it.
+
 ## [1.10.1] - 2026-08-12
 
 A maintenance release: the app is noticeably faster and lighter on battery, syncs incrementally instead of re-downloading everything, and a long list of unit-system bugs that gave miles/imperial users wrong numbers is fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Settings are now split into sections** — instead of one long scrolling page, Settings opens a list of categories (Connection, Display, Notifications, Data & sync, About) that each open their own page. The new Notifications page links straight to Android's per-channel settings for charging, sentry and tire-pressure alerts, and the first-run setup now shows only the connection form. Connection settings still have an explicit Save; everything else applies as soon as you change it.
+- **Connection settings are no longer hidden behind "Advanced network settings"** — the secondary server URL, API token, HTTP Basic Auth and certificate options are now laid out in plain view under Server, Authentication and Security headings. If you use MyTeslaMate, the Basic Auth fields you need are visible as soon as you open the page.
 
 ## [1.10.1] - 2026-08-12
 

--- a/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/NavGraph.kt
@@ -32,6 +32,13 @@ import com.matedroid.ui.screens.drives.DriveDetailScreen
 import com.matedroid.ui.screens.drives.DrivesScreen
 import com.matedroid.ui.screens.mileage.MileageScreen
 import com.matedroid.ui.screens.settings.SettingsScreen
+import com.matedroid.ui.screens.settings.SettingsSection
+import com.matedroid.ui.screens.settings.sections.AboutSettingsScreen
+import com.matedroid.ui.screens.settings.sections.ConnectionSettingsScreen
+import com.matedroid.ui.screens.settings.sections.DataSyncSettingsScreen
+import com.matedroid.ui.screens.settings.sections.DebugSettingsScreen
+import com.matedroid.ui.screens.settings.sections.DisplaySettingsScreen
+import com.matedroid.ui.screens.settings.sections.NotificationSettingsScreen
 import com.matedroid.ui.screens.stats.CountriesVisitedScreen
 import com.matedroid.ui.screens.stats.RegionsVisitedScreen
 import com.matedroid.ui.screens.stats.StatsScreen
@@ -56,6 +63,16 @@ import kotlinx.serialization.Serializable
 sealed interface Screen {
     @Serializable
     data object Settings : Screen
+
+    /**
+     * One settings detail page. [sectionId] is a [com.matedroid.ui.screens.settings.SettingsSection]
+     * id, kept as a String so the route stays stable and deep-linkable.
+     *
+     * [onboarding] marks the first-run pass, where this is the start destination: the
+     * category list is skipped entirely and saving continues to the dashboard.
+     */
+    @Serializable
+    data class SettingsSection(val sectionId: String, val onboarding: Boolean = false) : Screen
 
     @Serializable
     data object Dashboard : Screen
@@ -199,15 +216,43 @@ fun NavGraph(
     ) {
         composable<Screen.Settings> {
             SettingsScreen(
-                onNavigateToDashboard = {
-                    navController.navigate(Screen.Dashboard) {
-                        popUpTo<Screen.Settings> { inclusive = true }
-                    }
+                onNavigateToSection = { section ->
+                    navController.navigate(Screen.SettingsSection(section.id))
                 },
-                onNavigateToPalettePreview = {
-                    navController.navigate(Screen.PalettePreview)
-                }
+                onNavigateBack = { navController.popBackStack() }
             )
+        }
+
+        composable<Screen.SettingsSection> { backStackEntry ->
+            val route = backStackEntry.toRoute<Screen.SettingsSection>()
+            val onBack = { navController.popBackStack(); Unit }
+
+            when (SettingsSection.fromId(route.sectionId)) {
+                SettingsSection.CONNECTION -> ConnectionSettingsScreen(
+                    isOnboarding = route.onboarding,
+                    onNavigateBack = onBack,
+                    onNavigateToDashboard = {
+                        navController.navigate(Screen.Dashboard) {
+                            popUpTo<Screen.SettingsSection> { inclusive = true }
+                        }
+                    }
+                )
+
+                SettingsSection.DISPLAY -> DisplaySettingsScreen(onNavigateBack = onBack)
+
+                SettingsSection.NOTIFICATIONS -> NotificationSettingsScreen(onNavigateBack = onBack)
+
+                SettingsSection.DATA -> DataSyncSettingsScreen(onNavigateBack = onBack)
+
+                SettingsSection.ABOUT -> AboutSettingsScreen(onNavigateBack = onBack)
+
+                SettingsSection.DEBUG -> DebugSettingsScreen(
+                    onNavigateBack = onBack,
+                    onNavigateToPalettePreview = {
+                        navController.navigate(Screen.PalettePreview)
+                    }
+                )
+            }
         }
 
         composable<Screen.Dashboard> {

--- a/app/src/main/java/com/matedroid/ui/navigation/StartDestinationViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/navigation/StartDestinationViewModel.kt
@@ -3,6 +3,7 @@ package com.matedroid.ui.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.ui.screens.settings.SettingsSection
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +29,12 @@ class StartDestinationViewModel @Inject constructor(
             _startDestination.value = if (settings.isConfigured) {
                 Screen.Dashboard
             } else {
-                Screen.Settings
+                // First run: drop straight into the connection form. The category list
+                // would only offer sections that are meaningless without a server.
+                Screen.SettingsSection(
+                    sectionId = SettingsSection.CONNECTION.id,
+                    onboarding = true
+                )
             }
         }
         viewModelScope.launch {

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsComponents.kt
@@ -1,0 +1,261 @@
+package com.matedroid.ui.screens.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+
+/**
+ * Shared chrome for every settings detail page: a titled top bar with an optional back
+ * arrow, a snackbar host, and a scrolling content column.
+ *
+ * [onBack] is null during first-run onboarding, where there is nothing to go back to.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsSectionScaffold(
+    title: String,
+    onBack: (() -> Unit)?,
+    snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    bottomBar: @Composable () -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    if (onBack != null) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.back)
+                            )
+                        }
+                    }
+                }
+            )
+        },
+        bottomBar = bottomBar,
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            content = content
+        )
+    }
+}
+
+/**
+ * One row in the settings hub: tinted icon, title, live summary of the current value,
+ * and the chevron the app uses everywhere to mark a card as tappable.
+ */
+@Composable
+fun SettingsCategoryCard(
+    icon: ImageVector,
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * A label/hint pair with a trailing switch. Preferences using this apply immediately —
+ * only the connection form has an explicit save.
+ */
+@Composable
+fun SettingsSwitchRow(
+    title: String,
+    hint: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    trailingTitleContent: @Composable () -> Unit = {}
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                trailingTitleContent()
+            }
+            Text(
+                text = hint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled
+        )
+    }
+}
+
+/**
+ * A tappable row that hands off somewhere else (a system settings page, a browser).
+ * Same chevron affordance as [SettingsCategoryCard].
+ */
+@Composable
+fun SettingsLinkRow(
+    title: String,
+    hint: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = hint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/** Small caps header used to group related controls inside a detail page. */
+@Composable
+fun SettingsGroupHeader(
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(bottom = 8.dp)
+    )
+}
+
+/** Vertical rhythm helper so the section pages stay visually consistent. */
+@Composable
+fun SettingsSpacer(height: Int = 16) {
+    Spacer(modifier = Modifier.height(height.dp))
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsHubViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsHubViewModel.kt
@@ -1,0 +1,28 @@
+package com.matedroid.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.matedroid.data.local.AppSettings
+import com.matedroid.data.local.SettingsDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * Backs the settings hub only. Deliberately lighter than [SettingsViewModel]: the hub
+ * just needs the current values to render each category's summary line, so it depends on
+ * the DataStore alone rather than the repository, sync manager and notification managers.
+ */
+@HiltViewModel
+class SettingsHubViewModel @Inject constructor(
+    settingsDataStore: SettingsDataStore
+) : ViewModel() {
+
+    val settings: StateFlow<AppSettings> = settingsDataStore.settings.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = AppSettings()
+    )
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -1,946 +1,134 @@
 package com.matedroid.ui.screens.settings
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.Switch
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.matedroid.BuildConfig
 import com.matedroid.R
-import com.matedroid.data.local.TirePosition
+import com.matedroid.data.local.AppSettings
 import com.matedroid.data.model.Currency
-import com.matedroid.ui.components.MateDroidLoadingPlaceholder
 import com.matedroid.ui.theme.MateDroidTheme
-import com.matedroid.ui.theme.StatusWarning
-import com.matedroid.ui.theme.StatusError
-import com.matedroid.ui.theme.StatusSuccess
+import androidx.compose.ui.tooling.preview.Preview
 
+/**
+ * Settings hub: a category list that navigates to one detail page per [SettingsSection].
+ *
+ * Each row carries a live summary of what the section currently holds, so the value a
+ * user is looking for is visible without opening the page.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    onNavigateToDashboard: () -> Unit,
-    onNavigateToPalettePreview: () -> Unit = {},
-    viewModel: SettingsViewModel = hiltViewModel()
+    onNavigateToSection: (SettingsSection) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: SettingsHubViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    LaunchedEffect(uiState.error) {
-        uiState.error?.let {
-            snackbarHostState.showSnackbar(it)
-            viewModel.clearError()
-        }
-    }
-
-    LaunchedEffect(uiState.successMessage) {
-        uiState.successMessage?.let {
-            snackbarHostState.showSnackbar(it)
-            viewModel.clearSuccessMessage()
-        }
-    }
+    val settings by viewModel.settings.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.settings_title)) }
+                title = { Text(stringResource(R.string.settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
             )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        }
     ) { paddingValues ->
-        if (uiState.isLoading) {
-            LoadingContent(modifier = Modifier.padding(paddingValues))
-        } else {
-            SettingsContent(
-                modifier = Modifier.padding(paddingValues),
-                uiState = uiState,
-                onServerUrlChange = viewModel::updateServerUrl,
-                onSecondaryServerUrlChange = viewModel::updateSecondaryServerUrl,
-                onApiTokenChange = viewModel::updateApiToken,
-                onHttpBasicAuthUsernameChange = viewModel::updateHttpBasicAuthUsername,
-                onHttpBasicAuthPasswordChange = viewModel::updateHttpBasicAuthPassword,
-                onAcceptInvalidCertsChange = viewModel::updateAcceptInvalidCerts,
-                onCurrencyChange = viewModel::updateCurrency,
-                onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges,
-                onTestConnection = viewModel::testConnection,
-                onSave = { viewModel.saveSettings(onNavigateToDashboard) },
-                onPalettePreview = onNavigateToPalettePreview,
-                onForceResync = viewModel::forceResync,
-                onSimulateTpmsWarning = viewModel::simulateTpmsWarning,
-                onClearTpmsWarning = viewModel::clearTpmsWarning,
-                onRunTpmsCheckNow = viewModel::runTpmsCheckNow,
-                onSimulateSentryEvent = viewModel::simulateSentryEvent
-            )
-        }
+        SettingsHubContent(
+            modifier = Modifier.padding(paddingValues),
+            settings = settings,
+            onNavigateToSection = onNavigateToSection
+        )
     }
 }
 
 @Composable
-private fun LoadingContent(modifier: Modifier = Modifier) {
-    MateDroidLoadingPlaceholder(modifier = modifier)
-}
-
-@Composable
-private fun CollapsibleSection(
-    title: String,
-    expanded: Boolean,
-    onToggle: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+private fun SettingsHubContent(
+    settings: AppSettings,
+    onNavigateToSection: (SettingsSection) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggle)
-                .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f)
-            )
-            Icon(
-                imageVector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
-                contentDescription = stringResource(if (expanded) R.string.collapse else R.string.expand),
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
-
-        AnimatedVisibility(
-            visible = expanded,
-            enter = expandVertically(),
-            exit = shrinkVertically()
-        ) {
-            Column {
-                content()
-            }
-        }
-    }
-}
-
-@Composable
-private fun SettingsContent(
-    modifier: Modifier = Modifier,
-    uiState: SettingsUiState,
-    onServerUrlChange: (String) -> Unit,
-    onSecondaryServerUrlChange: (String) -> Unit,
-    onApiTokenChange: (String) -> Unit,
-    onHttpBasicAuthUsernameChange: (String) -> Unit,
-    onHttpBasicAuthPasswordChange: (String) -> Unit,
-    onAcceptInvalidCertsChange: (Boolean) -> Unit,
-    onCurrencyChange: (String) -> Unit,
-    onShowShortDrivesChargesChange: (Boolean) -> Unit,
-    onTestConnection: () -> Unit,
-    onSave: () -> Unit,
-    onPalettePreview: () -> Unit = {},
-    onForceResync: () -> Unit = {},
-    onSimulateTpmsWarning: (TirePosition) -> Unit = {},
-    onClearTpmsWarning: () -> Unit = {},
-    onRunTpmsCheckNow: () -> Unit = {},
-    onSimulateSentryEvent: () -> Unit = {}
-) {
-    var passwordVisible by remember { mutableStateOf(false) }
-    var basicAuthPasswordVisible by remember { mutableStateOf(false) }
-    var currencyDropdownExpanded by remember { mutableStateOf(false) }
-    var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
-    var showResyncConfirmDialog by remember { mutableStateOf(false) }
-    var advancedNetworkExpanded by rememberSaveable { mutableStateOf(false) }
-    var extraSettingsExpanded by rememberSaveable { mutableStateOf(false) }
-
     Column(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // === Server Connection Section ===
-        Text(
-            text = stringResource(R.string.settings_connect_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = stringResource(R.string.settings_connect_description),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = uiState.serverUrl,
-            onValueChange = onServerUrlChange,
-            label = { Text(stringResource(R.string.settings_server_url_label)) },
-            placeholder = { Text(stringResource(R.string.settings_server_url_placeholder)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("urlInput"),
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            enabled = !uiState.isTesting && !uiState.isSaving
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // === Advanced Network Settings (Collapsed by default) ===
-        HorizontalDivider()
-
-        CollapsibleSection(
-            title = stringResource(R.string.settings_advanced_network),
-            expanded = advancedNetworkExpanded,
-            onToggle = { advancedNetworkExpanded = !advancedNetworkExpanded }
-        ) {
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Secondary Server URL
-            OutlinedTextField(
-                value = uiState.secondaryServerUrl,
-                onValueChange = onSecondaryServerUrlChange,
-                label = { Text(stringResource(R.string.settings_secondary_url_label)) },
-                placeholder = { Text(stringResource(R.string.settings_secondary_url_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                enabled = !uiState.isTesting && !uiState.isSaving
+        SettingsSection.visibleSections().forEach { section ->
+            SettingsCategoryCard(
+                icon = section.icon,
+                title = stringResource(section.titleRes),
+                summary = sectionSummary(section, settings),
+                onClick = { onNavigateToSection(section) }
             )
-
-            Text(
-                text = stringResource(R.string.settings_secondary_url_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp)
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // API Token
-            OutlinedTextField(
-                value = uiState.apiToken,
-                onValueChange = onApiTokenChange,
-                label = { Text(stringResource(R.string.settings_api_token_label)) },
-                placeholder = { Text(stringResource(R.string.settings_api_token_placeholder)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("tokenInput"),
-                singleLine = true,
-                visualTransformation = if (passwordVisible) {
-                    VisualTransformation.None
-                } else {
-                    PasswordVisualTransformation()
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                trailingIcon = {
-                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                        Icon(
-                            imageVector = if (passwordVisible) {
-                                Icons.Filled.VisibilityOff
-                            } else {
-                                Icons.Filled.Visibility
-                            },
-                            contentDescription = stringResource(
-                                if (passwordVisible) R.string.hide_token else R.string.show_token
-                            )
-                        )
-                    }
-                },
-                enabled = !uiState.isTesting && !uiState.isSaving
-            )
-
-            Text(
-                text = stringResource(R.string.settings_api_token_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp)
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // HTTP Basic Auth
-            OutlinedTextField(
-                value = uiState.httpBasicAuthUsername,
-                onValueChange = onHttpBasicAuthUsernameChange,
-                label = { Text(stringResource(R.string.settings_http_basic_auth_username_label)) },
-                placeholder = { Text(stringResource(R.string.settings_http_basic_auth_username_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                enabled = !uiState.isTesting && !uiState.isSaving
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            OutlinedTextField(
-                value = uiState.httpBasicAuthPassword,
-                onValueChange = onHttpBasicAuthPasswordChange,
-                label = { Text(stringResource(R.string.settings_http_basic_auth_password_label)) },
-                placeholder = { Text(stringResource(R.string.settings_http_basic_auth_password_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                visualTransformation = if (basicAuthPasswordVisible) {
-                    VisualTransformation.None
-                } else {
-                    PasswordVisualTransformation()
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                trailingIcon = {
-                    IconButton(onClick = { basicAuthPasswordVisible = !basicAuthPasswordVisible }) {
-                        Icon(
-                            imageVector = if (basicAuthPasswordVisible) {
-                                Icons.Filled.VisibilityOff
-                            } else {
-                                Icons.Filled.Visibility
-                            },
-                            contentDescription = stringResource(
-                                if (basicAuthPasswordVisible) R.string.hide_password else R.string.show_password
-                            )
-                        )
-                    }
-                },
-                enabled = !uiState.isTesting && !uiState.isSaving
-            )
-
-            Text(
-                text = stringResource(R.string.settings_http_basic_auth_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp)
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Accept invalid certificates toggle
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.settings_accept_invalid_certs),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_accept_invalid_certs_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Switch(
-                    checked = uiState.acceptInvalidCerts,
-                    onCheckedChange = onAcceptInvalidCertsChange,
-                    enabled = !uiState.isTesting && !uiState.isSaving
-                )
-            }
-
-            if (uiState.acceptInvalidCerts) {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = StatusWarning.copy(alpha = 0.1f)
-                    )
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Warning,
-                            contentDescription = null,
-                            tint = StatusWarning,
-                            modifier = Modifier.size(20.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = stringResource(R.string.settings_accept_invalid_certs_warning),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = StatusWarning
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // === Display Settings Section ===
-        Text(
-            text = stringResource(R.string.settings_display_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Currency selection
-        val selectedCurrency = Currency.findByCode(uiState.currencyCode)
-
-        Box {
-            OutlinedTextField(
-                value = "${selectedCurrency.symbol} ${selectedCurrency.code} - ${selectedCurrency.name}",
-                onValueChange = {},
-                label = { Text(stringResource(R.string.settings_currency_label)) },
-                modifier = Modifier.fillMaxWidth(),
-                readOnly = true,
-                trailingIcon = {
-                    IconButton(onClick = { currencyDropdownExpanded = true }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowDropDown,
-                            contentDescription = stringResource(R.string.settings_currency_select)
-                        )
-                    }
-                }
-            )
-
-            DropdownMenu(
-                expanded = currencyDropdownExpanded,
-                onDismissRequest = { currencyDropdownExpanded = false },
-                modifier = Modifier.fillMaxWidth(0.9f)
-            ) {
-                Currency.ALL.forEach { currency ->
-                    DropdownMenuItem(
-                        text = {
-                            Text("${currency.symbol} ${currency.code} - ${currency.name}")
-                        },
-                        onClick = {
-                            onCurrencyChange(currency.code)
-                            currencyDropdownExpanded = false
-                        }
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // === Extra Settings (Collapsed by default) ===
-        HorizontalDivider()
-
-        CollapsibleSection(
-            title = stringResource(R.string.settings_extra),
-            expanded = extraSettingsExpanded,
-            onToggle = { extraSettingsExpanded = !extraSettingsExpanded }
-        ) {
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Show short drives / charges toggle
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = stringResource(R.string.settings_show_short_label),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        IconButton(
-                            onClick = { showShortDrivesChargesInfoDialog = true },
-                            modifier = Modifier.size(32.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Info,
-                                contentDescription = stringResource(R.string.more_information),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(18.dp)
-                            )
-                        }
-                    }
-                    Text(
-                        text = stringResource(R.string.settings_show_short_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Switch(
-                    checked = uiState.showShortDrivesCharges,
-                    onCheckedChange = onShowShortDrivesChargesChange
-                )
-            }
-
-            // Info dialog for short drives / charges
-            if (showShortDrivesChargesInfoDialog) {
-                AlertDialog(
-                    onDismissRequest = { showShortDrivesChargesInfoDialog = false },
-                    title = { Text(stringResource(R.string.settings_short_dialog_title)) },
-                    text = {
-                        Text(stringResource(R.string.settings_short_dialog_text))
-                    },
-                    confirmButton = {
-                        TextButton(onClick = { showShortDrivesChargesInfoDialog = false }) {
-                            Text(stringResource(R.string.ok))
-                        }
-                    }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Force Full Resync button
-            OutlinedButton(
-                onClick = { showResyncConfirmDialog = true },
-                enabled = !uiState.isResyncing,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                if (uiState.isResyncing) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(stringResource(if (uiState.isResyncing) R.string.settings_resyncing else R.string.settings_resync_button))
-            }
-
-            Text(
-                text = stringResource(R.string.settings_resync_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp)
-            )
-
-            // Resync confirmation dialog
-            if (showResyncConfirmDialog) {
-                AlertDialog(
-                    onDismissRequest = { showResyncConfirmDialog = false },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Filled.Warning,
-                            contentDescription = null,
-                            tint = StatusWarning,
-                            modifier = Modifier.size(32.dp)
-                        )
-                    },
-                    title = { Text(stringResource(R.string.settings_resync_dialog_title)) },
-                    text = {
-                        Text(
-                            buildAnnotatedString {
-                                append(stringResource(R.string.settings_resync_dialog_text_prefix))
-                                withStyle(SpanStyle(color = StatusError, fontWeight = FontWeight.Bold)) {
-                                    append(stringResource(R.string.settings_resync_dialog_text_delete))
-                                }
-                                append(stringResource(R.string.settings_resync_dialog_text_suffix))
-                            }
-                        )
-                    },
-                    confirmButton = {
-                        Button(
-                            onClick = {
-                                showResyncConfirmDialog = false
-                                onForceResync()
-                            }
-                        ) {
-                            Text(stringResource(R.string.settings_resync_confirm))
-                        }
-                    },
-                    dismissButton = {
-                        TextButton(onClick = { showResyncConfirmDialog = false }) {
-                            Text(stringResource(R.string.cancel))
-                        }
-                    }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // Test result card
-        uiState.testResult?.let { result ->
-            TestResultCard(result = result)
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-
-        // Action buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            OutlinedButton(
-                onClick = onTestConnection,
-                enabled = uiState.serverUrl.isNotBlank() && !uiState.isTesting && !uiState.isSaving,
-                modifier = Modifier.weight(1f)
-            ) {
-                if (uiState.isTesting) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(stringResource(R.string.settings_test_connection))
-            }
-
-            Button(
-                onClick = onSave,
-                enabled = uiState.serverUrl.isNotBlank() && !uiState.isTesting && !uiState.isSaving,
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag("saveButton")
-            ) {
-                if (uiState.isSaving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(stringResource(R.string.settings_save))
-            }
-        }
-
-        // Debug: Palette Preview button (only visible in debug builds)
-        if (com.matedroid.BuildConfig.DEBUG) {
-            var tpmsDropdownExpanded by remember { mutableStateOf(false) }
-
-            Spacer(modifier = Modifier.height(32.dp))
-            OutlinedButton(
-                onClick = onPalettePreview,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.settings_palette_preview))
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // TPMS Debug: Simulate Warning with tire selection
-            Box {
-                OutlinedButton(
-                    onClick = { tpmsDropdownExpanded = true },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(stringResource(R.string.debug_tpms_simulate_warning))
-                    Icon(
-                        imageVector = Icons.Filled.ArrowDropDown,
-                        contentDescription = null,
-                        modifier = Modifier.padding(start = 4.dp)
-                    )
-                }
-
-                DropdownMenu(
-                    expanded = tpmsDropdownExpanded,
-                    onDismissRequest = { tpmsDropdownExpanded = false }
-                ) {
-                    TirePosition.entries.forEach { tire ->
-                        val tireName = when (tire) {
-                            TirePosition.FL -> stringResource(R.string.tire_fl_full)
-                            TirePosition.FR -> stringResource(R.string.tire_fr_full)
-                            TirePosition.RL -> stringResource(R.string.tire_rl_full)
-                            TirePosition.RR -> stringResource(R.string.tire_rr_full)
-                        }
-                        DropdownMenuItem(
-                            text = { Text(tireName) },
-                            onClick = {
-                                tpmsDropdownExpanded = false
-                                onSimulateTpmsWarning(tire)
-                            }
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // TPMS Debug: Clear State
-            OutlinedButton(
-                onClick = onClearTpmsWarning,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.debug_tpms_clear_state))
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // TPMS Debug: Run Check Now
-            OutlinedButton(
-                onClick = onRunTpmsCheckNow,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.debug_tpms_run_now))
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Sentry Debug: Simulate Event
-            OutlinedButton(
-                onClick = onSimulateSentryEvent,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.debug_sentry_simulate_event))
-            }
-        }
-
-        // Version number and issue link at bottom
-        Spacer(modifier = Modifier.height(48.dp))
-        Text(
-            text = "v${com.matedroid.BuildConfig.VERSION_NAME} (${com.matedroid.BuildConfig.GIT_SHA})",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        val uriHandler = LocalUriHandler.current
-        Text(
-            text = stringResource(R.string.settings_report_issue),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .clickable { uriHandler.openUri("https://github.com/vide/matedroid/issues") }
-        )
-        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
+/**
+ * Summary line for a hub row: the current value where there is a single meaningful one,
+ * the static description otherwise.
+ */
 @Composable
-private fun TestResultCard(result: TestResult) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            // Primary server result
-            ServerTestResultRow(
-                label = stringResource(R.string.settings_primary_server),
-                result = result.primaryResult
-            )
+private fun sectionSummary(section: SettingsSection, settings: AppSettings): String =
+    when (section) {
+        SettingsSection.CONNECTION -> settings.serverUrl.takeIf { it.isNotBlank() }
+            ?.removePrefix("https://")
+            ?.removePrefix("http://")
+            ?: stringResource(R.string.settings_not_configured)
 
-            // Secondary server result (if tested)
-            result.secondaryResult?.let { secondaryResult ->
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                ServerTestResultRow(
-                    label = stringResource(R.string.settings_secondary_server),
-                    result = secondaryResult
-                )
-            }
+        SettingsSection.DISPLAY -> Currency.findByCode(settings.currencyCode).let {
+            "${it.symbol} ${it.code}"
         }
-    }
-}
 
-@Composable
-private fun ServerTestResultRow(
-    label: String,
-    result: ServerTestResult
-) {
-    val connectedText = stringResource(R.string.settings_connected)
-    val (icon, color, statusText) = when (result) {
-        is ServerTestResult.Success -> Triple(
-            Icons.Filled.CheckCircle,
-            StatusSuccess,
-            connectedText
-        )
-        is ServerTestResult.Failure -> Triple(
-            Icons.Filled.Error,
-            StatusError,
-            result.message
-        )
-    }
+        SettingsSection.ABOUT -> "v${BuildConfig.VERSION_NAME}"
 
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = color,
-            modifier = Modifier.size(20.dp)
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                text = statusText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = color
-            )
-        }
+        else -> stringResource(section.summaryRes)
     }
-}
 
 @Preview(showBackground = true)
 @Composable
-private fun SettingsScreenPreview() {
+private fun SettingsHubPreview() {
     MateDroidTheme {
-        SettingsContent(
-            uiState = SettingsUiState(isLoading = false),
-            onServerUrlChange = {},
-            onSecondaryServerUrlChange = {},
-            onApiTokenChange = {},
-            onHttpBasicAuthUsernameChange = {},
-            onHttpBasicAuthPasswordChange = {},
-            onAcceptInvalidCertsChange = {},
-            onCurrencyChange = {},
-            onShowShortDrivesChargesChange = {},
-            onTestConnection = {},
-            onSave = {}
+        SettingsHubContent(
+            settings = AppSettings(serverUrl = "https://teslamate.example.com"),
+            onNavigateToSection = {}
         )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SettingsScreenWithResultPreview() {
+private fun SettingsHubUnconfiguredPreview() {
     MateDroidTheme {
-        SettingsContent(
-            uiState = SettingsUiState(
-                isLoading = false,
-                serverUrl = "https://teslamate.example.com",
-                testResult = TestResult(
-                    primaryResult = ServerTestResult.Success
-                )
-            ),
-            onServerUrlChange = {},
-            onSecondaryServerUrlChange = {},
-            onApiTokenChange = {},
-            onHttpBasicAuthUsernameChange = {},
-            onHttpBasicAuthPasswordChange = {},
-            onAcceptInvalidCertsChange = {},
-            onCurrencyChange = {},
-            onShowShortDrivesChargesChange = {},
-            onTestConnection = {},
-            onSave = {}
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SettingsScreenWithBothResultsPreview() {
-    MateDroidTheme {
-        SettingsContent(
-            uiState = SettingsUiState(
-                isLoading = false,
-                serverUrl = "https://teslamate.example.com",
-                secondaryServerUrl = "https://teslamate.local",
-                testResult = TestResult(
-                    primaryResult = ServerTestResult.Failure("Connection timed out"),
-                    secondaryResult = ServerTestResult.Success
-                )
-            ),
-            onServerUrlChange = {},
-            onSecondaryServerUrlChange = {},
-            onApiTokenChange = {},
-            onHttpBasicAuthUsernameChange = {},
-            onHttpBasicAuthPasswordChange = {},
-            onAcceptInvalidCertsChange = {},
-            onCurrencyChange = {},
-            onShowShortDrivesChargesChange = {},
-            onTestConnection = {},
-            onSave = {}
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SettingsScreenWithWarningPreview() {
-    MateDroidTheme {
-        SettingsContent(
-            uiState = SettingsUiState(
-                isLoading = false,
-                serverUrl = "https://teslamate.example.com",
-                acceptInvalidCerts = true
-            ),
-            onServerUrlChange = {},
-            onSecondaryServerUrlChange = {},
-            onApiTokenChange = {},
-            onHttpBasicAuthUsernameChange = {},
-            onHttpBasicAuthPasswordChange = {},
-            onAcceptInvalidCertsChange = {},
-            onCurrencyChange = {},
-            onShowShortDrivesChargesChange = {},
-            onTestConnection = {},
-            onSave = {}
+        SettingsHubContent(
+            settings = AppSettings(),
+            onNavigateToSection = {}
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsSection.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsSection.kt
@@ -1,0 +1,74 @@
+package com.matedroid.ui.screens.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.matedroid.BuildConfig
+import com.matedroid.R
+
+/**
+ * The settings hub is a category list; each entry here is one detail page.
+ *
+ * [id] is the stable navigation argument — it is persisted in the back stack and used by
+ * deep links, so renaming one is a breaking change. The enum order is the display order.
+ */
+enum class SettingsSection(
+    val id: String,
+    @param:StringRes val titleRes: Int,
+    @param:StringRes val summaryRes: Int,
+    val icon: ImageVector,
+    val debugOnly: Boolean = false
+) {
+    CONNECTION(
+        id = "connection",
+        titleRes = R.string.settings_section_connection,
+        summaryRes = R.string.settings_section_connection_summary,
+        icon = Icons.Filled.Dns
+    ),
+    DISPLAY(
+        id = "display",
+        titleRes = R.string.settings_section_display,
+        summaryRes = R.string.settings_section_display_summary,
+        icon = Icons.Filled.Palette
+    ),
+    NOTIFICATIONS(
+        id = "notifications",
+        titleRes = R.string.settings_section_notifications,
+        summaryRes = R.string.settings_section_notifications_summary,
+        icon = Icons.Filled.Notifications
+    ),
+    DATA(
+        id = "data",
+        titleRes = R.string.settings_section_data,
+        summaryRes = R.string.settings_section_data_summary,
+        icon = Icons.Filled.Sync
+    ),
+    ABOUT(
+        id = "about",
+        titleRes = R.string.settings_section_about,
+        summaryRes = R.string.settings_section_about_summary,
+        icon = Icons.Filled.Info
+    ),
+    DEBUG(
+        id = "debug",
+        titleRes = R.string.settings_section_debug,
+        summaryRes = R.string.settings_section_debug_summary,
+        icon = Icons.Filled.BugReport,
+        debugOnly = true
+    );
+
+    companion object {
+        /** Falls back to [CONNECTION] so an unknown deep link never lands on a blank page. */
+        fun fromId(id: String): SettingsSection = entries.firstOrNull { it.id == id } ?: CONNECTION
+
+        /** Sections shown in the hub for the current build type. */
+        fun visibleSections(): List<SettingsSection> =
+            entries.filter { !it.debugOnly || BuildConfig.DEBUG }
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -314,6 +314,11 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(testResult = null)
     }
 
+    /** Surfaces a snackbar from the UI layer (e.g. the "saved" confirmation). */
+    fun showMessage(message: String) {
+        _uiState.value = _uiState.value.copy(successMessage = message)
+    }
+
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
     }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/AboutSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/AboutSettingsScreen.kt
@@ -1,0 +1,127 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.matedroid.BuildConfig
+import com.matedroid.R
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
+import com.matedroid.ui.screens.settings.SettingsLinkRow
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.theme.MateDroidTheme
+
+private const val ISSUES_URL = "https://github.com/vide/matedroid/issues"
+private const val SOURCE_URL = "https://github.com/vide/matedroid"
+
+/** App identity and where to go for help. */
+@Composable
+fun AboutSettingsScreen(
+    onNavigateBack: () -> Unit
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val uriHandler = LocalUriHandler.current
+
+    AboutSettingsContent(
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onOpenIssues = { uriHandler.openUri(ISSUES_URL) },
+        onOpenSource = { uriHandler.openUri(SOURCE_URL) }
+    )
+}
+
+@Composable
+private fun AboutSettingsContent(
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onOpenIssues: () -> Unit,
+    onOpenSource: () -> Unit
+) {
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_about),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.CenterHorizontally)
+                )
+                Text(
+                    text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_SHA})",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp)
+                )
+            }
+        }
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_support))
+
+        SettingsLinkRow(
+            title = stringResource(R.string.settings_report_issue),
+            hint = stringResource(R.string.settings_report_issue_hint),
+            icon = Icons.Filled.BugReport,
+            onClick = onOpenIssues
+        )
+
+        HorizontalDivider()
+
+        SettingsLinkRow(
+            title = stringResource(R.string.settings_source_code),
+            hint = stringResource(R.string.settings_source_code_hint),
+            icon = Icons.Filled.Code,
+            onClick = onOpenSource
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AboutSettingsPreview() {
+    MateDroidTheme {
+        AboutSettingsContent(
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onOpenIssues = {},
+            onOpenSource = {}
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
@@ -1,9 +1,5 @@
 package com.matedroid.ui.screens.settings.sections
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,8 +13,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
@@ -32,8 +26,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,7 +35,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,6 +49,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.matedroid.R
 import com.matedroid.ui.screens.settings.ServerTestResult
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
 import com.matedroid.ui.screens.settings.SettingsSectionScaffold
 import com.matedroid.ui.screens.settings.SettingsSpacer
 import com.matedroid.ui.screens.settings.SettingsUiState
@@ -67,8 +61,13 @@ import com.matedroid.ui.theme.StatusSuccess
 import com.matedroid.ui.theme.StatusWarning
 
 /**
- * Server connection settings. The only section with an explicit save: the URL and
- * credentials need validating together, and a half-typed URL must not be committed.
+ * Server connection settings, laid out as flat groups (Server / Authentication /
+ * Security) rather than hiding the optional fields behind a disclosure. Reaching this
+ * page is already one level of disclosure; nesting another inside it is what used to
+ * make HTTP Basic Auth hard to find. Each optional field says so in its own label.
+ *
+ * The only section with an explicit save: URL and credentials need validating together,
+ * so a half-typed URL must not be committed.
  *
  * During first-run onboarding ([isOnboarding]) there is no back arrow and saving
  * continues to the dashboard; afterwards saving stays put and confirms with a snackbar.
@@ -139,7 +138,7 @@ private fun ConnectionSettingsContent(
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
     var basicAuthPasswordVisible by remember { mutableStateOf(false) }
-    var advancedNetworkExpanded by rememberSaveable { mutableStateOf(false) }
+    val fieldsEnabled = !uiState.isTesting && !uiState.isSaving
 
     SettingsSectionScaffold(
         title = stringResource(R.string.settings_section_connection),
@@ -160,7 +159,10 @@ private fun ConnectionSettingsContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        SettingsSpacer()
+        SettingsSpacer(24)
+
+        // ==================== Server ====================
+        SettingsGroupHeader(stringResource(R.string.settings_group_server))
 
         OutlinedTextField(
             value = uiState.serverUrl,
@@ -172,30 +174,157 @@ private fun ConnectionSettingsContent(
                 .testTag("urlInput"),
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            enabled = !uiState.isTesting && !uiState.isSaving
+            enabled = fieldsEnabled
         )
 
         SettingsSpacer()
 
-        HorizontalDivider()
-
-        AdvancedNetworkSection(
-            expanded = advancedNetworkExpanded,
-            onToggle = { advancedNetworkExpanded = !advancedNetworkExpanded },
-            uiState = uiState,
-            passwordVisible = passwordVisible,
-            onPasswordVisibleChange = { passwordVisible = it },
-            basicAuthPasswordVisible = basicAuthPasswordVisible,
-            onBasicAuthPasswordVisibleChange = { basicAuthPasswordVisible = it },
-            onSecondaryServerUrlChange = onSecondaryServerUrlChange,
-            onApiTokenChange = onApiTokenChange,
-            onHttpBasicAuthUsernameChange = onHttpBasicAuthUsernameChange,
-            onHttpBasicAuthPasswordChange = onHttpBasicAuthPasswordChange,
-            onAcceptInvalidCertsChange = onAcceptInvalidCertsChange
+        OutlinedTextField(
+            value = uiState.secondaryServerUrl,
+            onValueChange = onSecondaryServerUrlChange,
+            label = { Text(stringResource(R.string.settings_secondary_url_label)) },
+            placeholder = { Text(stringResource(R.string.settings_secondary_url_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            enabled = fieldsEnabled
         )
 
+        FieldHint(stringResource(R.string.settings_secondary_url_hint))
+
+        SettingsSpacer(24)
+
+        // ==================== Authentication ====================
+        SettingsGroupHeader(stringResource(R.string.settings_group_authentication))
+
+        OutlinedTextField(
+            value = uiState.apiToken,
+            onValueChange = onApiTokenChange,
+            label = { Text(stringResource(R.string.settings_api_token_label)) },
+            placeholder = { Text(stringResource(R.string.settings_api_token_placeholder)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("tokenInput"),
+            singleLine = true,
+            visualTransformation = if (passwordVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            trailingIcon = {
+                VisibilityToggle(
+                    visible = passwordVisible,
+                    onToggle = { passwordVisible = !passwordVisible },
+                    showDescription = R.string.show_token,
+                    hideDescription = R.string.hide_token
+                )
+            },
+            enabled = fieldsEnabled
+        )
+
+        FieldHint(stringResource(R.string.settings_api_token_hint))
+
+        SettingsSpacer()
+
+        OutlinedTextField(
+            value = uiState.httpBasicAuthUsername,
+            onValueChange = onHttpBasicAuthUsernameChange,
+            label = { Text(stringResource(R.string.settings_http_basic_auth_username_label)) },
+            placeholder = { Text(stringResource(R.string.settings_http_basic_auth_username_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = fieldsEnabled
+        )
+
+        SettingsSpacer(8)
+
+        OutlinedTextField(
+            value = uiState.httpBasicAuthPassword,
+            onValueChange = onHttpBasicAuthPasswordChange,
+            label = { Text(stringResource(R.string.settings_http_basic_auth_password_label)) },
+            placeholder = { Text(stringResource(R.string.settings_http_basic_auth_password_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = if (basicAuthPasswordVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            trailingIcon = {
+                VisibilityToggle(
+                    visible = basicAuthPasswordVisible,
+                    onToggle = { basicAuthPasswordVisible = !basicAuthPasswordVisible },
+                    showDescription = R.string.show_password,
+                    hideDescription = R.string.hide_password
+                )
+            },
+            enabled = fieldsEnabled
+        )
+
+        FieldHint(stringResource(R.string.settings_http_basic_auth_hint))
+
+        SettingsSpacer(24)
+
+        // ==================== Security ====================
+        SettingsGroupHeader(stringResource(R.string.settings_group_security))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_accept_invalid_certs),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = stringResource(R.string.settings_accept_invalid_certs_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = uiState.acceptInvalidCerts,
+                onCheckedChange = onAcceptInvalidCertsChange,
+                enabled = fieldsEnabled
+            )
+        }
+
+        if (uiState.acceptInvalidCerts) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = StatusWarning.copy(alpha = 0.1f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = StatusWarning,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.settings_accept_invalid_certs_warning),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = StatusWarning
+                    )
+                }
+            }
+        }
+
         uiState.testResult?.let { result ->
-            SettingsSpacer()
+            SettingsSpacer(24)
             TestResultCard(result = result)
         }
 
@@ -258,200 +387,6 @@ private fun ConnectionActionBar(
                         if (isOnboarding) R.string.settings_save else R.string.settings_save_short
                     )
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun AdvancedNetworkSection(
-    expanded: Boolean,
-    onToggle: () -> Unit,
-    uiState: SettingsUiState,
-    passwordVisible: Boolean,
-    onPasswordVisibleChange: (Boolean) -> Unit,
-    basicAuthPasswordVisible: Boolean,
-    onBasicAuthPasswordVisibleChange: (Boolean) -> Unit,
-    onSecondaryServerUrlChange: (String) -> Unit,
-    onApiTokenChange: (String) -> Unit,
-    onHttpBasicAuthUsernameChange: (String) -> Unit,
-    onHttpBasicAuthPasswordChange: (String) -> Unit,
-    onAcceptInvalidCertsChange: (Boolean) -> Unit
-) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggle)
-                .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.settings_advanced_network),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f)
-            )
-            Icon(
-                imageVector = if (expanded) {
-                    Icons.Filled.KeyboardArrowUp
-                } else {
-                    Icons.Filled.KeyboardArrowDown
-                },
-                contentDescription = stringResource(
-                    if (expanded) R.string.collapse else R.string.expand
-                ),
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
-
-        AnimatedVisibility(
-            visible = expanded,
-            enter = expandVertically(),
-            exit = shrinkVertically()
-        ) {
-            Column {
-                SettingsSpacer(8)
-
-                OutlinedTextField(
-                    value = uiState.secondaryServerUrl,
-                    onValueChange = onSecondaryServerUrlChange,
-                    label = { Text(stringResource(R.string.settings_secondary_url_label)) },
-                    placeholder = { Text(stringResource(R.string.settings_secondary_url_placeholder)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                    enabled = !uiState.isTesting && !uiState.isSaving
-                )
-
-                FieldHint(stringResource(R.string.settings_secondary_url_hint))
-
-                SettingsSpacer()
-
-                OutlinedTextField(
-                    value = uiState.apiToken,
-                    onValueChange = onApiTokenChange,
-                    label = { Text(stringResource(R.string.settings_api_token_label)) },
-                    placeholder = { Text(stringResource(R.string.settings_api_token_placeholder)) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("tokenInput"),
-                    singleLine = true,
-                    visualTransformation = if (passwordVisible) {
-                        VisualTransformation.None
-                    } else {
-                        PasswordVisualTransformation()
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    trailingIcon = {
-                        VisibilityToggle(
-                            visible = passwordVisible,
-                            onToggle = { onPasswordVisibleChange(!passwordVisible) },
-                            showDescription = R.string.show_token,
-                            hideDescription = R.string.hide_token
-                        )
-                    },
-                    enabled = !uiState.isTesting && !uiState.isSaving
-                )
-
-                FieldHint(stringResource(R.string.settings_api_token_hint))
-
-                SettingsSpacer()
-
-                OutlinedTextField(
-                    value = uiState.httpBasicAuthUsername,
-                    onValueChange = onHttpBasicAuthUsernameChange,
-                    label = { Text(stringResource(R.string.settings_http_basic_auth_username_label)) },
-                    placeholder = { Text(stringResource(R.string.settings_http_basic_auth_username_placeholder)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    enabled = !uiState.isTesting && !uiState.isSaving
-                )
-
-                SettingsSpacer(8)
-
-                OutlinedTextField(
-                    value = uiState.httpBasicAuthPassword,
-                    onValueChange = onHttpBasicAuthPasswordChange,
-                    label = { Text(stringResource(R.string.settings_http_basic_auth_password_label)) },
-                    placeholder = { Text(stringResource(R.string.settings_http_basic_auth_password_placeholder)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    visualTransformation = if (basicAuthPasswordVisible) {
-                        VisualTransformation.None
-                    } else {
-                        PasswordVisualTransformation()
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    trailingIcon = {
-                        VisibilityToggle(
-                            visible = basicAuthPasswordVisible,
-                            onToggle = { onBasicAuthPasswordVisibleChange(!basicAuthPasswordVisible) },
-                            showDescription = R.string.show_password,
-                            hideDescription = R.string.hide_password
-                        )
-                    },
-                    enabled = !uiState.isTesting && !uiState.isSaving
-                )
-
-                FieldHint(stringResource(R.string.settings_http_basic_auth_hint))
-
-                SettingsSpacer()
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.settings_accept_invalid_certs),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            text = stringResource(R.string.settings_accept_invalid_certs_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Switch(
-                        checked = uiState.acceptInvalidCerts,
-                        onCheckedChange = onAcceptInvalidCertsChange,
-                        enabled = !uiState.isTesting && !uiState.isSaving
-                    )
-                }
-
-                if (uiState.acceptInvalidCerts) {
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = CardDefaults.cardColors(
-                            containerColor = StatusWarning.copy(alpha = 0.1f)
-                        )
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Warning,
-                                contentDescription = null,
-                                tint = StatusWarning,
-                                modifier = Modifier.size(20.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(R.string.settings_accept_invalid_certs_warning),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = StatusWarning
-                            )
-                        }
-                    }
-                }
-
-                SettingsSpacer(8)
             }
         }
     }
@@ -611,6 +546,7 @@ private fun ConnectionSettingsWithResultPreview() {
                 isLoading = false,
                 serverUrl = "https://teslamate.example.com",
                 secondaryServerUrl = "https://teslamate.local",
+                acceptInvalidCerts = true,
                 testResult = TestResult(
                     primaryResult = ServerTestResult.Failure("Connection timed out"),
                     secondaryResult = ServerTestResult.Success

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
@@ -1,0 +1,632 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.matedroid.R
+import com.matedroid.ui.screens.settings.ServerTestResult
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.screens.settings.SettingsUiState
+import com.matedroid.ui.screens.settings.SettingsViewModel
+import com.matedroid.ui.screens.settings.TestResult
+import com.matedroid.ui.theme.MateDroidTheme
+import com.matedroid.ui.theme.StatusError
+import com.matedroid.ui.theme.StatusSuccess
+import com.matedroid.ui.theme.StatusWarning
+
+/**
+ * Server connection settings. The only section with an explicit save: the URL and
+ * credentials need validating together, and a half-typed URL must not be committed.
+ *
+ * During first-run onboarding ([isOnboarding]) there is no back arrow and saving
+ * continues to the dashboard; afterwards saving stays put and confirms with a snackbar.
+ */
+@Composable
+fun ConnectionSettingsScreen(
+    isOnboarding: Boolean,
+    onNavigateBack: () -> Unit,
+    onNavigateToDashboard: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val savedMessage = stringResource(R.string.settings_saved)
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(uiState.successMessage) {
+        uiState.successMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSuccessMessage()
+        }
+    }
+
+    ConnectionSettingsContent(
+        uiState = uiState,
+        isOnboarding = isOnboarding,
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack.takeIf { !isOnboarding },
+        onServerUrlChange = viewModel::updateServerUrl,
+        onSecondaryServerUrlChange = viewModel::updateSecondaryServerUrl,
+        onApiTokenChange = viewModel::updateApiToken,
+        onHttpBasicAuthUsernameChange = viewModel::updateHttpBasicAuthUsername,
+        onHttpBasicAuthPasswordChange = viewModel::updateHttpBasicAuthPassword,
+        onAcceptInvalidCertsChange = viewModel::updateAcceptInvalidCerts,
+        onTestConnection = viewModel::testConnection,
+        onSave = {
+            viewModel.saveSettings {
+                if (isOnboarding) {
+                    onNavigateToDashboard()
+                } else {
+                    viewModel.showMessage(savedMessage)
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun ConnectionSettingsContent(
+    uiState: SettingsUiState,
+    isOnboarding: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: (() -> Unit)?,
+    onServerUrlChange: (String) -> Unit,
+    onSecondaryServerUrlChange: (String) -> Unit,
+    onApiTokenChange: (String) -> Unit,
+    onHttpBasicAuthUsernameChange: (String) -> Unit,
+    onHttpBasicAuthPasswordChange: (String) -> Unit,
+    onAcceptInvalidCertsChange: (Boolean) -> Unit,
+    onTestConnection: () -> Unit,
+    onSave: () -> Unit
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+    var basicAuthPasswordVisible by remember { mutableStateOf(false) }
+    var advancedNetworkExpanded by rememberSaveable { mutableStateOf(false) }
+
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_connection),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState,
+        bottomBar = {
+            ConnectionActionBar(
+                uiState = uiState,
+                isOnboarding = isOnboarding,
+                onTestConnection = onTestConnection,
+                onSave = onSave
+            )
+        }
+    ) {
+        Text(
+            text = stringResource(R.string.settings_connect_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        SettingsSpacer()
+
+        OutlinedTextField(
+            value = uiState.serverUrl,
+            onValueChange = onServerUrlChange,
+            label = { Text(stringResource(R.string.settings_server_url_label)) },
+            placeholder = { Text(stringResource(R.string.settings_server_url_placeholder)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("urlInput"),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            enabled = !uiState.isTesting && !uiState.isSaving
+        )
+
+        SettingsSpacer()
+
+        HorizontalDivider()
+
+        AdvancedNetworkSection(
+            expanded = advancedNetworkExpanded,
+            onToggle = { advancedNetworkExpanded = !advancedNetworkExpanded },
+            uiState = uiState,
+            passwordVisible = passwordVisible,
+            onPasswordVisibleChange = { passwordVisible = it },
+            basicAuthPasswordVisible = basicAuthPasswordVisible,
+            onBasicAuthPasswordVisibleChange = { basicAuthPasswordVisible = it },
+            onSecondaryServerUrlChange = onSecondaryServerUrlChange,
+            onApiTokenChange = onApiTokenChange,
+            onHttpBasicAuthUsernameChange = onHttpBasicAuthUsernameChange,
+            onHttpBasicAuthPasswordChange = onHttpBasicAuthPasswordChange,
+            onAcceptInvalidCertsChange = onAcceptInvalidCertsChange
+        )
+
+        uiState.testResult?.let { result ->
+            SettingsSpacer()
+            TestResultCard(result = result)
+        }
+
+        SettingsSpacer()
+    }
+}
+
+/** Test and Save pinned to the bottom so they stay reachable with the form scrolled. */
+@Composable
+private fun ConnectionActionBar(
+    uiState: SettingsUiState,
+    isOnboarding: Boolean,
+    onTestConnection: () -> Unit,
+    onSave: () -> Unit
+) {
+    Surface(
+        tonalElevation = 3.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                // The bottomBar slot sits below Scaffold's inset padding, so it has to
+                // clear the system navigation bar itself.
+                .navigationBarsPadding()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onTestConnection,
+                enabled = uiState.serverUrl.isNotBlank() && !uiState.isTesting && !uiState.isSaving,
+                modifier = Modifier.weight(1f)
+            ) {
+                if (uiState.isTesting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.settings_test_connection))
+            }
+
+            Button(
+                onClick = onSave,
+                enabled = uiState.serverUrl.isNotBlank() && !uiState.isTesting && !uiState.isSaving,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("saveButton")
+            ) {
+                if (uiState.isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(
+                    stringResource(
+                        if (isOnboarding) R.string.settings_save else R.string.settings_save_short
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdvancedNetworkSection(
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    uiState: SettingsUiState,
+    passwordVisible: Boolean,
+    onPasswordVisibleChange: (Boolean) -> Unit,
+    basicAuthPasswordVisible: Boolean,
+    onBasicAuthPasswordVisibleChange: (Boolean) -> Unit,
+    onSecondaryServerUrlChange: (String) -> Unit,
+    onApiTokenChange: (String) -> Unit,
+    onHttpBasicAuthUsernameChange: (String) -> Unit,
+    onHttpBasicAuthPasswordChange: (String) -> Unit,
+    onAcceptInvalidCertsChange: (Boolean) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onToggle)
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.settings_advanced_network),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = if (expanded) {
+                    Icons.Filled.KeyboardArrowUp
+                } else {
+                    Icons.Filled.KeyboardArrowDown
+                },
+                contentDescription = stringResource(
+                    if (expanded) R.string.collapse else R.string.expand
+                ),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically(),
+            exit = shrinkVertically()
+        ) {
+            Column {
+                SettingsSpacer(8)
+
+                OutlinedTextField(
+                    value = uiState.secondaryServerUrl,
+                    onValueChange = onSecondaryServerUrlChange,
+                    label = { Text(stringResource(R.string.settings_secondary_url_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_secondary_url_placeholder)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    enabled = !uiState.isTesting && !uiState.isSaving
+                )
+
+                FieldHint(stringResource(R.string.settings_secondary_url_hint))
+
+                SettingsSpacer()
+
+                OutlinedTextField(
+                    value = uiState.apiToken,
+                    onValueChange = onApiTokenChange,
+                    label = { Text(stringResource(R.string.settings_api_token_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_api_token_placeholder)) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("tokenInput"),
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        VisibilityToggle(
+                            visible = passwordVisible,
+                            onToggle = { onPasswordVisibleChange(!passwordVisible) },
+                            showDescription = R.string.show_token,
+                            hideDescription = R.string.hide_token
+                        )
+                    },
+                    enabled = !uiState.isTesting && !uiState.isSaving
+                )
+
+                FieldHint(stringResource(R.string.settings_api_token_hint))
+
+                SettingsSpacer()
+
+                OutlinedTextField(
+                    value = uiState.httpBasicAuthUsername,
+                    onValueChange = onHttpBasicAuthUsernameChange,
+                    label = { Text(stringResource(R.string.settings_http_basic_auth_username_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_http_basic_auth_username_placeholder)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    enabled = !uiState.isTesting && !uiState.isSaving
+                )
+
+                SettingsSpacer(8)
+
+                OutlinedTextField(
+                    value = uiState.httpBasicAuthPassword,
+                    onValueChange = onHttpBasicAuthPasswordChange,
+                    label = { Text(stringResource(R.string.settings_http_basic_auth_password_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_http_basic_auth_password_placeholder)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    visualTransformation = if (basicAuthPasswordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        VisibilityToggle(
+                            visible = basicAuthPasswordVisible,
+                            onToggle = { onBasicAuthPasswordVisibleChange(!basicAuthPasswordVisible) },
+                            showDescription = R.string.show_password,
+                            hideDescription = R.string.hide_password
+                        )
+                    },
+                    enabled = !uiState.isTesting && !uiState.isSaving
+                )
+
+                FieldHint(stringResource(R.string.settings_http_basic_auth_hint))
+
+                SettingsSpacer()
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.settings_accept_invalid_certs),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_accept_invalid_certs_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = uiState.acceptInvalidCerts,
+                        onCheckedChange = onAcceptInvalidCertsChange,
+                        enabled = !uiState.isTesting && !uiState.isSaving
+                    )
+                }
+
+                if (uiState.acceptInvalidCerts) {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = StatusWarning.copy(alpha = 0.1f)
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Warning,
+                                contentDescription = null,
+                                tint = StatusWarning,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.settings_accept_invalid_certs_warning),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = StatusWarning
+                            )
+                        }
+                    }
+                }
+
+                SettingsSpacer(8)
+            }
+        }
+    }
+}
+
+@Composable
+private fun VisibilityToggle(
+    visible: Boolean,
+    onToggle: () -> Unit,
+    showDescription: Int,
+    hideDescription: Int
+) {
+    IconButton(onClick = onToggle) {
+        Icon(
+            imageVector = if (visible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+            contentDescription = stringResource(if (visible) hideDescription else showDescription)
+        )
+    }
+}
+
+@Composable
+private fun FieldHint(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 4.dp)
+    )
+}
+
+@Composable
+private fun TestResultCard(result: TestResult) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            ServerTestResultRow(
+                label = stringResource(R.string.settings_primary_server),
+                result = result.primaryResult
+            )
+
+            result.secondaryResult?.let { secondaryResult ->
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                ServerTestResultRow(
+                    label = stringResource(R.string.settings_secondary_server),
+                    result = secondaryResult
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServerTestResultRow(
+    label: String,
+    result: ServerTestResult
+) {
+    val connectedText = stringResource(R.string.settings_connected)
+    val (icon, color, statusText) = when (result) {
+        is ServerTestResult.Success -> Triple(
+            Icons.Filled.CheckCircle,
+            StatusSuccess,
+            connectedText
+        )
+        is ServerTestResult.Failure -> Triple(
+            Icons.Filled.Error,
+            StatusError,
+            result.message
+        )
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = statusText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = color
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionSettingsPreview() {
+    MateDroidTheme {
+        ConnectionSettingsContent(
+            uiState = SettingsUiState(
+                isLoading = false,
+                serverUrl = "https://teslamate.example.com"
+            ),
+            isOnboarding = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onServerUrlChange = {},
+            onSecondaryServerUrlChange = {},
+            onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
+            onAcceptInvalidCertsChange = {},
+            onTestConnection = {},
+            onSave = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionSettingsOnboardingPreview() {
+    MateDroidTheme {
+        ConnectionSettingsContent(
+            uiState = SettingsUiState(isLoading = false),
+            isOnboarding = true,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = null,
+            onServerUrlChange = {},
+            onSecondaryServerUrlChange = {},
+            onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
+            onAcceptInvalidCertsChange = {},
+            onTestConnection = {},
+            onSave = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionSettingsWithResultPreview() {
+    MateDroidTheme {
+        ConnectionSettingsContent(
+            uiState = SettingsUiState(
+                isLoading = false,
+                serverUrl = "https://teslamate.example.com",
+                secondaryServerUrl = "https://teslamate.local",
+                testResult = TestResult(
+                    primaryResult = ServerTestResult.Failure("Connection timed out"),
+                    secondaryResult = ServerTestResult.Success
+                )
+            ),
+            isOnboarding = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onServerUrlChange = {},
+            onSecondaryServerUrlChange = {},
+            onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
+            onAcceptInvalidCertsChange = {},
+            onTestConnection = {},
+            onSave = {}
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DataSyncSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DataSyncSettingsScreen.kt
@@ -1,0 +1,175 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.matedroid.R
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.screens.settings.SettingsViewModel
+import com.matedroid.ui.theme.MateDroidTheme
+import com.matedroid.ui.theme.StatusError
+import com.matedroid.ui.theme.StatusWarning
+
+/**
+ * Maintenance actions on the local cache. Destructive operations confirm first.
+ */
+@Composable
+fun DataSyncSettingsScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(uiState.successMessage) {
+        uiState.successMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSuccessMessage()
+        }
+    }
+
+    DataSyncSettingsContent(
+        isResyncing = uiState.isResyncing,
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onForceResync = viewModel::forceResync
+    )
+}
+
+@Composable
+private fun DataSyncSettingsContent(
+    isResyncing: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onForceResync: () -> Unit
+) {
+    var showResyncConfirmDialog by remember { mutableStateOf(false) }
+
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_data),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState
+    ) {
+        SettingsGroupHeader(stringResource(R.string.settings_group_maintenance))
+
+        OutlinedButton(
+            onClick = { showResyncConfirmDialog = true },
+            enabled = !isResyncing,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            if (isResyncing) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(
+                stringResource(
+                    if (isResyncing) R.string.settings_resyncing else R.string.settings_resync_button
+                )
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.settings_resync_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+
+        SettingsSpacer()
+
+        if (showResyncConfirmDialog) {
+            AlertDialog(
+                onDismissRequest = { showResyncConfirmDialog = false },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = StatusWarning,
+                        modifier = Modifier.size(32.dp)
+                    )
+                },
+                title = { Text(stringResource(R.string.settings_resync_dialog_title)) },
+                text = {
+                    Text(
+                        buildAnnotatedString {
+                            append(stringResource(R.string.settings_resync_dialog_text_prefix))
+                            withStyle(SpanStyle(color = StatusError, fontWeight = FontWeight.Bold)) {
+                                append(stringResource(R.string.settings_resync_dialog_text_delete))
+                            }
+                            append(stringResource(R.string.settings_resync_dialog_text_suffix))
+                        }
+                    )
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            showResyncConfirmDialog = false
+                            onForceResync()
+                        }
+                    ) {
+                        Text(stringResource(R.string.settings_resync_confirm))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showResyncConfirmDialog = false }) {
+                        Text(stringResource(R.string.cancel))
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DataSyncSettingsPreview() {
+    MateDroidTheme {
+        DataSyncSettingsContent(
+            isResyncing = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onForceResync = {}
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DebugSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DebugSettingsScreen.kt
@@ -1,0 +1,175 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.matedroid.R
+import com.matedroid.data.local.TirePosition
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.screens.settings.SettingsViewModel
+import com.matedroid.ui.theme.MateDroidTheme
+
+/**
+ * Developer tools. Only reachable in debug builds — [com.matedroid.ui.screens.settings.SettingsSection.DEBUG]
+ * is filtered out of the hub for release builds.
+ */
+@Composable
+fun DebugSettingsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToPalettePreview: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.successMessage) {
+        uiState.successMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSuccessMessage()
+        }
+    }
+
+    DebugSettingsContent(
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onPalettePreview = onNavigateToPalettePreview,
+        onSimulateTpmsWarning = viewModel::simulateTpmsWarning,
+        onClearTpmsWarning = viewModel::clearTpmsWarning,
+        onRunTpmsCheckNow = viewModel::runTpmsCheckNow,
+        onSimulateSentryEvent = viewModel::simulateSentryEvent
+    )
+}
+
+@Composable
+private fun DebugSettingsContent(
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onPalettePreview: () -> Unit,
+    onSimulateTpmsWarning: (TirePosition) -> Unit,
+    onClearTpmsWarning: () -> Unit,
+    onRunTpmsCheckNow: () -> Unit,
+    onSimulateSentryEvent: () -> Unit
+) {
+    var tpmsDropdownExpanded by remember { mutableStateOf(false) }
+
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_debug),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState
+    ) {
+        SettingsGroupHeader(stringResource(R.string.settings_group_appearance_debug))
+
+        OutlinedButton(
+            onClick = onPalettePreview,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.settings_palette_preview))
+        }
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_tpms_debug))
+
+        Box {
+            OutlinedButton(
+                onClick = { tpmsDropdownExpanded = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.debug_tpms_simulate_warning))
+                Icon(
+                    imageVector = Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+
+            DropdownMenu(
+                expanded = tpmsDropdownExpanded,
+                onDismissRequest = { tpmsDropdownExpanded = false }
+            ) {
+                TirePosition.entries.forEach { tire ->
+                    val tireName = when (tire) {
+                        TirePosition.FL -> stringResource(R.string.tire_fl_full)
+                        TirePosition.FR -> stringResource(R.string.tire_fr_full)
+                        TirePosition.RL -> stringResource(R.string.tire_rl_full)
+                        TirePosition.RR -> stringResource(R.string.tire_rr_full)
+                    }
+                    DropdownMenuItem(
+                        text = { Text(tireName) },
+                        onClick = {
+                            tpmsDropdownExpanded = false
+                            onSimulateTpmsWarning(tire)
+                        }
+                    )
+                }
+            }
+        }
+
+        SettingsSpacer(8)
+
+        OutlinedButton(
+            onClick = onClearTpmsWarning,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.debug_tpms_clear_state))
+        }
+
+        SettingsSpacer(8)
+
+        OutlinedButton(
+            onClick = onRunTpmsCheckNow,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.debug_tpms_run_now))
+        }
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_sentry_debug))
+
+        OutlinedButton(
+            onClick = onSimulateSentryEvent,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.debug_sentry_simulate_event))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DebugSettingsPreview() {
+    MateDroidTheme {
+        DebugSettingsContent(
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onPalettePreview = {},
+            onSimulateTpmsWarning = {},
+            onClearTpmsWarning = {},
+            onRunTpmsCheckNow = {},
+            onSimulateSentryEvent = {}
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
@@ -1,0 +1,170 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.matedroid.R
+import com.matedroid.data.model.Currency
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.screens.settings.SettingsSwitchRow
+import com.matedroid.ui.screens.settings.SettingsViewModel
+import com.matedroid.ui.theme.MateDroidTheme
+
+/**
+ * How data is presented: currency for costs, and which entries the lists include.
+ * Every control here writes through immediately — there is no save button.
+ */
+@Composable
+fun DisplaySettingsScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    DisplaySettingsContent(
+        currencyCode = uiState.currencyCode,
+        showShortDrivesCharges = uiState.showShortDrivesCharges,
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onCurrencyChange = viewModel::updateCurrency,
+        onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges
+    )
+}
+
+@Composable
+private fun DisplaySettingsContent(
+    currencyCode: String,
+    showShortDrivesCharges: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onCurrencyChange: (String) -> Unit,
+    onShowShortDrivesChargesChange: (Boolean) -> Unit
+) {
+    var currencyDropdownExpanded by remember { mutableStateOf(false) }
+    var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
+
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_display),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState
+    ) {
+        SettingsGroupHeader(stringResource(R.string.settings_group_costs))
+
+        val selectedCurrency = Currency.findByCode(currencyCode)
+
+        Box {
+            OutlinedTextField(
+                value = "${selectedCurrency.symbol} ${selectedCurrency.code} - ${selectedCurrency.name}",
+                onValueChange = {},
+                label = { Text(stringResource(R.string.settings_currency_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                readOnly = true,
+                trailingIcon = {
+                    IconButton(onClick = { currencyDropdownExpanded = true }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowDropDown,
+                            contentDescription = stringResource(R.string.settings_currency_select)
+                        )
+                    }
+                }
+            )
+
+            DropdownMenu(
+                expanded = currencyDropdownExpanded,
+                onDismissRequest = { currencyDropdownExpanded = false },
+                modifier = Modifier.fillMaxWidth(0.9f)
+            ) {
+                Currency.ALL.forEach { currency ->
+                    DropdownMenuItem(
+                        text = {
+                            Text("${currency.symbol} ${currency.code} - ${currency.name}")
+                        },
+                        onClick = {
+                            onCurrencyChange(currency.code)
+                            currencyDropdownExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_lists))
+
+        SettingsSwitchRow(
+            title = stringResource(R.string.settings_show_short_label),
+            hint = stringResource(R.string.settings_show_short_hint),
+            checked = showShortDrivesCharges,
+            onCheckedChange = onShowShortDrivesChargesChange,
+            trailingTitleContent = {
+                IconButton(
+                    onClick = { showShortDrivesChargesInfoDialog = true },
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = stringResource(R.string.more_information),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        )
+
+        if (showShortDrivesChargesInfoDialog) {
+            AlertDialog(
+                onDismissRequest = { showShortDrivesChargesInfoDialog = false },
+                title = { Text(stringResource(R.string.settings_short_dialog_title)) },
+                text = { Text(stringResource(R.string.settings_short_dialog_text)) },
+                confirmButton = {
+                    TextButton(onClick = { showShortDrivesChargesInfoDialog = false }) {
+                        Text(stringResource(R.string.ok))
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DisplaySettingsPreview() {
+    MateDroidTheme {
+        DisplaySettingsContent(
+            currencyCode = "EUR",
+            showShortDrivesCharges = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onCurrencyChange = {},
+            onShowShortDrivesChargesChange = {}
+        )
+    }
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/NotificationSettingsScreen.kt
@@ -1,0 +1,143 @@
+package com.matedroid.ui.screens.settings.sections
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.TireRepair
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.notification.ChargingNotificationManager
+import com.matedroid.notification.SentryNotificationManager
+import com.matedroid.data.sync.TpmsPressureWorker
+import com.matedroid.ui.screens.settings.SettingsGroupHeader
+import com.matedroid.ui.screens.settings.SettingsLinkRow
+import com.matedroid.ui.screens.settings.SettingsSectionScaffold
+import com.matedroid.ui.screens.settings.SettingsSpacer
+import com.matedroid.ui.theme.MateDroidTheme
+
+/**
+ * Notification settings hand off to the Android system UI rather than duplicating the
+ * per-channel toggles in-app: the OS already owns sound, importance and Do Not Disturb
+ * for each channel, and an in-app copy would drift out of sync with it.
+ */
+@Composable
+fun NotificationSettingsScreen(
+    onNavigateBack: () -> Unit
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    NotificationSettingsContent(
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onOpenChannel = { channelId -> context.openNotificationChannelSettings(channelId) },
+        onOpenAppNotifications = { context.openAppNotificationSettings() }
+    )
+}
+
+@Composable
+private fun NotificationSettingsContent(
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onOpenChannel: (String) -> Unit,
+    onOpenAppNotifications: () -> Unit
+) {
+    SettingsSectionScaffold(
+        title = stringResource(R.string.settings_section_notifications),
+        onBack = onNavigateBack,
+        snackbarHostState = snackbarHostState
+    ) {
+        Text(
+            text = stringResource(R.string.settings_notifications_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_channels))
+
+        SettingsLinkRow(
+            title = stringResource(R.string.charging_channel_name),
+            hint = stringResource(R.string.charging_channel_description),
+            icon = Icons.Filled.Bolt,
+            onClick = { onOpenChannel(ChargingNotificationManager.CHANNEL_ID) }
+        )
+
+        SettingsLinkRow(
+            title = stringResource(R.string.sentry_channel_name),
+            hint = stringResource(R.string.sentry_channel_description),
+            icon = Icons.Filled.Security,
+            onClick = { onOpenChannel(SentryNotificationManager.CHANNEL_ID) }
+        )
+
+        SettingsLinkRow(
+            title = stringResource(R.string.tpms_channel_name),
+            hint = stringResource(R.string.tpms_channel_description),
+            icon = Icons.Filled.TireRepair,
+            onClick = { onOpenChannel(TpmsPressureWorker.CHANNEL_ID) }
+        )
+
+        SettingsSpacer(8)
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+        SettingsLinkRow(
+            title = stringResource(R.string.settings_notifications_all_title),
+            hint = stringResource(R.string.settings_notifications_all_hint),
+            icon = Icons.Filled.NotificationsActive,
+            onClick = onOpenAppNotifications
+        )
+    }
+}
+
+/**
+ * Opens the system page for one channel. A channel only exists once it has been created,
+ * which happens the first time that kind of notification fires — until then the intent is
+ * rejected, so fall back to the app-level notification page.
+ */
+private fun Context.openNotificationChannelSettings(channelId: String) {
+    val channelIntent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    val launched = runCatching { startActivity(channelIntent) }.isSuccess
+    if (!launched) {
+        openAppNotificationSettings()
+    }
+}
+
+private fun Context.openAppNotificationSettings() {
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    runCatching { startActivity(intent) }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NotificationSettingsPreview() {
+    MateDroidTheme {
+        NotificationSettingsContent(
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onOpenChannel = {},
+            onOpenAppNotifications = {}
+        )
+    }
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -199,6 +199,48 @@
     <string name="collapse">Contraure</string>
     <string name="expand">Expandir</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">Connexió</string>
+    <string name="settings_section_connection_summary">URL del servidor i credencials</string>
+    <string name="settings_section_display">Pantalla</string>
+    <string name="settings_section_display_summary">Moneda i contingut de les llistes</string>
+    <string name="settings_section_notifications">Notificacions</string>
+    <string name="settings_section_notifications_summary">Alertes de càrrega, Sentinella i pneumàtics</string>
+    <string name="settings_section_data">Dades i sincronització</string>
+    <string name="settings_section_data_summary">Manteniment de les dades desades</string>
+    <string name="settings_section_about">Quant a</string>
+    <string name="settings_section_about_summary">Versió i suport</string>
+    <string name="settings_section_debug">Eines de depuració</string>
+    <string name="settings_section_debug_summary">Opcions per a desenvolupadors</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">Sense configurar</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">Costos</string>
+    <string name="settings_group_lists">Llistes</string>
+    <string name="settings_group_channels">Canals de notificació</string>
+    <string name="settings_group_maintenance">Manteniment</string>
+    <string name="settings_group_support">Suport</string>
+    <string name="settings_group_appearance_debug">Aparença</string>
+    <string name="settings_group_tpms_debug">Pressió dels pneumàtics</string>
+    <string name="settings_group_sentry_debug">Sentinella</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">Android gestiona les notificacions de MateDroid. Toca una categoria per canviar-ne el so, la importància o desactivar-la.</string>
+    <string name="settings_notifications_all_title">Totes les notificacions de MateDroid</string>
+    <string name="settings_notifications_all_hint">Obre la configuració de notificacions del sistema per a l\'app</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">Desa</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">Configuració desada</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">Informa d\'un error o demana una funció a GitHub</string>
+    <string name="settings_source_code">Codi font</string>
+    <string name="settings_source_code_hint">Explora el projecte a GitHub</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">Connecta a TeslamateApi</string>
     <string name="settings_connect_description">Introdueix l\'URL del teu servidor TeslamateApi per connectar.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -195,10 +195,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">Carregant configuració…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">Contraure</string>
-    <string name="expand">Expandir</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">Connexió</string>
     <string name="settings_section_connection_summary">URL del servidor i credencials</string>
@@ -217,6 +213,9 @@
     <string name="settings_not_configured">Sense configurar</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">Servidor</string>
+    <string name="settings_group_authentication">Autenticació</string>
+    <string name="settings_group_security">Seguretat</string>
     <string name="settings_group_costs">Costos</string>
     <string name="settings_group_lists">Llistes</string>
     <string name="settings_group_channels">Canals de notificació</string>
@@ -248,9 +247,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del servidor</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">Configuració de xarxa avançada</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">URL del servidor secundari (opcional)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -199,6 +199,48 @@
     <string name="collapse">Einklappen</string>
     <string name="expand">Ausklappen</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">Verbindung</string>
+    <string name="settings_section_connection_summary">Server-URL und Zugangsdaten</string>
+    <string name="settings_section_display">Anzeige</string>
+    <string name="settings_section_display_summary">Währung und Listeninhalte</string>
+    <string name="settings_section_notifications">Benachrichtigungen</string>
+    <string name="settings_section_notifications_summary">Lade-, Sentry- und Reifenwarnungen</string>
+    <string name="settings_section_data">Daten &amp; Synchronisierung</string>
+    <string name="settings_section_data_summary">Wartung der gespeicherten Daten</string>
+    <string name="settings_section_about">Über</string>
+    <string name="settings_section_about_summary">Version und Support</string>
+    <string name="settings_section_debug">Debug-Werkzeuge</string>
+    <string name="settings_section_debug_summary">Entwickleroptionen</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">Nicht eingerichtet</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">Kosten</string>
+    <string name="settings_group_lists">Listen</string>
+    <string name="settings_group_channels">Benachrichtigungskanäle</string>
+    <string name="settings_group_maintenance">Wartung</string>
+    <string name="settings_group_support">Support</string>
+    <string name="settings_group_appearance_debug">Darstellung</string>
+    <string name="settings_group_tpms_debug">Reifendruck</string>
+    <string name="settings_group_sentry_debug">Sentry</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">MateDroid-Benachrichtigungen werden von Android verwaltet. Tippe auf eine Kategorie, um Ton und Wichtigkeit zu ändern oder sie abzuschalten.</string>
+    <string name="settings_notifications_all_title">Alle MateDroid-Benachrichtigungen</string>
+    <string name="settings_notifications_all_hint">Systemeinstellungen für App-Benachrichtigungen öffnen</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">Speichern</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">Einstellungen gespeichert</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">Fehler melden oder Funktion auf GitHub vorschlagen</string>
+    <string name="settings_source_code">Quellcode</string>
+    <string name="settings_source_code_hint">Projekt auf GitHub ansehen</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">Mit TeslamateApi verbinden</string>
     <string name="settings_connect_description">Gib die URL deines TeslamateApi-Servers ein, um eine Verbindung herzustellen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -195,10 +195,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">Einstellungen werden geladen…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">Einklappen</string>
-    <string name="expand">Ausklappen</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">Verbindung</string>
     <string name="settings_section_connection_summary">Server-URL und Zugangsdaten</string>
@@ -217,6 +213,9 @@
     <string name="settings_not_configured">Nicht eingerichtet</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">Server</string>
+    <string name="settings_group_authentication">Authentifizierung</string>
+    <string name="settings_group_security">Sicherheit</string>
     <string name="settings_group_costs">Kosten</string>
     <string name="settings_group_lists">Listen</string>
     <string name="settings_group_channels">Benachrichtigungskanäle</string>
@@ -248,9 +247,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">Server-URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">Erweiterte Netzwerkeinstellungen</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">Sekundäre Server-URL (optional)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -199,6 +199,48 @@
     <string name="collapse">Contraer</string>
     <string name="expand">Expandir</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">Conexión</string>
+    <string name="settings_section_connection_summary">URL del servidor y credenciales</string>
+    <string name="settings_section_display">Pantalla</string>
+    <string name="settings_section_display_summary">Moneda y contenido de las listas</string>
+    <string name="settings_section_notifications">Notificaciones</string>
+    <string name="settings_section_notifications_summary">Alertas de carga, Centinela y neumáticos</string>
+    <string name="settings_section_data">Datos y sincronización</string>
+    <string name="settings_section_data_summary">Mantenimiento de los datos guardados</string>
+    <string name="settings_section_about">Acerca de</string>
+    <string name="settings_section_about_summary">Versión y soporte</string>
+    <string name="settings_section_debug">Herramientas de depuración</string>
+    <string name="settings_section_debug_summary">Opciones para desarrolladores</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">Sin configurar</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">Costes</string>
+    <string name="settings_group_lists">Listas</string>
+    <string name="settings_group_channels">Canales de notificación</string>
+    <string name="settings_group_maintenance">Mantenimiento</string>
+    <string name="settings_group_support">Soporte</string>
+    <string name="settings_group_appearance_debug">Apariencia</string>
+    <string name="settings_group_tpms_debug">Presión de neumáticos</string>
+    <string name="settings_group_sentry_debug">Centinela</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">Android gestiona las notificaciones de MateDroid. Toca una categoría para cambiar su sonido, su importancia o desactivarla.</string>
+    <string name="settings_notifications_all_title">Todas las notificaciones de MateDroid</string>
+    <string name="settings_notifications_all_hint">Abrir los ajustes de notificaciones del sistema para la app</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">Guardar</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">Ajustes guardados</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">Informa de un error o solicita una función en GitHub</string>
+    <string name="settings_source_code">Código fuente</string>
+    <string name="settings_source_code_hint">Explora el proyecto en GitHub</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">Conectar a TeslamateApi</string>
     <string name="settings_connect_description">Introduce la URL de tu servidor TeslamateApi para conectar.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -195,10 +195,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">Cargando ajustes…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">Contraer</string>
-    <string name="expand">Expandir</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">Conexión</string>
     <string name="settings_section_connection_summary">URL del servidor y credenciales</string>
@@ -217,6 +213,9 @@
     <string name="settings_not_configured">Sin configurar</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">Servidor</string>
+    <string name="settings_group_authentication">Autenticación</string>
+    <string name="settings_group_security">Seguridad</string>
     <string name="settings_group_costs">Costes</string>
     <string name="settings_group_lists">Listas</string>
     <string name="settings_group_channels">Canales de notificación</string>
@@ -248,9 +247,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del servidor</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">Ajustes de red avanzados</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">URL del servidor secundario (opcional)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -199,6 +199,48 @@
     <string name="collapse">Comprimi</string>
     <string name="expand">Espandi</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">Connessione</string>
+    <string name="settings_section_connection_summary">URL del server e credenziali</string>
+    <string name="settings_section_display">Visualizzazione</string>
+    <string name="settings_section_display_summary">Valuta e contenuto degli elenchi</string>
+    <string name="settings_section_notifications">Notifiche</string>
+    <string name="settings_section_notifications_summary">Avvisi ricarica, Sentinella e gomme</string>
+    <string name="settings_section_data">Dati e sincronizzazione</string>
+    <string name="settings_section_data_summary">Manutenzione dei dati salvati</string>
+    <string name="settings_section_about">Informazioni</string>
+    <string name="settings_section_about_summary">Versione e assistenza</string>
+    <string name="settings_section_debug">Strumenti di debug</string>
+    <string name="settings_section_debug_summary">Opzioni per sviluppatori</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">Non configurato</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">Costi</string>
+    <string name="settings_group_lists">Elenchi</string>
+    <string name="settings_group_channels">Canali di notifica</string>
+    <string name="settings_group_maintenance">Manutenzione</string>
+    <string name="settings_group_support">Assistenza</string>
+    <string name="settings_group_appearance_debug">Aspetto</string>
+    <string name="settings_group_tpms_debug">Pressione gomme</string>
+    <string name="settings_group_sentry_debug">Sentinella</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">Le notifiche di MateDroid sono gestite da Android. Tocca una categoria per cambiarne il suono, l\'importanza o disattivarla.</string>
+    <string name="settings_notifications_all_title">Tutte le notifiche di MateDroid</string>
+    <string name="settings_notifications_all_hint">Apri le impostazioni di sistema delle notifiche dell\'app</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">Salva</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">Impostazioni salvate</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">Segnala un bug o richiedi una funzione su GitHub</string>
+    <string name="settings_source_code">Codice sorgente</string>
+    <string name="settings_source_code_hint">Esplora il progetto su GitHub</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">Connetti a TeslamateApi</string>
     <string name="settings_connect_description">Inserisci l\'URL del server TeslamateApi per connetterti.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -195,10 +195,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">Caricamento impostazioni…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">Comprimi</string>
-    <string name="expand">Espandi</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">Connessione</string>
     <string name="settings_section_connection_summary">URL del server e credenziali</string>
@@ -217,6 +213,9 @@
     <string name="settings_not_configured">Non configurato</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">Server</string>
+    <string name="settings_group_authentication">Autenticazione</string>
+    <string name="settings_group_security">Sicurezza</string>
     <string name="settings_group_costs">Costi</string>
     <string name="settings_group_lists">Elenchi</string>
     <string name="settings_group_channels">Canali di notifica</string>
@@ -248,9 +247,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del server</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">Impostazioni di rete avanzate</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">URL server secondario (opzionale)</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -199,6 +199,48 @@
     <string name="collapse">收起</string>
     <string name="expand">展开</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">连接</string>
+    <string name="settings_section_connection_summary">服务器地址和凭据</string>
+    <string name="settings_section_display">显示</string>
+    <string name="settings_section_display_summary">货币和列表内容</string>
+    <string name="settings_section_notifications">通知</string>
+    <string name="settings_section_notifications_summary">充电、哨兵和胎压提醒</string>
+    <string name="settings_section_data">数据与同步</string>
+    <string name="settings_section_data_summary">缓存数据维护</string>
+    <string name="settings_section_about">关于</string>
+    <string name="settings_section_about_summary">版本与支持</string>
+    <string name="settings_section_debug">调试工具</string>
+    <string name="settings_section_debug_summary">开发者选项</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">尚未配置</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">费用</string>
+    <string name="settings_group_lists">列表</string>
+    <string name="settings_group_channels">通知渠道</string>
+    <string name="settings_group_maintenance">维护</string>
+    <string name="settings_group_support">支持</string>
+    <string name="settings_group_appearance_debug">外观</string>
+    <string name="settings_group_tpms_debug">胎压</string>
+    <string name="settings_group_sentry_debug">哨兵</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">MateDroid 的通知由 Android 管理。点按某个类别即可更改提示音、重要程度或将其关闭。</string>
+    <string name="settings_notifications_all_title">所有 MateDroid 通知</string>
+    <string name="settings_notifications_all_hint">打开系统的应用通知设置</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">保存</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">设置已保存</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">在 GitHub 上报告问题或提出功能建议</string>
+    <string name="settings_source_code">源代码</string>
+    <string name="settings_source_code_hint">在 GitHub 上浏览项目</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">连接 TeslamateApi</string>
     <string name="settings_connect_description">输入你的 TeslamateApi 服务器 URL 以连接。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -195,10 +195,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">正在加载设置…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">收起</string>
-    <string name="expand">展开</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">连接</string>
     <string name="settings_section_connection_summary">服务器地址和凭据</string>
@@ -217,6 +213,9 @@
     <string name="settings_not_configured">尚未配置</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">服务器</string>
+    <string name="settings_group_authentication">身份验证</string>
+    <string name="settings_group_security">安全</string>
     <string name="settings_group_costs">费用</string>
     <string name="settings_group_lists">列表</string>
     <string name="settings_group_channels">通知渠道</string>
@@ -248,9 +247,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">服务器 URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">高级网络设置</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">备用服务器 URL（可选）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,10 +198,6 @@
     <!-- Shown while loading settings from storage -->
     <string name="loading_settings">Loading settings…</string>
 
-    <!-- Content description for expand/collapse section arrows -->
-    <string name="collapse">Collapse</string>
-    <string name="expand">Expand</string>
-
     <!-- Settings hub: category names shown in the settings list, one per detail page -->
     <string name="settings_section_connection">Connection</string>
     <string name="settings_section_connection_summary">Server URL and credentials</string>
@@ -220,6 +216,9 @@
     <string name="settings_not_configured">Not configured</string>
 
     <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_server">Server</string>
+    <string name="settings_group_authentication">Authentication</string>
+    <string name="settings_group_security">Security</string>
     <string name="settings_group_costs">Costs</string>
     <string name="settings_group_lists">Lists</string>
     <string name="settings_group_channels">Notification channels</string>
@@ -251,9 +250,6 @@
     <!-- Server URL field -->
     <string name="settings_server_url_label">Server URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>
-
-    <!-- Advanced network settings section (collapsible) -->
-    <string name="settings_advanced_network">Advanced network settings</string>
 
     <!-- Secondary server URL field -->
     <string name="settings_secondary_url_label">Secondary Server URL (optional)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,48 @@
     <string name="collapse">Collapse</string>
     <string name="expand">Expand</string>
 
+    <!-- Settings hub: category names shown in the settings list, one per detail page -->
+    <string name="settings_section_connection">Connection</string>
+    <string name="settings_section_connection_summary">Server URL and credentials</string>
+    <string name="settings_section_display">Display</string>
+    <string name="settings_section_display_summary">Currency and list contents</string>
+    <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_notifications_summary">Charging, sentry and tire alerts</string>
+    <string name="settings_section_data">Data &amp; sync</string>
+    <string name="settings_section_data_summary">Cached data maintenance</string>
+    <string name="settings_section_about">About</string>
+    <string name="settings_section_about_summary">Version and support</string>
+    <string name="settings_section_debug">Debug tools</string>
+    <string name="settings_section_debug_summary">Developer options</string>
+
+    <!-- Summary shown in the settings hub when no server has been set up yet -->
+    <string name="settings_not_configured">Not configured</string>
+
+    <!-- Group headers inside settings detail pages -->
+    <string name="settings_group_costs">Costs</string>
+    <string name="settings_group_lists">Lists</string>
+    <string name="settings_group_channels">Notification channels</string>
+    <string name="settings_group_maintenance">Maintenance</string>
+    <string name="settings_group_support">Support</string>
+    <string name="settings_group_appearance_debug">Appearance</string>
+    <string name="settings_group_tpms_debug">Tire pressure</string>
+    <string name="settings_group_sentry_debug">Sentry</string>
+
+    <!-- Notifications settings page -->
+    <string name="settings_notifications_description">MateDroid notifications are managed by Android. Tap a category to change its sound, importance, or turn it off.</string>
+    <string name="settings_notifications_all_title">All MateDroid notifications</string>
+    <string name="settings_notifications_all_hint">Open the system notification settings for the app</string>
+
+    <!-- Save button on the connection page when not in first-run setup -->
+    <string name="settings_save_short">Save</string>
+    <!-- Snackbar confirmation after saving connection settings -->
+    <string name="settings_saved">Settings saved</string>
+
+    <!-- About page -->
+    <string name="settings_report_issue_hint">Report a bug or request a feature on GitHub</string>
+    <string name="settings_source_code">Source code</string>
+    <string name="settings_source_code_hint">Browse the project on GitHub</string>
+
     <!-- Server connection section -->
     <string name="settings_connect_title">Connect to TeslamateApi</string>
     <string name="settings_connect_description">Enter your TeslamateApi server URL to connect.</string>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,6 +55,30 @@ If the screen has a car palette in scope pass `palette.accent`; otherwise leave 
 
 Never instantiate an osmdroid `MapView` inside a raw `AndroidView` — use `RouteMapView` (in `ui/components/RouteMapView.kt`). It owns the shared boilerplate: MAPNIK tile source, gesture handling (`MapGestureMode.TWO_FINGER_PAN` for maps embedded in scrollable pages, `INERT` for tap-through mini-maps, `FULL` for fullscreen), the optional dim/desaturate tile filter (`dimTiles`), an optional 120 ms deferred mount (`deferMount`) so the first frame paints before osmdroid's synchronous constructor runs, and the mandatory `onDetach()` on release. Screen-specific content goes through `onMapReady` (one-time setup: markers, polylines, zoom/center) and `update` (change-driven passes — guard expensive overlay rebuilds against unchanged inputs, see `TripDetailScreen`/`RegionsVisitedScreen`). The same file exports `mapDimFilter(isDark)` and `boundingBoxOf(points)` for padded route viewports.
 
+### Settings screen architecture
+
+Settings is a **category list → detail page** structure (the pattern Android and iOS system settings use), not a single scrolling form.
+
+- `ui/screens/settings/SettingsScreen.kt` is the **hub**: one tappable card per section, each showing a live summary of its current value. Backed by `SettingsHubViewModel`, which reads the DataStore only — it deliberately does not depend on the repository or sync manager.
+- `ui/screens/settings/SettingsSection.kt` is the **registry**: an enum of sections carrying the navigation id, title/summary string resources, icon, and a `debugOnly` flag. Order of the enum constants is the display order.
+- `ui/screens/settings/sections/` holds one composable per detail page. They share `SettingsViewModel`, each instantiating its own copy via `hiltViewModel()`.
+- `ui/screens/settings/SettingsComponents.kt` holds the shared building blocks: `SettingsSectionScaffold` (top bar + back arrow + snackbar + scrolling column), `SettingsCategoryCard`, `SettingsSwitchRow`, `SettingsLinkRow`, `SettingsGroupHeader`, `SettingsSpacer`.
+
+**Save semantics**: only the Connection page has an explicit Save, because its URL and credentials need validating together. Every other preference writes through to the DataStore the moment it changes — do not add a save button to a new section.
+
+**Navigation**: sections are real destinations (`Screen.SettingsSection(sectionId, onboarding)`), not local state, so the back stack, rotation and deep links work for free. `sectionId` is the stable `SettingsSection.id` string — renaming one breaks existing deep links.
+
+**First run**: when no server is configured, `StartDestinationViewModel` starts directly on the Connection page with `onboarding = true`. That hides the back arrow, skips the hub entirely (the other sections are meaningless without a server), and makes Save continue to the dashboard instead of staying put.
+
+**Notifications** deep-link into the Android per-channel settings rather than duplicating toggles in-app, so sound/importance/DND stay owned by the OS. A channel only exists once its first notification has fired, so the intent falls back to the app-level notification page.
+
+#### Adding a new settings section
+
+1. Add a constant to the `SettingsSection` enum with its id, title/summary string resources and icon.
+2. Add the string resources to all six locale files (see [Adding a New String](#adding-a-new-string)).
+3. Create the composable in `ui/screens/settings/sections/`, wrapping the content in `SettingsSectionScaffold`.
+4. Add the branch to the `when` in `NavGraph.kt`'s `composable<Screen.SettingsSection>`.
+
 ### Localization (i18n)
 
 The app supports multiple languages using Android's standard resource-based localization system. Currently supported languages:


### PR DESCRIPTION
Settings was a single 550-line scrolling column with two collapsible sections buried in it. It is now a **category list → detail page** structure, the pattern Android and iOS system settings use.

## Sections

| Section | Contents |
|---|---|
| **Connection** | Server URL, secondary URL, API token, HTTP Basic Auth, certificate handling, Test/Save |
| **Display** | Currency, show short drives/charges |
| **Notifications** | Deep links to the Android per-channel settings (charging, sentry, tire pressure) + app-level notifications |
| **Data & sync** | Force full resync |
| **About** | Version + git SHA, report an issue, source code |
| **Debug tools** | Palette preview, TPMS simulate/clear/run, simulate sentry event — debug builds only |

## Design decisions

- **Sections are real nav destinations** (`Screen.SettingsSection(sectionId, onboarding)`) rather than local state, so the back stack, rotation and deep links work without extra machinery. `sectionId` is a stable string.
- **Hub rows carry a live summary** of the current value (server host, currency, version), so the value you're looking for is visible without opening the page.
- **Only Connection has an explicit Save.** It needs URL + credentials validated together. Everything else writes through on change, the standard Android behaviour.
- **First run skips the hub entirely** — `StartDestinationViewModel` starts on Connection with `onboarding = true`, which hides the back arrow and makes Save continue to the dashboard. The other sections are meaningless before a server is configured.
- **Notifications hand off to the OS** instead of duplicating per-channel toggles, so sound/importance/DND stay owned by Android. Falls back to the app-level page for channels that haven't fired yet.
- **The Connection page is flat, not accordioned** (second commit). Reaching it is already one level of disclosure; nesting another inside is what made HTTP Basic Auth hard to find for MyTeslaMate users. Fields are grouped under Server / Authentication / Security, matching the other detail pages.

## Notes

- Strings added to all six locales (en, it, es, ca, de, zh); `settings_advanced_network`, `collapse` and `expand` removed as dead.
- `docs/DEVELOPMENT.md` documents the architecture and how to add a new section.
- Fixes the sticky Test/Save bar overlapping the system nav bar (`bottomBar` sits outside Scaffold's inset padding).

## Verification

`lintDebug` and `testDebugUnitTest` pass. Installed on device and walked through the hub, Connection, Notifications and Debug pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)