### PR TITLE
Make the short drive/charge thresholds configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The "short drives / charges" thresholds are now configurable** (Settings → Display) — pick the minimum drive duration, minimum drive distance and minimum charge energy that count as worth listing, instead of the previously fixed 1 min / 1 km / 0.1 kWh. Each can also be set to "no minimum". As before, hidden entries are still counted in every total, average and statistic, so changing a threshold only affects what the lists show — no resync needed.
+
 ### Changed
 - **Settings are now split into sections** — instead of one long scrolling page, Settings opens a list of categories (Connection, Display, Notifications, Data & sync, About) that each open their own page. The new Notifications page links straight to Android's per-channel settings for charging, sentry and tire-pressure alerts, and the first-run setup now shows only the connection form. Connection settings still have an explicit Save; everything else applies as soon as you change it.
 - **Connection settings are no longer hidden behind "Advanced network settings"** — the secondary server URL, API token, HTTP Basic Auth and certificate options are now laid out in plain view under Server, Authentication and Security headings. If you use MyTeslaMate, the Basic Auth fields you need are visible as soon as you open the page.

--- a/app/src/main/java/com/matedroid/MateDroidApp.kt
+++ b/app/src/main/java/com/matedroid/MateDroidApp.kt
@@ -17,6 +17,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.sync.ChargingNotificationWorker
 import com.matedroid.data.sync.DataSyncWorker
 import com.matedroid.data.sync.TpmsPressureWorker
+import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.domain.UnitSystem
 import com.matedroid.notification.SentryNotificationManager
 import dagger.hilt.android.HiltAndroidApp
