### PR TITLE
Let the user choose the display time zone (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **You can now choose which time zone times are shown in** (Settings → Display → Time zone). The default is unchanged — TeslaMate server time, which matches the TeslaMate web interface and shows each drive at the time it happened. You can switch to your phone's time zone, or pick a specific one. Useful if your TeslaMate runs with the default Docker time zone (UTC), which previously made every time read wrong by your whole offset with no way to correct it.
 - **The "short drives / charges" thresholds are now configurable** (Settings → Display) — pick the minimum drive duration, minimum drive distance and minimum charge energy that count as worth listing, instead of the previously fixed 1 min / 1 km / 0.1 kWh. Each can also be set to "no minimum". As before, hidden entries are still counted in every total, average and statistic, so changing a threshold only affects what the lists show — no resync needed.
 
 ### Changed

--- a/app/src/main/java/com/matedroid/MateDroidApp.kt
+++ b/app/src/main/java/com/matedroid/MateDroidApp.kt
@@ -17,6 +17,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.sync.ChargingNotificationWorker
 import com.matedroid.data.sync.DataSyncWorker
 import com.matedroid.data.sync.TpmsPressureWorker
+import com.matedroid.domain.AppTimeZone
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.domain.UnitSystem
 import com.matedroid.notification.SentryNotificationManager
@@ -56,12 +57,14 @@ class MateDroidApp : Application(), Configuration.Provider {
             UnitSystem.isImperial = settingsDataStore.isImperial.first()
         }
 
-        // Restore the user's short drive/charge thresholds into their process-wide mirror.
+        // Restore the display preferences that live in process-wide mirrors, before any
+        // list filtering or date formatting runs.
         appScope.launch {
             val settings = settingsDataStore.settings.first()
             ShortEntryFilter.minDriveDurationMin = settings.shortDriveMinDurationMin
             ShortEntryFilter.minDriveDistance = settings.shortDriveMinDistance
             ShortEntryFilter.minChargeEnergyKwh = settings.shortChargeMinEnergyKwh
+            AppTimeZone.mode = settings.timeZoneMode
         }
 
         // Configure OSMDroid tile cache (shared across all map screens)

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.matedroid.domain.AppTimeZone
 import com.matedroid.domain.ShortEntryFilter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -58,6 +59,7 @@ data class AppSettings(
     val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+    val timeZoneMode: String = AppTimeZone.MODE_SERVER,
     val teslamateBaseUrl: String = "",
     val lastSelectedCarId: Int? = null
 ) {
@@ -83,6 +85,7 @@ class SettingsDataStore @Inject constructor(
     private val shortDriveMinDurationKey = intPreferencesKey("short_drive_min_duration_min")
     private val shortDriveMinDistanceKey = doublePreferencesKey("short_drive_min_distance")
     private val shortChargeMinEnergyKey = doublePreferencesKey("short_charge_min_energy_kwh")
+    private val timeZoneModeKey = stringPreferencesKey("time_zone_mode")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
@@ -120,6 +123,7 @@ class SettingsDataStore @Inject constructor(
                 ?: ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
             shortChargeMinEnergyKwh = preferences[shortChargeMinEnergyKey]
                 ?: ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+            timeZoneMode = preferences[timeZoneModeKey] ?: AppTimeZone.MODE_SERVER,
             teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
             lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
@@ -211,6 +215,16 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveShowShortDrivesCharges(show: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[showShortDrivesChargesKey] = show
+        }
+    }
+
+    /**
+     * Which clock timestamps are displayed in: [AppTimeZone.MODE_SERVER],
+     * [AppTimeZone.MODE_DEVICE], or an explicit zone id such as `Europe/Madrid`.
+     */
+    suspend fun saveTimeZoneMode(mode: String) {
+        context.dataStore.edit { preferences ->
+            preferences[timeZoneModeKey] = mode
         }
     }
 

--- a/app/src/main/java/com/matedroid/domain/AppTimeZone.kt
+++ b/app/src/main/java/com/matedroid/domain/AppTimeZone.kt
@@ -1,0 +1,56 @@
+package com.matedroid.domain
+
+import java.time.ZoneId
+
+/**
+ * Which clock the app renders timestamps in.
+ *
+ * TeslamateAPI returns every timestamp as server-local time *with* its UTC offset attached
+ * (e.g. `2026-08-15T11:29:19+02:00`). That offset makes the instant unambiguous, so we can
+ * render it in whichever zone the user prefers:
+ *
+ * - [MODE_SERVER] (default) keeps the wall clock exactly as TeslaMate sent it, i.e. the time
+ *   where the car and the TeslaMate server are. This matches TeslaMate's own web UI, and for a
+ *   car log it is usually what you want — a drive reads at the time it actually happened,
+ *   even if you check the app from another country.
+ * - [MODE_DEVICE] converts to the phone's current zone.
+ * - Any other value is treated as an explicit [ZoneId] id (e.g. `Europe/Madrid`), for when
+ *   neither the server nor the phone is on the clock the user wants — most commonly a
+ *   TeslaMate instance left on the Docker default of UTC.
+ *
+ * Like [UnitSystem] and [ShortEntryFilter], this is a process-wide mirror of the stored
+ * preference rather than something threaded through call sites: restored at app start by
+ * [com.matedroid.MateDroidApp] and written through by
+ * [com.matedroid.ui.screens.settings.SettingsViewModel]. That is what lets
+ * [com.matedroid.util.parseIsoDateTime] stay a plain function — it has 26 call sites, and
+ * passing a zone to each would be a far bigger change than the behaviour warrants.
+ *
+ * This affects displayed wall-clock times only. Elapsed-time math (e.g. "10 minutes ago") works
+ * off the absolute instant and is correct under every mode.
+ */
+object AppTimeZone {
+    /** Render timestamps in the zone TeslamateAPI sent them in. The default. */
+    const val MODE_SERVER = "server"
+
+    /** Render timestamps in the phone's current zone. */
+    const val MODE_DEVICE = "device"
+
+    @Volatile
+    var mode: String = MODE_SERVER
+
+    /**
+     * The zone to convert timestamps into, or `null` to keep the timestamp's own offset.
+     *
+     * An unrecognised zone id falls back to `null` (server time) rather than throwing, so a
+     * stale preference — a zone id dropped by a future tzdb update — degrades to the default
+     * instead of breaking every date in the app.
+     */
+    fun displayZone(): ZoneId? = when (val current = mode) {
+        MODE_SERVER -> null
+        MODE_DEVICE -> ZoneId.systemDefault()
+        else -> runCatching { ZoneId.of(current) }.getOrNull()
+    }
+
+    /** True when [mode] names an explicit zone rather than one of the automatic modes. */
+    fun isFixedZone(): Boolean = mode != MODE_SERVER && mode != MODE_DEVICE
+}

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TirePosition
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.AppTimeZone
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TpmsStateRepository
@@ -46,6 +47,7 @@ data class SettingsUiState(
     val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+    val timeZoneMode: String = AppTimeZone.MODE_SERVER,
     val isLoading: Boolean = true,
     val isTesting: Boolean = false,
     val isSaving: Boolean = false,
@@ -112,6 +114,7 @@ class SettingsViewModel @Inject constructor(
                 shortDriveMinDurationMin = settings.shortDriveMinDurationMin,
                 shortDriveMinDistance = settings.shortDriveMinDistance,
                 shortChargeMinEnergyKwh = settings.shortChargeMinEnergyKwh,
+                timeZoneMode = settings.timeZoneMode,
                 isLoading = false
             )
         }
@@ -184,6 +187,18 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showShortDrivesCharges = show)
         viewModelScope.launch {
             settingsDataStore.saveShowShortDrivesCharges(show)
+        }
+    }
+
+    /**
+     * [mode] is [AppTimeZone.MODE_SERVER], [AppTimeZone.MODE_DEVICE], or a zone id. The mirror
+     * is updated synchronously so dates re-render on the way back out of Settings.
+     */
+    fun updateTimeZoneMode(mode: String) {
+        _uiState.value = _uiState.value.copy(timeZoneMode = mode)
+        AppTimeZone.mode = mode
+        viewModelScope.launch {
+            settingsDataStore.saveTimeZoneMode(mode)
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
@@ -2,6 +2,7 @@ package com.matedroid.ui.screens.settings.sections
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -29,6 +30,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.matedroid.R
 import com.matedroid.data.model.Currency
+import com.matedroid.domain.AppTimeZone
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.domain.UnitSystem
 import com.matedroid.ui.screens.settings.SettingsGroupHeader
@@ -58,8 +60,10 @@ fun DisplaySettingsScreen(
         shortDriveMinDurationMin = uiState.shortDriveMinDurationMin,
         shortDriveMinDistance = uiState.shortDriveMinDistance,
         shortChargeMinEnergyKwh = uiState.shortChargeMinEnergyKwh,
+        timeZoneMode = uiState.timeZoneMode,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack,
+        onTimeZoneModeChange = viewModel::updateTimeZoneMode,
         onCurrencyChange = viewModel::updateCurrency,
         onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges,
         onShortDriveMinDurationChange = viewModel::updateShortDriveMinDuration,
@@ -75,8 +79,10 @@ private fun DisplaySettingsContent(
     shortDriveMinDurationMin: Int,
     shortDriveMinDistance: Double,
     shortChargeMinEnergyKwh: Double,
+    timeZoneMode: String,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
+    onTimeZoneModeChange: (String) -> Unit,
     onCurrencyChange: (String) -> Unit,
     onShowShortDrivesChargesChange: (Boolean) -> Unit,
     onShortDriveMinDurationChange: (Int) -> Unit,
@@ -91,6 +97,22 @@ private fun DisplaySettingsContent(
         onBack = onNavigateBack,
         snackbarHostState = snackbarHostState
     ) {
+        SettingsGroupHeader(stringResource(R.string.settings_group_datetime))
+
+        TimeZonePicker(
+            mode = timeZoneMode,
+            onModeChange = onTimeZoneModeChange
+        )
+
+        Text(
+            text = stringResource(R.string.settings_timezone_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+
+        SettingsSpacer(24)
+
         SettingsGroupHeader(stringResource(R.string.settings_group_costs))
 
         val selectedCurrency = Currency.findByCode(currencyCode)
@@ -313,8 +335,10 @@ private fun DisplaySettingsPreview() {
             shortDriveMinDurationMin = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
             shortDriveMinDistance = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
             shortChargeMinEnergyKwh = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+            timeZoneMode = AppTimeZone.MODE_SERVER,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
+            onTimeZoneModeChange = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},
             onShortDriveMinDurationChange = {},

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/TimeZonePicker.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/TimeZonePicker.kt
@@ -1,0 +1,185 @@
+package com.matedroid.ui.screens.settings.sections
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.matedroid.R
+import com.matedroid.domain.AppTimeZone
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * Picker for [AppTimeZone.mode]: the two automatic modes plus "pick a zone", which opens a
+ * searchable list of every zone the platform knows about.
+ */
+@Composable
+fun TimeZonePicker(
+    mode: String,
+    onModeChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    var showZoneDialog by remember { mutableStateOf(false) }
+
+    val serverLabel = stringResource(R.string.settings_timezone_server)
+    val deviceLabel = stringResource(
+        R.string.settings_timezone_device,
+        ZoneId.systemDefault().id
+    )
+    val pickLabel = stringResource(R.string.settings_timezone_pick)
+
+    val currentLabel = when (mode) {
+        AppTimeZone.MODE_SERVER -> serverLabel
+        AppTimeZone.MODE_DEVICE -> deviceLabel
+        else -> zoneLabel(mode)
+    }
+
+    Box(modifier = modifier) {
+        OutlinedTextField(
+            value = currentLabel,
+            onValueChange = {},
+            label = { Text(stringResource(R.string.settings_timezone_label)) },
+            modifier = Modifier.fillMaxWidth(),
+            readOnly = true,
+            trailingIcon = {
+                IconButton(onClick = { menuExpanded = true }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowDropDown,
+                        contentDescription = stringResource(R.string.settings_timezone_select)
+                    )
+                }
+            }
+        )
+
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            DropdownMenuItem(
+                text = { Text(serverLabel) },
+                onClick = {
+                    onModeChange(AppTimeZone.MODE_SERVER)
+                    menuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = { Text(deviceLabel) },
+                onClick = {
+                    onModeChange(AppTimeZone.MODE_DEVICE)
+                    menuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = { Text(pickLabel) },
+                onClick = {
+                    menuExpanded = false
+                    showZoneDialog = true
+                }
+            )
+        }
+    }
+
+    if (showZoneDialog) {
+        ZoneSelectionDialog(
+            onDismiss = { showZoneDialog = false },
+            onZoneSelected = { zoneId ->
+                onModeChange(zoneId)
+                showZoneDialog = false
+            }
+        )
+    }
+}
+
+/**
+ * Searchable list of every available zone id. There are several hundred, so the list is
+ * filtered rather than scrolled — typing "madrid" or "+02" narrows it immediately.
+ */
+@Composable
+private fun ZoneSelectionDialog(
+    onDismiss: () -> Unit,
+    onZoneSelected: (String) -> Unit
+) {
+    var query by remember { mutableStateOf("") }
+
+    // Sorted once per dialog; ~600 ids, cheap enough and avoids re-sorting on each keystroke.
+    val allZones = remember { ZoneId.getAvailableZoneIds().sorted() }
+    val labelled = remember(allZones) { allZones.map { it to zoneLabel(it) } }
+    val filtered = remember(query, labelled) {
+        if (query.isBlank()) {
+            labelled
+        } else {
+            labelled.filter { (_, label) -> label.contains(query.trim(), ignoreCase = true) }
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_timezone_pick)) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    label = { Text(stringResource(R.string.settings_timezone_search)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                    items(filtered, key = { (id, _) -> id }) { (id, label) ->
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onZoneSelected(id) }
+                                .padding(vertical = 12.dp)
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+/**
+ * "Europe/Madrid (+02:00)" — the current offset makes the list searchable by offset and
+ * disambiguates the many zone ids that share a city name.
+ */
+private fun zoneLabel(zoneId: String): String {
+    val zone = runCatching { ZoneId.of(zoneId) }.getOrNull() ?: return zoneId
+    val offset = zone.rules.getOffset(Instant.now())
+    val text = if (offset == ZoneOffset.UTC) "+00:00" else offset.id
+    return "$zoneId ($text)"
+}

--- a/app/src/main/java/com/matedroid/util/DateTimeParse.kt
+++ b/app/src/main/java/com/matedroid/util/DateTimeParse.kt
@@ -2,6 +2,7 @@ package com.matedroid.util
 
 import android.content.res.Resources
 import com.matedroid.R
+import com.matedroid.domain.AppTimeZone
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -11,23 +12,34 @@ import java.time.format.FormatStyle
 import java.util.Locale
 
 /**
- * Parse an ISO-8601 datetime string into a [LocalDateTime].
+ * Parse an ISO-8601 datetime string into a [LocalDateTime] for display.
  *
  * Accepts datetime strings with or without a timezone offset, and with or
  * without a trailing "Z" suffix. TeslaMate emits both forms (RFC 3339
  * with offset, or ISO with a trailing Z).
  *
- * Examples:
- *   "2026-05-10T15:39:00Z"      → 2026-05-10T15:39
- *   "2026-05-10T15:39:00+02:00" → 2026-05-10T15:39
- *   "" or null                   → null
+ * The offset is resolved through [AppTimeZone]: under the default
+ * [AppTimeZone.MODE_SERVER] the wall clock is kept exactly as sent (the time
+ * where the car and TeslaMate server are), otherwise the instant is converted
+ * into the configured zone. A string carrying no offset has no instant to
+ * convert, so it is always taken at face value.
+ *
+ * Examples for "2026-05-10T15:39:00Z", with the device in UTC+2:
+ *   MODE_SERVER          → 2026-05-10T15:39
+ *   MODE_DEVICE          → 2026-05-10T17:39
+ *   "" or null           → null
  */
 fun parseIsoDateTime(dateStr: String?): LocalDateTime? {
     if (dateStr.isNullOrBlank()) return null
     return try {
         try {
-            OffsetDateTime.parse(dateStr).toLocalDateTime()
+            val parsed = OffsetDateTime.parse(dateStr)
+            when (val zone = AppTimeZone.displayZone()) {
+                null -> parsed.toLocalDateTime()
+                else -> parsed.atZoneSameInstant(zone).toLocalDateTime()
+            }
         } catch (_: DateTimeParseException) {
+            // No offset in the string — nothing to convert, so take it as written.
             LocalDateTime.parse(dateStr.replace("Z", ""))
         }
     } catch (_: Exception) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -216,6 +216,18 @@
     <string name="settings_group_server">Servidor</string>
     <string name="settings_group_authentication">Autenticació</string>
     <string name="settings_group_security">Seguretat</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">Data i hora</string>
+    <string name="settings_timezone_label">Zona horària</string>
+    <string name="settings_timezone_hint">La zona en què es mostren les hores. L\'hora del servidor TeslaMate coincideix amb la interfície web de TeslaMate i mostra cada trajecte a l\'hora en què va passar.</string>
+    <string name="settings_timezone_server">Servidor TeslaMate</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">Aquest dispositiu (%1$s)</string>
+    <string name="settings_timezone_pick">Tria una zona horària…</string>
+    <string name="settings_timezone_search">Cerca</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">Selecciona la zona horària</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">Els trajectes i les càrregues per sota d\'aquests valors s\'amaguen de les llistes. Sempre es compten en els totals i les estadístiques.</string>
     <string name="settings_threshold_drive_duration_label">Durada mínima del trajecte</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -216,6 +216,18 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Authentifizierung</string>
     <string name="settings_group_security">Sicherheit</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">Datum &amp; Uhrzeit</string>
+    <string name="settings_timezone_label">Zeitzone</string>
+    <string name="settings_timezone_hint">In welcher Zone Uhrzeiten angezeigt werden. Die TeslaMate-Serverzeit entspricht der TeslaMate-Weboberfläche und zeigt jede Fahrt zu der Uhrzeit, zu der sie stattgefunden hat.</string>
+    <string name="settings_timezone_server">TeslaMate-Server</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">Dieses Gerät (%1$s)</string>
+    <string name="settings_timezone_pick">Zeitzone auswählen…</string>
+    <string name="settings_timezone_search">Suchen</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">Zeitzone auswählen</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">Fahrten und Ladevorgänge unterhalb dieser Werte werden in Listen ausgeblendet. In Summen und Statistiken zählen sie immer mit.</string>
     <string name="settings_threshold_drive_duration_label">Mindestdauer einer Fahrt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,6 +216,18 @@
     <string name="settings_group_server">Servidor</string>
     <string name="settings_group_authentication">Autenticación</string>
     <string name="settings_group_security">Seguridad</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">Fecha y hora</string>
+    <string name="settings_timezone_label">Zona horaria</string>
+    <string name="settings_timezone_hint">La zona en la que se muestran las horas. La hora del servidor TeslaMate coincide con la interfaz web de TeslaMate y muestra cada trayecto a la hora en que ocurrió.</string>
+    <string name="settings_timezone_server">Servidor TeslaMate</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">Este dispositivo (%1$s)</string>
+    <string name="settings_timezone_pick">Elegir una zona horaria…</string>
+    <string name="settings_timezone_search">Buscar</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">Seleccionar zona horaria</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">Los trayectos y las cargas por debajo de estos valores se ocultan de las listas. Siempre se incluyen en los totales y las estadísticas.</string>
     <string name="settings_threshold_drive_duration_label">Duración mínima del trayecto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -216,6 +216,18 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Autenticazione</string>
     <string name="settings_group_security">Sicurezza</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">Data e ora</string>
+    <string name="settings_timezone_label">Fuso orario</string>
+    <string name="settings_timezone_hint">Il fuso in cui vengono mostrati gli orari. L\'ora del server TeslaMate coincide con l\'interfaccia web di TeslaMate e mostra ogni tragitto all\'ora in cui è avvenuto.</string>
+    <string name="settings_timezone_server">Server TeslaMate</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">Questo dispositivo (%1$s)</string>
+    <string name="settings_timezone_pick">Scegli un fuso orario…</string>
+    <string name="settings_timezone_search">Cerca</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">Seleziona fuso orario</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">I tragitti e le ricariche sotto questi valori vengono nascosti dagli elenchi. Sono sempre inclusi nei totali e nelle statistiche.</string>
     <string name="settings_threshold_drive_duration_label">Durata minima del tragitto</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -216,6 +216,18 @@
     <string name="settings_group_server">服务器</string>
     <string name="settings_group_authentication">身份验证</string>
     <string name="settings_group_security">安全</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">日期与时间</string>
+    <string name="settings_timezone_label">时区</string>
+    <string name="settings_timezone_hint">显示时间所用的时区。TeslaMate 服务器时间与 TeslaMate 网页界面一致，按行程实际发生的时间显示。</string>
+    <string name="settings_timezone_server">TeslaMate 服务器</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">本设备（%1$s）</string>
+    <string name="settings_timezone_pick">选择时区…</string>
+    <string name="settings_timezone_search">搜索</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">选择时区</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">低于这些数值的行程和充电将不在列表中显示，但始终会计入总计和统计数据。</string>
     <string name="settings_threshold_drive_duration_label">最短行程时长</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,18 @@
     <string name="settings_group_server">Server</string>
     <string name="settings_group_authentication">Authentication</string>
     <string name="settings_group_security">Security</string>
+    <!-- Time zone preference (Display section) -->
+    <string name="settings_group_datetime">Date &amp; time</string>
+    <string name="settings_timezone_label">Time zone</string>
+    <string name="settings_timezone_hint">Which clock times are shown in. TeslaMate server time matches the TeslaMate web interface and shows each drive at the time it happened.</string>
+    <string name="settings_timezone_server">TeslaMate server</string>
+    <!-- %1$s is the device's current time zone, e.g. Europe/Madrid -->
+    <string name="settings_timezone_device">This device (%1$s)</string>
+    <string name="settings_timezone_pick">Pick a time zone…</string>
+    <string name="settings_timezone_search">Search</string>
+    <!-- Content description for the time zone dropdown arrow -->
+    <string name="settings_timezone_select">Select time zone</string>
+
     <!-- Configurable thresholds for the "short drives / charges" rule (Display section) -->
     <string name="settings_thresholds_hint">Drives and charges below these values are hidden from lists. They are always counted in totals and statistics.</string>
     <string name="settings_threshold_drive_duration_label">Minimum drive duration</string>

--- a/app/src/test/java/com/matedroid/util/DateTimeParseTimeZoneTest.kt
+++ b/app/src/test/java/com/matedroid/util/DateTimeParseTimeZoneTest.kt
@@ -1,0 +1,133 @@
+package com.matedroid.util
+
+import com.matedroid.domain.AppTimeZone
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * [parseIsoDateTime] resolves the offset through the process-wide [AppTimeZone] mirror, so each
+ * test restores the default afterwards rather than leaking a mode into the rest of the suite.
+ *
+ * All fixtures use explicit zones (never the machine's default) so the suite behaves the same on
+ * a developer laptop and on CI.
+ */
+class DateTimeParseTimeZoneTest {
+
+    /** 15:39 UTC — i.e. 17:39 in Madrid, 00:39 the next day in Tokyo. */
+    private val utcTimestamp = "2026-05-10T15:39:00Z"
+
+    /** The same instant, as TeslaMate would send it from a server in Spain. */
+    private val madridTimestamp = "2026-05-10T17:39:00+02:00"
+
+    @Before
+    @After
+    fun resetMode() {
+        AppTimeZone.mode = AppTimeZone.MODE_SERVER
+    }
+
+    // ==================== Default (server) mode ====================
+
+    @Test
+    fun `server mode keeps the wall clock TeslaMate sent, ignoring the offset`() {
+        assertEquals("2026-05-10T15:39", parseIsoDateTime(utcTimestamp).toString())
+        assertEquals("2026-05-10T17:39", parseIsoDateTime(madridTimestamp).toString())
+    }
+
+    @Test
+    fun `server mode is the default so upgrading changes nothing`() {
+        assertEquals(AppTimeZone.MODE_SERVER, AppTimeZone.mode)
+        assertNull(AppTimeZone.displayZone())
+    }
+
+    // ==================== Fixed zone ====================
+
+    @Test
+    fun `a fixed zone converts both encodings of the same instant identically`() {
+        AppTimeZone.mode = "Europe/Madrid"
+
+        assertEquals("2026-05-10T17:39", parseIsoDateTime(utcTimestamp).toString())
+        assertEquals("2026-05-10T17:39", parseIsoDateTime(madridTimestamp).toString())
+    }
+
+    @Test
+    fun `a fixed zone can roll the date over`() {
+        AppTimeZone.mode = "Asia/Tokyo"
+
+        // 15:39Z is 00:39 the following day in JST (UTC+9).
+        assertEquals("2026-05-11T00:39", parseIsoDateTime(utcTimestamp).toString())
+    }
+
+    @Test
+    fun `this is what fixes a TeslaMate server left on the Docker default of UTC`() {
+        // The reported bug: server emits UTC, user is in Madrid, times read two hours early.
+        assertEquals("2026-05-10T15:39", parseIsoDateTime(utcTimestamp).toString())
+
+        AppTimeZone.mode = "Europe/Madrid"
+        assertEquals("2026-05-10T17:39", parseIsoDateTime(utcTimestamp).toString())
+    }
+
+    // ==================== Robustness ====================
+
+    @Test
+    fun `an unknown zone id falls back to server time instead of throwing`() {
+        AppTimeZone.mode = "Mars/Olympus_Mons"
+
+        assertNull(AppTimeZone.displayZone())
+        assertEquals("2026-05-10T15:39", parseIsoDateTime(utcTimestamp).toString())
+    }
+
+    @Test
+    fun `a timestamp without an offset is taken at face value in every mode`() {
+        val noOffset = "2026-05-10T15:39:00"
+
+        assertEquals("2026-05-10T15:39", parseIsoDateTime(noOffset).toString())
+
+        AppTimeZone.mode = "Asia/Tokyo"
+        assertEquals("2026-05-10T15:39", parseIsoDateTime(noOffset).toString())
+    }
+
+    @Test
+    fun `blank and malformed input stays null in every mode`() {
+        AppTimeZone.mode = "Europe/Madrid"
+
+        assertNull(parseIsoDateTime(null))
+        assertNull(parseIsoDateTime(""))
+        assertNull(parseIsoDateTime("   "))
+        assertNull(parseIsoDateTime("not a date"))
+    }
+
+    @Test
+    fun `parseIsoDate follows the converted instant across a date boundary`() {
+        // 23:30 in Madrid is already the next day in Tokyo.
+        val lateEvening = "2026-05-10T23:30:00+02:00"
+
+        assertEquals("2026-05-10", parseIsoDate(lateEvening).toString())
+
+        AppTimeZone.mode = "Asia/Tokyo"
+        assertEquals("2026-05-11", parseIsoDate(lateEvening).toString())
+    }
+
+    // ==================== Mode helpers ====================
+
+    @Test
+    fun `isFixedZone distinguishes explicit zones from the automatic modes`() {
+        AppTimeZone.mode = AppTimeZone.MODE_SERVER
+        assert(!AppTimeZone.isFixedZone())
+
+        AppTimeZone.mode = AppTimeZone.MODE_DEVICE
+        assert(!AppTimeZone.isFixedZone())
+
+        AppTimeZone.mode = "Europe/Madrid"
+        assert(AppTimeZone.isFixedZone())
+    }
+
+    @Test
+    fun `device mode resolves to the JVM default zone`() {
+        AppTimeZone.mode = AppTimeZone.MODE_DEVICE
+
+        assertEquals(java.time.ZoneId.systemDefault(), AppTimeZone.displayZone())
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -111,6 +111,32 @@ When adding a new `drive_*`/`*_drive*` string, translate "drive" with the drive-
 reserve the trip-column term for `trip_*`/`trips_*` strings — never let the two collapse to the
 same word in a locale, or the Drives/Trips navigation and stats become ambiguous.
 
+#### Time zones
+
+TeslamateAPI returns every timestamp as **server-local time with its UTC offset attached**
+(`2026-08-15T11:29:19+02:00`), never bare UTC. The offset makes the instant unambiguous, so the
+app can render it in whichever clock the user prefers.
+
+`domain/AppTimeZone.kt` holds that preference (Settings → Display → Time zone) as a process-wide
+mirror, the same pattern as `UnitSystem` and `ShortEntryFilter` — restored at app start by
+`MateDroidApp`, written through by `SettingsViewModel`. It exists as a mirror because
+`parseIsoDateTime` has ~26 call sites and threading a zone through each would dwarf the change.
+
+- `MODE_SERVER` (**default**) — keep the wall clock as sent. Matches TeslaMate's own web UI and
+  shows each drive at the time it actually happened, wherever you are when you look.
+- `MODE_DEVICE` — convert to the phone's zone.
+- Any other value is an explicit zone id (`Europe/Madrid`). Mainly for TeslaMate instances left
+  on the Docker default of UTC, where neither server nor phone time is what the user wants.
+  An unrecognised id degrades to server time rather than throwing.
+
+Only `parseIsoDateTime` (and `parseIsoDate` through it) consults this. **Elapsed-time math must
+keep using the absolute instant** — `OffsetDateTime.parse(x).toInstant()`, as
+`StatusIndicatorsRow` and `CarModels.stateSinceEpochMs` do — which is correct under every mode.
+
+Known gap: some day-*grouping* code (e.g. `SentryHistoryViewModel`, `WhereWasIDateTimePicker`)
+still buckets by `ZoneId.systemDefault()` independently of this setting, so an entry near midnight
+can group into a different day than its displayed time suggests. Pre-existing, not yet unified.
+
 #### Hiding short drives / charges
 
 The "Show short drives / charges" setting (`showShortDrivesCharges`, default off) hides trivial


### PR DESCRIPTION
Closes #326 — but deliberately **not ready to merge yet**, pending the reporter's clarification on their TeslaMate setup.

## What's actually wrong

TeslamateAPI returns every timestamp as server-local time **with its UTC offset attached** — `2026-08-15T11:29:19+02:00`, never bare UTC. `parseIsoDateTime` then did:

```kotlin
OffsetDateTime.parse(dateStr).toLocalDateTime()   // keeps 11:29, throws +02:00 away
```

`.toLocalDateTime()` keeps the wall-clock fields and discards the offset — it does not convert. So every clock time in the app renders in **the TeslaMate server's time zone**, with no way to change it. If your server and phone share a zone (as mine do) it looks perfectly correct, which is why this went unnoticed.

On a TeslaMate left at the Docker default of UTC, the API returns `+00:00` and every trip time reads wrong by the user's whole offset. That matches the report exactly.

**It's also internally inconsistent.** Elapsed-time math *does* honour the offset (`StatusIndicatorsRow.kt:96`, `CarModels.kt:128` use `.toInstant()`). On a UTC server the dashboard says a drive ended "10 minutes ago" while the drives list shows it ending at 09:41 and the phone clock reads 11:51. Durations right, clock times wrong.

## The change

Settings → Display → Time zone:

| Mode | Behaviour |
|---|---|
| **TeslaMate server** (default) | Wall clock as sent — today's exact behaviour |
| This device | Converted to the phone's zone |
| Pick a time zone… | Explicit zone from a searchable list of all ~600 ids, labelled with current offset |

**The default is unchanged on purpose.** Nobody's times move on upgrade, and server time is arguably the right default for a car log anyway: it matches TeslaMate's own web UI, and shows a drive at the time it *happened* rather than the time where you happen to be standing when you look. The setting exists because we shouldn't be silently at the mercy of the server's `TZ` config.

## Implementation

- `domain/AppTimeZone.kt` is a process-wide mirror, the pattern `UnitSystem` and `ShortEntryFilter` already use — restored at app start, written through by `SettingsViewModel`. Chosen because `parseIsoDateTime` has **26 call sites**; threading a zone through each would dwarf the behaviour change.
- The entire behavioural change is contained in `parseIsoDateTime`. Elapsed-time paths are untouched and stay correct under every mode.
- An unrecognised zone id (e.g. one dropped by a future tzdb update) falls back to server time rather than throwing every date in the app.

## Notes

- **New coverage**: `DateTimeParseTimeZoneTest`, 11 cases — this parser had none. Includes the reported UTC-server scenario, date-rollover across zones, unknown-zone fallback, and a guard that `MODE_SERVER` remains the default. All fixtures use explicit zones, never the machine default, so it behaves the same on CI.
- **Known gap, documented not fixed**: some day-*grouping* code (`SentryHistoryViewModel`, `WhereWasIDateTimePicker`) still buckets by `ZoneId.systemDefault()` independently of this setting, so an entry near midnight can group into a different day than its displayed time. Pre-existing; called out in `docs/DEVELOPMENT.md`.

## Verification

`lintDebug` and `testDebugUnitTest` pass. Not yet exercised on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)