@@ -53,6 +54,14 @@ class MateDroidApp : Application(), Configuration.Provider {
         // Restore the last known unit system before any trip detection / filtering runs.
         appScope.launch {
             UnitSystem.isImperial = settingsDataStore.isImperial.first()
+        }
+
+        // Restore the user's short drive/charge thresholds into their process-wide mirror.
+        appScope.launch {
+            val settings = settingsDataStore.settings.first()
+            ShortEntryFilter.minDriveDurationMin = settings.shortDriveMinDurationMin
+            ShortEntryFilter.minDriveDistance = settings.shortDriveMinDistance
+            ShortEntryFilter.minChargeEnergyKwh = settings.shortChargeMinEnergyKwh
         }
 
         // Configure OSMDroid tile cache (shared across all map screens)

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.matedroid.domain.ShortEntryFilter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -53,6 +55,9 @@ data class AppSettings(
     val acceptInvalidCerts: Boolean = false,
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
+    val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
+    val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
+    val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
     val teslamateBaseUrl: String = "",
     val lastSelectedCarId: Int? = null
 ) {
@@ -75,6 +80,9 @@ class SettingsDataStore @Inject constructor(
     private val acceptInvalidCertsKey = booleanPreferencesKey("accept_invalid_certs")
     private val currencyCodeKey = stringPreferencesKey("currency_code")
     private val showShortDrivesChargesKey = booleanPreferencesKey("show_short_drives_charges")
+    private val shortDriveMinDurationKey = intPreferencesKey("short_drive_min_duration_min")
+    private val shortDriveMinDistanceKey = doublePreferencesKey("short_drive_min_distance")
+    private val shortChargeMinEnergyKey = doublePreferencesKey("short_charge_min_energy_kwh")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
@@ -106,6 +114,12 @@ class SettingsDataStore @Inject constructor(
             acceptInvalidCerts = preferences[acceptInvalidCertsKey] ?: false,
             currencyCode = preferences[currencyCodeKey] ?: "EUR",
             showShortDrivesCharges = preferences[showShortDrivesChargesKey] ?: false,
+            shortDriveMinDurationMin = preferences[shortDriveMinDurationKey]
+                ?: ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
+            shortDriveMinDistance = preferences[shortDriveMinDistanceKey]
+                ?: ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
+            shortChargeMinEnergyKwh = preferences[shortChargeMinEnergyKey]
+                ?: ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
             teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
             lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
@@ -197,6 +211,22 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveShowShortDrivesCharges(show: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[showShortDrivesChargesKey] = show
+        }
+    }
+
+    /**
+     * Thresholds behind the "short drive / charge" rule. Distance is stored in the user's
+     * display unit — see [ShortEntryFilter] for why it is not normalised to km.
+     */
+    suspend fun saveShortEntryThresholds(
+        driveMinDurationMin: Int,
+        driveMinDistance: Double,
+        chargeMinEnergyKwh: Double
+    ) {
+        context.dataStore.edit { preferences ->
+            preferences[shortDriveMinDurationKey] = driveMinDurationMin
+            preferences[shortDriveMinDistanceKey] = driveMinDistance
+            preferences[shortChargeMinEnergyKey] = chargeMinEnergyKwh
         }
     }
 

--- a/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
+++ b/app/src/main/java/com/matedroid/domain/ShortEntryFilter.kt
@@ -7,13 +7,24 @@ import com.matedroid.data.local.entity.DriveSummary
 
 /**
  * Single source of truth for the "short drive / charge" rule behind the
- * `showShortDrivesCharges` setting (Settings → "Show short drives / charges").
+ * `showShortDrivesCharges` setting (Settings → Display → "Show short drives / charges").
  *
  * When the setting is OFF (the default), entries matching the "short" definition are hidden
  * from every list-like surface: the drives list, the charges list, and the trip timelines /
- * leg lists. They are still counted in totals, averages and statistics.
+ * leg lists. They are still counted in totals, averages and statistics — this filter is
+ * purely presentational and never touches what is fetched or stored.
  *
- * "Short" means a drive under 1 minute OR under 1 km, or a charge that added 0.1 kWh or less.
+ * The thresholds are user-configurable (Settings → Display). Like [UnitSystem], this object is
+ * a process-wide mirror of the stored preference: restored at app start by
+ * [com.matedroid.MateDroidApp] and written through by
+ * [com.matedroid.ui.screens.settings.SettingsViewModel] whenever the user picks a new value.
+ * Keeping the mirror here is what lets every [isSignificant] helper stay zero-argument, so no
+ * call site has to thread thresholds through its own state.
+ *
+ * Distances are compared in the user's display unit, NOT in km: TeslamateAPI pre-converts
+ * every distance it returns, and the configured threshold is picked from unit-aware presets,
+ * so both sides of the comparison are already in the same unit. Do not scale through
+ * [UnitSystem] here.
  *
  * IMPORTANT: keep ALL thresholds and the predicate logic here, and never re-implement them at a
  * call site. Any new screen that renders individual drives/charges MUST filter through one of the
@@ -22,25 +33,39 @@ import com.matedroid.data.local.entity.DriveSummary
  */
 object ShortEntryFilter {
     /** A drive shorter than this many minutes is "short". */
-    const val MIN_DRIVE_DURATION_MIN = 1
+    const val DEFAULT_MIN_DRIVE_DURATION_MIN = 1
 
-    /**
-     * A drive shorter than this many km is "short". API distances arrive pre-converted
-     * (km or mi), so the comparison scales this through [UnitSystem.thresholdKmToUserUnits].
-     */
-    const val MIN_DRIVE_DISTANCE_KM = 1.0
+    /** A drive shorter than this, in the user's distance unit, is "short". */
+    const val DEFAULT_MIN_DRIVE_DISTANCE = 1.0
 
     /** A charge that added this much energy (kWh) or less is "short". */
-    const val MIN_CHARGE_ENERGY_KWH = 0.1
+    const val DEFAULT_MIN_CHARGE_ENERGY_KWH = 0.1
+
+    /** Values offered in the Settings pickers. `0` means "no minimum" for that dimension. */
+    val DRIVE_DURATION_PRESETS_MIN = listOf(0, 1, 2, 5, 10)
+    val DRIVE_DISTANCE_PRESETS = listOf(0.0, 0.5, 1.0, 2.0, 5.0, 10.0)
+    val CHARGE_ENERGY_PRESETS_KWH = listOf(0.0, 0.1, 0.5, 1.0, 2.0, 5.0)
+
+    @Volatile
+    var minDriveDurationMin: Int = DEFAULT_MIN_DRIVE_DURATION_MIN
+
+    @Volatile
+    var minDriveDistance: Double = DEFAULT_MIN_DRIVE_DISTANCE
+
+    @Volatile
+    var minChargeEnergyKwh: Double = DEFAULT_MIN_CHARGE_ENERGY_KWH
 
     /** True when a drive is significant enough to show in lists. */
     fun isSignificantDrive(durationMin: Int?, distance: Double?): Boolean =
-        (durationMin ?: 0) >= MIN_DRIVE_DURATION_MIN &&
-            (distance ?: 0.0) >= UnitSystem.thresholdKmToUserUnits(MIN_DRIVE_DISTANCE_KM)
+        (durationMin ?: 0) >= minDriveDurationMin &&
+            (distance ?: 0.0) >= minDriveDistance
 
-    /** True when a charge is significant enough to show in lists. */
+    /**
+     * True when a charge is significant enough to show in lists. A threshold of 0 means
+     * "no minimum" — without the guard the strict `>` would still hide 0 kWh charges.
+     */
     fun isSignificantCharge(energyKwh: Double?): Boolean =
-        (energyKwh ?: 0.0) > MIN_CHARGE_ENERGY_KWH
+        minChargeEnergyKwh <= 0.0 || (energyKwh ?: 0.0) > minChargeEnergyKwh
 }
 
 // Typed helpers — one per model that carries drives/charges. Adding a new drive/charge model?

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TirePosition
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TpmsStateRepository
 import com.matedroid.notification.SentryNotificationManager
@@ -42,6 +43,9 @@ data class SettingsUiState(
     val acceptInvalidCerts: Boolean = false,
     val currencyCode: String = "EUR",
     val showShortDrivesCharges: Boolean = false,
+    val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
+    val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
+    val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
     val isLoading: Boolean = true,
     val isTesting: Boolean = false,
     val isSaving: Boolean = false,
@@ -105,6 +109,9 @@ class SettingsViewModel @Inject constructor(
                 acceptInvalidCerts = settings.acceptInvalidCerts,
                 currencyCode = settings.currencyCode,
                 showShortDrivesCharges = settings.showShortDrivesCharges,
+                shortDriveMinDurationMin = settings.shortDriveMinDurationMin,
+                shortDriveMinDistance = settings.shortDriveMinDistance,
+                shortChargeMinEnergyKwh = settings.shortChargeMinEnergyKwh,
                 isLoading = false
             )
         }
@@ -177,6 +184,40 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showShortDrivesCharges = show)
         viewModelScope.launch {
             settingsDataStore.saveShowShortDrivesCharges(show)
+        }
+    }
+
+    fun updateShortDriveMinDuration(minutes: Int) {
+        _uiState.value = _uiState.value.copy(shortDriveMinDurationMin = minutes)
+        persistShortEntryThresholds()
+    }
+
+    fun updateShortDriveMinDistance(distance: Double) {
+        _uiState.value = _uiState.value.copy(shortDriveMinDistance = distance)
+        persistShortEntryThresholds()
+    }
+
+    fun updateShortChargeMinEnergy(energyKwh: Double) {
+        _uiState.value = _uiState.value.copy(shortChargeMinEnergyKwh = energyKwh)
+        persistShortEntryThresholds()
+    }
+
+    /**
+     * Writes the thresholds to disk and to the [ShortEntryFilter] mirror the lists read from.
+     * The mirror is updated synchronously so a list re-filters on the way back from Settings
+     * rather than on the next app start.
+     */
+    private fun persistShortEntryThresholds() {
+        val state = _uiState.value
+        ShortEntryFilter.minDriveDurationMin = state.shortDriveMinDurationMin
+        ShortEntryFilter.minDriveDistance = state.shortDriveMinDistance
+        ShortEntryFilter.minChargeEnergyKwh = state.shortChargeMinEnergyKwh
+        viewModelScope.launch {
+            settingsDataStore.saveShortEntryThresholds(
+                driveMinDurationMin = state.shortDriveMinDurationMin,
+                driveMinDistance = state.shortDriveMinDistance,
+                chargeMinEnergyKwh = state.shortChargeMinEnergyKwh
+            )
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
@@ -29,12 +29,16 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.matedroid.R
 import com.matedroid.data.model.Currency
+import com.matedroid.domain.ShortEntryFilter
+import com.matedroid.domain.UnitSystem
 import com.matedroid.ui.screens.settings.SettingsGroupHeader
 import com.matedroid.ui.screens.settings.SettingsSectionScaffold
 import com.matedroid.ui.screens.settings.SettingsSpacer
 import com.matedroid.ui.screens.settings.SettingsSwitchRow
 import com.matedroid.ui.screens.settings.SettingsViewModel
 import com.matedroid.ui.theme.MateDroidTheme
+import java.util.Locale
+import kotlin.math.floor
 
 /**
  * How data is presented: currency for costs, and which entries the lists include.
@@ -51,10 +55,16 @@ fun DisplaySettingsScreen(
     DisplaySettingsContent(
         currencyCode = uiState.currencyCode,
         showShortDrivesCharges = uiState.showShortDrivesCharges,
+        shortDriveMinDurationMin = uiState.shortDriveMinDurationMin,
+        shortDriveMinDistance = uiState.shortDriveMinDistance,
+        shortChargeMinEnergyKwh = uiState.shortChargeMinEnergyKwh,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack,
         onCurrencyChange = viewModel::updateCurrency,
-        onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges
+        onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges,
+        onShortDriveMinDurationChange = viewModel::updateShortDriveMinDuration,
+        onShortDriveMinDistanceChange = viewModel::updateShortDriveMinDistance,
+        onShortChargeMinEnergyChange = viewModel::updateShortChargeMinEnergy
     )
 }
 
@@ -62,10 +72,16 @@ fun DisplaySettingsScreen(
 private fun DisplaySettingsContent(
     currencyCode: String,
     showShortDrivesCharges: Boolean,
+    shortDriveMinDurationMin: Int,
+    shortDriveMinDistance: Double,
+    shortChargeMinEnergyKwh: Double,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
     onCurrencyChange: (String) -> Unit,
-    onShowShortDrivesChargesChange: (Boolean) -> Unit
+    onShowShortDrivesChargesChange: (Boolean) -> Unit,
+    onShortDriveMinDurationChange: (Int) -> Unit,
+    onShortDriveMinDistanceChange: (Double) -> Unit,
+    onShortChargeMinEnergyChange: (Double) -> Unit
 ) {
     var currencyDropdownExpanded by remember { mutableStateOf(false) }
     var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
@@ -151,8 +167,141 @@ private fun DisplaySettingsContent(
                 }
             )
         }
+
+        // The thresholds only do anything while short entries are being hidden, so they are
+        // disabled (not removed) when the switch is on — leaving them visible keeps the rule
+        // discoverable and stops the section from reflowing as the switch is toggled.
+        val thresholdsEnabled = !showShortDrivesCharges
+
+        SettingsSpacer()
+
+        Text(
+            text = stringResource(R.string.settings_thresholds_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        SettingsSpacer()
+
+        ThresholdPicker(
+            label = stringResource(R.string.settings_threshold_drive_duration_label),
+            value = shortDriveMinDurationMin,
+            options = ShortEntryFilter.DRIVE_DURATION_PRESETS_MIN,
+            enabled = thresholdsEnabled,
+            optionLabel = { minutes ->
+                if (minutes <= 0) {
+                    stringResource(R.string.settings_threshold_no_minimum)
+                } else {
+                    stringResource(R.string.settings_threshold_value_minutes, minutes)
+                }
+            },
+            onValueChange = onShortDriveMinDurationChange
+        )
+
+        SettingsSpacer()
+
+        ThresholdPicker(
+            label = stringResource(R.string.settings_threshold_drive_distance_label),
+            value = shortDriveMinDistance,
+            options = ShortEntryFilter.DRIVE_DISTANCE_PRESETS,
+            enabled = thresholdsEnabled,
+            optionLabel = { distance ->
+                if (distance <= 0.0) {
+                    stringResource(R.string.settings_threshold_no_minimum)
+                } else {
+                    stringResource(
+                        if (UnitSystem.isImperial) {
+                            R.string.settings_threshold_value_mi
+                        } else {
+                            R.string.settings_threshold_value_km
+                        },
+                        formatThreshold(distance)
+                    )
+                }
+            },
+            onValueChange = onShortDriveMinDistanceChange
+        )
+
+        SettingsSpacer()
+
+        ThresholdPicker(
+            label = stringResource(R.string.settings_threshold_charge_energy_label),
+            value = shortChargeMinEnergyKwh,
+            options = ShortEntryFilter.CHARGE_ENERGY_PRESETS_KWH,
+            enabled = thresholdsEnabled,
+            optionLabel = { energy ->
+                if (energy <= 0.0) {
+                    stringResource(R.string.settings_threshold_no_minimum)
+                } else {
+                    stringResource(R.string.settings_threshold_value_kwh, formatThreshold(energy))
+                }
+            },
+            onValueChange = onShortChargeMinEnergyChange
+        )
     }
 }
+
+/**
+ * Read-only field opening a dropdown of preset values. Generic over the value type so the
+ * minute (Int) and distance/energy (Double) pickers share one implementation.
+ */
+@Composable
+private fun <T> ThresholdPicker(
+    label: String,
+    value: T,
+    options: List<T>,
+    enabled: Boolean,
+    optionLabel: @Composable (T) -> String,
+    onValueChange: (T) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        OutlinedTextField(
+            value = optionLabel(value),
+            onValueChange = {},
+            label = { Text(label) },
+            modifier = Modifier.fillMaxWidth(),
+            readOnly = true,
+            enabled = enabled,
+            trailingIcon = {
+                IconButton(onClick = { expanded = true }, enabled = enabled) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowDropDown,
+                        contentDescription = stringResource(R.string.settings_threshold_select)
+                    )
+                }
+            }
+        )
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Formats a threshold for display, dropping the decimal on whole values ("1" not "1.0") and
+ * using the device locale's decimal separator ("0,5" in Italian/Spanish/Catalan).
+ */
+private fun formatThreshold(value: Double): String =
+    if (value == floor(value)) {
+        value.toInt().toString()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", value)
+    }
 
 @Preview(showBackground = true)
 @Composable
@@ -161,10 +310,16 @@ private fun DisplaySettingsPreview() {
         DisplaySettingsContent(
             currencyCode = "EUR",
             showShortDrivesCharges = false,
+            shortDriveMinDurationMin = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
+            shortDriveMinDistance = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
+            shortChargeMinEnergyKwh = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
             onCurrencyChange = {},
-            onShowShortDrivesChargesChange = {}
+            onShowShortDrivesChargesChange = {},
+            onShortDriveMinDurationChange = {},
+            onShortDriveMinDistanceChange = {},
+            onShortChargeMinEnergyChange = {}
         )
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -216,6 +216,21 @@
     <string name="settings_group_server">Servidor</string>
     <string name="settings_group_authentication">Autenticació</string>
     <string name="settings_group_security">Seguretat</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">Els trajectes i les càrregues per sota d\'aquests valors s\'amaguen de les llistes. Sempre es compten en els totals i les estadístiques.</string>
+    <string name="settings_threshold_drive_duration_label">Durada mínima del trajecte</string>
+    <string name="settings_threshold_drive_distance_label">Distància mínima del trajecte</string>
+    <string name="settings_threshold_charge_energy_label">Energia mínima de la càrrega</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">Sense mínim</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">Selecciona el valor</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">Costos</string>
     <string name="settings_group_lists">Llistes</string>
     <string name="settings_group_channels">Canals de notificació</string>
@@ -293,7 +308,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Trajectes i càrregues curts</string>
-    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els següents elements estan ocults de les llistes:\n\n• Trajectes de menys d\'1 minut o menys d\'1 km\n• Càrregues de 0,1 kWh o menys\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
+    <string name="settings_short_dialog_text">Quan està desactivat (per defecte), els trajectes i les càrregues per sota dels valors mínims configurats a sota estan ocults de les llistes.\n\nAquests elements segueixen inclosos als totals, mitjanes i estadístiques. Activa aquesta configuració per veure tots els elements a les llistes.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Força resincronització completa</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -216,6 +216,21 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Authentifizierung</string>
     <string name="settings_group_security">Sicherheit</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">Fahrten und Ladevorgänge unterhalb dieser Werte werden in Listen ausgeblendet. In Summen und Statistiken zählen sie immer mit.</string>
+    <string name="settings_threshold_drive_duration_label">Mindestdauer einer Fahrt</string>
+    <string name="settings_threshold_drive_distance_label">Mindeststrecke einer Fahrt</string>
+    <string name="settings_threshold_charge_energy_label">Mindestenergie eines Ladevorgangs</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">Kein Minimum</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">Wert auswählen</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">Kosten</string>
     <string name="settings_group_lists">Listen</string>
     <string name="settings_group_channels">Benachrichtigungskanäle</string>
@@ -293,7 +308,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Kurze Fahrten &amp; Ladevorgänge</string>
-    <string name="settings_short_dialog_text">Wenn deaktiviert (Standard), werden die folgenden Einträge in den Listen ausgeblendet:\n\n• Fahrten unter 1 Minute oder weniger als 1 km\n• Ladevorgänge von 0,1 kWh oder weniger\n\nDiese Einträge werden weiterhin in Summen, Durchschnitten und Statistiken berücksichtigt. Aktiviere diese Einstellung, um alle Einträge in den Listen zu sehen.</string>
+    <string name="settings_short_dialog_text">Wenn deaktiviert (Standard), werden Fahrten und Ladevorgänge unterhalb der unten eingestellten Mindestwerte in den Listen ausgeblendet.\n\nDiese Einträge werden weiterhin in Summen, Durchschnitten und Statistiken berücksichtigt. Aktiviere diese Einstellung, um alle Einträge in den Listen zu sehen.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Vollständige Neu-Synchronisierung erzwingen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,6 +216,21 @@
     <string name="settings_group_server">Servidor</string>
     <string name="settings_group_authentication">Autenticación</string>
     <string name="settings_group_security">Seguridad</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">Los trayectos y las cargas por debajo de estos valores se ocultan de las listas. Siempre se incluyen en los totales y las estadísticas.</string>
+    <string name="settings_threshold_drive_duration_label">Duración mínima del trayecto</string>
+    <string name="settings_threshold_drive_distance_label">Distancia mínima del trayecto</string>
+    <string name="settings_threshold_charge_energy_label">Energía mínima de la carga</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">Sin mínimo</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">Seleccionar valor</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">Costes</string>
     <string name="settings_group_lists">Listas</string>
     <string name="settings_group_channels">Canales de notificación</string>
@@ -293,7 +308,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Trayectos y cargas cortos</string>
-    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los siguientes elementos están ocultos de las listas:\n\n• Trayectos de menos de 1 minuto o menos de 1 km\n• Cargas de 0,1 kWh o menos\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
+    <string name="settings_short_dialog_text">Cuando está desactivado (por defecto), los trayectos y las cargas por debajo de los valores mínimos configurados abajo están ocultos de las listas.\n\nEstos elementos siguen incluidos en totales, promedios y estadísticas. Activa este ajuste para ver todos los elementos en las listas.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forzar resincronización completa</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -216,6 +216,21 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Autenticazione</string>
     <string name="settings_group_security">Sicurezza</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">I tragitti e le ricariche sotto questi valori vengono nascosti dagli elenchi. Sono sempre inclusi nei totali e nelle statistiche.</string>
+    <string name="settings_threshold_drive_duration_label">Durata minima del tragitto</string>
+    <string name="settings_threshold_drive_distance_label">Distanza minima del tragitto</string>
+    <string name="settings_threshold_charge_energy_label">Energia minima della ricarica</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">Nessun minimo</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">Seleziona valore</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">Costi</string>
     <string name="settings_group_lists">Elenchi</string>
     <string name="settings_group_channels">Canali di notifica</string>
@@ -293,7 +308,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Tragitti e ricariche brevi</string>
-    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i seguenti elementi sono nascosti dalle liste:\n\n• Tragitti sotto 1 minuto o meno di 1 km\n• Ricariche di 0,1 kWh o meno\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
+    <string name="settings_short_dialog_text">Quando disabilitato (predefinito), i tragitti e le ricariche sotto i valori minimi impostati qui sotto sono nascosti dalle liste.\n\nQuesti elementi sono comunque inclusi nei totali, medie e statistiche. Abilita questa impostazione per vedere tutti gli elementi nelle liste.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Forza risincronizzazione completa</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -216,6 +216,21 @@
     <string name="settings_group_server">服务器</string>
     <string name="settings_group_authentication">身份验证</string>
     <string name="settings_group_security">安全</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">低于这些数值的行程和充电将不在列表中显示，但始终会计入总计和统计数据。</string>
+    <string name="settings_threshold_drive_duration_label">最短行程时长</string>
+    <string name="settings_threshold_drive_distance_label">最短行程距离</string>
+    <string name="settings_threshold_charge_energy_label">最低充电电量</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">不限</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">选择数值</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">费用</string>
     <string name="settings_group_lists">列表</string>
     <string name="settings_group_channels">通知渠道</string>
@@ -293,7 +308,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">短途行程和充电</string>
-    <string name="settings_short_dialog_text">关闭时（默认），以下内容将从列表中隐藏：\n\n• 不足 1 分钟或不到 1 km 的行程\n• 0.1 kWh 以下的充电\n\n这些记录仍会计入总计、平均值和统计数据。启用此设置可在列表中查看所有记录。</string>
+    <string name="settings_short_dialog_text">关闭时（默认），低于下方所设最小值的行程和充电将从列表中隐藏。\n\n这些记录仍会计入总计、平均值和统计数据。启用此设置可在列表中查看所有记录。</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">强制全量同步</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,21 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Authentication</string>
     <string name="settings_group_security">Security</string>
+    <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
+    <string name="settings_thresholds_hint">Drives and charges below these values are hidden from lists. They are always counted in totals and statistics.</string>
+    <string name="settings_threshold_drive_duration_label">Minimum drive duration</string>
+    <string name="settings_threshold_drive_distance_label">Minimum drive distance</string>
+    <string name="settings_threshold_charge_energy_label">Minimum charge energy</string>
+    <!-- Shown when a threshold is set to zero, i.e. that check is switched off -->
+    <string name="settings_threshold_no_minimum">No minimum</string>
+    <!-- Content description for the threshold dropdown arrows -->
+    <string name="settings_threshold_select">Select value</string>
+    <!-- Threshold values. Units (min, km, mi, kWh) are technical and stay untranslated -->
+    <string name="settings_threshold_value_minutes">%1$d min</string>
+    <string name="settings_threshold_value_km">%1$s km</string>
+    <string name="settings_threshold_value_mi">%1$s mi</string>
+    <string name="settings_threshold_value_kwh">%1$s kWh</string>
+
     <string name="settings_group_costs">Costs</string>
     <string name="settings_group_lists">Lists</string>
     <string name="settings_group_channels">Notification channels</string>
@@ -296,7 +311,7 @@
 
     <!-- Short drives/charges info dialog -->
     <string name="settings_short_dialog_title">Short drives &amp; charges</string>
-    <string name="settings_short_dialog_text">When disabled (default), the following are hidden from the lists:\n\n• Drives under 1 minute or less than 1 km\n• Charges of 0.1 kWh or less\n\nThese entries are still included in totals, averages, and statistics. Enable this setting to see all entries in the lists.</string>
+    <string name="settings_short_dialog_text">When disabled (default), drives and charges below the minimum values set below are hidden from the lists.\n\nThese entries are still included in totals, averages, and statistics. Enable this setting to see all entries in the lists.</string>
 
     <!-- Force resync button and dialog -->
     <string name="settings_resync_button">Force Full Resync</string>

--- a/app/src/test/java/com/matedroid/domain/ShortEntryFilterTest.kt
+++ b/app/src/test/java/com/matedroid/domain/ShortEntryFilterTest.kt
@@ -1,0 +1,132 @@
+package com.matedroid.domain
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The thresholds live in a process-wide mirror, so every test restores the defaults afterwards
+ * to keep the object from leaking state into the rest of the suite.
+ */
+class ShortEntryFilterTest {
+
+    @Before
+    @After
+    fun resetThresholds() {
+        ShortEntryFilter.minDriveDurationMin = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN
+        ShortEntryFilter.minDriveDistance = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE
+        ShortEntryFilter.minChargeEnergyKwh = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH
+    }
+
+    // ==================== Defaults ====================
+
+    @Test
+    fun `default drive thresholds keep the historical 1 min and 1 unit rule`() {
+        assertFalse(ShortEntryFilter.isSignificantDrive(durationMin = 0, distance = 5.0))
+        assertFalse(ShortEntryFilter.isSignificantDrive(durationMin = 5, distance = 0.9))
+        assertTrue(ShortEntryFilter.isSignificantDrive(durationMin = 1, distance = 1.0))
+        assertTrue(ShortEntryFilter.isSignificantDrive(durationMin = 30, distance = 42.0))
+    }
+
+    @Test
+    fun `default charge threshold keeps the historical 0-1 kWh rule`() {
+        assertFalse(ShortEntryFilter.isSignificantCharge(0.1))
+        assertFalse(ShortEntryFilter.isSignificantCharge(0.05))
+        assertTrue(ShortEntryFilter.isSignificantCharge(0.11))
+        assertTrue(ShortEntryFilter.isSignificantCharge(50.0))
+    }
+
+    @Test
+    fun `null values are treated as zero and filtered out`() {
+        assertFalse(ShortEntryFilter.isSignificantDrive(durationMin = null, distance = null))
+        assertFalse(ShortEntryFilter.isSignificantCharge(null))
+    }
+
+    // ==================== Configured thresholds ====================
+
+    @Test
+    fun `raising the duration threshold hides drives that were previously shown`() {
+        val tenMinuteDrive = { ShortEntryFilter.isSignificantDrive(durationMin = 10, distance = 50.0) }
+
+        assertTrue(tenMinuteDrive())
+
+        ShortEntryFilter.minDriveDurationMin = 20
+        assertFalse(tenMinuteDrive())
+    }
+
+    @Test
+    fun `raising the distance threshold hides drives that were previously shown`() {
+        val twoUnitDrive = { ShortEntryFilter.isSignificantDrive(durationMin = 30, distance = 2.0) }
+
+        assertTrue(twoUnitDrive())
+
+        ShortEntryFilter.minDriveDistance = 5.0
+        assertFalse(twoUnitDrive())
+    }
+
+    @Test
+    fun `raising the charge threshold hides charges that were previously shown`() {
+        val oneKwhCharge = { ShortEntryFilter.isSignificantCharge(1.0) }
+
+        assertTrue(oneKwhCharge())
+
+        ShortEntryFilter.minChargeEnergyKwh = 2.0
+        assertFalse(oneKwhCharge())
+    }
+
+    @Test
+    fun `a drive must clear both the duration and the distance threshold`() {
+        ShortEntryFilter.minDriveDurationMin = 5
+        ShortEntryFilter.minDriveDistance = 5.0
+
+        assertFalse(ShortEntryFilter.isSignificantDrive(durationMin = 10, distance = 1.0))
+        assertFalse(ShortEntryFilter.isSignificantDrive(durationMin = 1, distance = 10.0))
+        assertTrue(ShortEntryFilter.isSignificantDrive(durationMin = 10, distance = 10.0))
+    }
+
+    // ==================== "No minimum" (threshold 0) ====================
+
+    @Test
+    fun `zero duration threshold stops filtering on duration`() {
+        ShortEntryFilter.minDriveDurationMin = 0
+        ShortEntryFilter.minDriveDistance = 0.0
+
+        assertTrue(ShortEntryFilter.isSignificantDrive(durationMin = 0, distance = 0.0))
+    }
+
+    @Test
+    fun `zero charge threshold shows even a zero kWh charge`() {
+        ShortEntryFilter.minChargeEnergyKwh = 0.0
+
+        // Without the explicit guard the strict `>` comparison would still hide this.
+        assertTrue(ShortEntryFilter.isSignificantCharge(0.0))
+        assertTrue(ShortEntryFilter.isSignificantCharge(0.01))
+    }
+
+    // ==================== Presets ====================
+
+    @Test
+    fun `every preset list offers the default value so the picker always has a match`() {
+        assertTrue(
+            ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN
+                in ShortEntryFilter.DRIVE_DURATION_PRESETS_MIN
+        )
+        assertTrue(
+            ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE
+                in ShortEntryFilter.DRIVE_DISTANCE_PRESETS
+        )
+        assertTrue(
+            ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH
+                in ShortEntryFilter.CHARGE_ENERGY_PRESETS_KWH
+        )
+    }
+
+    @Test
+    fun `every preset list offers a no-minimum option`() {
+        assertTrue(0 in ShortEntryFilter.DRIVE_DURATION_PRESETS_MIN)
+        assertTrue(0.0 in ShortEntryFilter.DRIVE_DISTANCE_PRESETS)
+        assertTrue(0.0 in ShortEntryFilter.CHARGE_ENERGY_PRESETS_KWH)
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -114,8 +114,12 @@ same word in a locale, or the Drives/Trips navigation and stats become ambiguous
 #### Hiding short drives / charges
 
 The "Show short drives / charges" setting (`showShortDrivesCharges`, default off) hides trivial
-entries — drives under 1 min or 1 km, and charges of 0.1 kWh or less — from **list-like
+entries — by default drives under 1 min or 1 km, and charges of 0.1 kWh or less — from **list-like
 surfaces** while still counting them in totals, averages and statistics.
+
+This filter is **purely presentational**. Short entries are always fetched, always stored, and
+always counted; nothing in the data layer filters on these thresholds, so changing one is a
+re-render and never needs a resync.
 
 The rule lives in **one place**: `domain/ShortEntryFilter.kt`. It exposes the thresholds plus
 `isSignificant()` helpers for every drive/charge model (`DriveData`, `ChargeData`, `DriveSummary`,
@@ -125,6 +129,18 @@ consistent (it previously diverged: the trip timeline shipped without the filter
 legs). Current call sites: `DrivesViewModel`, `ChargesViewModel`, `TripTimelineBuilder` and the
 trip leg list / counts in `TripsScreen` + `TripDetailScreen`. Add a new model? Add its
 `isSignificant()` helper in `ShortEntryFilter.kt`.
+
+**The thresholds are user-configurable** (Settings → Display), chosen from presets defined in
+`ShortEntryFilter.*_PRESETS`. Like `UnitSystem`, the object is a process-wide mirror of the stored
+preference: restored at app start by `MateDroidApp` and written through by `SettingsViewModel` the
+moment the user picks a value. That mirror is what lets the `isSignificant()` helpers stay
+zero-argument — no call site has to thread thresholds through its own state. A threshold of `0`
+means "no minimum" for that dimension.
+
+The distance threshold is compared **in the user's display unit, not km**. TeslamateAPI
+pre-converts every distance it returns and the presets are labelled in the active unit, so both
+sides of the comparison already match — do not scale it through `UnitSystem.thresholdKmToUserUnits`
+(that helper remains for genuinely km-defined constants such as the trip-detection minimum).
 
 #### Adding/Modifying Translations
 


### PR DESCRIPTION
First change enabled by the settings split (#362). Settings → Display now lets you set the thresholds behind the "Show short drives / charges" rule instead of living with the hardcoded 1 min / 1 km / 0.1 kWh.

## Answering the question this started from

The filter is **purely presentational** — verified, not assumed:

- `ShortEntryFilter` is a plain object of constants and predicates. No queries.
- All five call sites filter in-memory over already-loaded lists (`DrivesViewModel:280`, `ChargesViewModel:397`, `TripTimelineBuilder:39-40`, `TripsScreen:413`).
- Grepping the DAOs and Room queries for duration/distance/energy comparisons returns nothing.

Short entries are always fetched, always stored, always counted in totals/averages/stats. Changing a threshold is a re-render, never a resync. That's now stated explicitly in `docs/DEVELOPMENT.md` so it doesn't have to be re-derived.

## What's configurable

| Threshold | Presets |
|---|---|
| Minimum drive duration | no minimum · 1 · 2 · 5 · 10 min |
| Minimum drive distance | no minimum · 0.5 · 1 · 2 · 5 · 10 km/mi |
| Minimum charge energy | no minimum · 0.1 · 0.5 · 1 · 2 · 5 kWh |

Presets rather than free text: they match the Currency picker directly above them, and they avoid locale decimal-separator parsing — it/es/ca users type `0,5`, not `0.5`.

The pickers sit under the existing switch and are **disabled, not hidden**, when the switch is on — the thresholds only bite while short entries are being hidden, but leaving them visible keeps the rule discoverable and stops the section reflowing as you toggle.

## Implementation

- `ShortEntryFilter` becomes a process-wide mirror of the preference — the same pattern `UnitSystem` already uses and documents. Restored at app start by `MateDroidApp`, written through by `SettingsViewModel` the moment a value is picked. **This is what keeps the `isSignificant()` helpers zero-argument, so all five call sites are untouched.**
- `0` means "no minimum". The charge predicate needed an explicit guard for this — its `>` comparison would otherwise still hide 0 kWh charges.
- Distance is compared in the user's display unit rather than scaled from km, since the presets are labelled in the active unit and TeslamateAPI already pre-converts. ⚠️ This shifts the imperial default from 0.62 mi to 1 mi — now adjustable either way. Metric behaviour is unchanged.

## Notes

- **New test coverage**: `ShortEntryFilterTest`, 11 cases. The filter had none before — including a regression test that the defaults still reproduce the old 1 min / 1 unit / 0.1 kWh behaviour.
- The info dialog hardcoded "under 1 minute", "less than 1 km", "0.1 kWh or less" — reworded in all six locales, since those numbers are no longer fixed.
- Italian uses *tragitto* for drive, not *viaggio* (that's "trip"), per the terminology table in `docs/DEVELOPMENT.md`.

## Verification

`lintDebug` and `testDebugUnitTest` pass. Not yet checked on device — the test phone is sitting behind its keyguard and won't unlock over adb; the debug build is installed and ready to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)