### PR TITLE
fix: filter GPS noise out of drive climb and clarify elevation labels (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Settings are now split into sections** — instead of one long scrolling page, Settings opens a list of categories (Connection, Display, Notifications, Data & sync, About) that each open their own page. The new Notifications page links straight to Android's per-channel settings for charging, sentry and tire-pressure alerts, and the first-run setup now shows only the connection form. Connection settings still have an explicit Save; everything else applies as soon as you change it.
 - **Connection settings are no longer hidden behind "Advanced network settings"** — the secondary server URL, API token, HTTP Basic Auth and certificate options are now laid out in plain view under Server, Authentication and Security headings. If you use MyTeslaMate, the Basic Auth fields you need are visible as soon as you open the page.
+- **Drive elevation is clearer: "Gain"/"Loss" are now "Climb"/"Descent", plus a new "Net"** (#338) — the old "Gain" was the total climbing done over the drive, so it stayed positive even on a downhill drive and read like "you ended this much higher". The Elevation card now also shows Net, the plain difference between where the drive ended and where it started, so a downhill drive reads Climb +120 m / Net -107 m at a glance.
+
+### Fixed
+- **Drive climb and descent are no longer inflated by GPS noise** (#338) — the car logs a position roughly three times a second with elevation rounded to the metre, and every metre of jitter was being counted as real climbing, overstating it by 20% or more on a long drive. Sustained changes of at least 5 m now count, smaller wobbles don't. Existing drives are recalculated on the next sync.
+- **Elevation now respects the miles/imperial setting on the drive detail screen** — the elevation figures were always printed in metres, even for users on miles who see feet everywhere else.
 
 ## [1.10.1] - 2026-08-12
 

--- a/app/src/main/java/com/matedroid/data/local/entity/DriveDetailAggregate.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/DriveDetailAggregate.kt
@@ -39,10 +39,10 @@ data class DriveDetailAggregate(
     // === Elevation ===
     val maxElevation: Int?,         // meters
     val minElevation: Int?,         // meters
-    val startElevation: Int?,       // meters - first position elevation (V2)
-    val endElevation: Int?,         // meters - last position elevation (V2)
-    val elevationGain: Int?,        // Total meters climbed (accumulated)
-    val elevationLoss: Int?,        // Total meters descended (accumulated)
+    val startElevation: Int?,       // meters - first position with an elevation (V2)
+    val endElevation: Int?,         // meters - last position with an elevation (V2)
+    val elevationGain: Int?,        // Total meters climbed (accumulated, noise-filtered by ElevationStats)
+    val elevationLoss: Int?,        // Total meters descended (accumulated, noise-filtered by ElevationStats)
     val hasElevationData: Boolean,  // False if all positions had null elevation
 
     // === Temperature extremes ===

--- a/app/src/main/java/com/matedroid/data/local/entity/SyncState.kt
+++ b/app/src/main/java/com/matedroid/data/local/entity/SyncState.kt
@@ -45,7 +45,7 @@ data class SyncState(
  * records with older versions will be reprocessed.
  */
 object SchemaVersion {
-    const val CURRENT = 5
+    const val CURRENT = 6
 
     // Changelog:
     // V1 (initial): elevation, temp extremes, power, climate, charger info
@@ -53,4 +53,6 @@ object SchemaVersion {
     // V3: startCountryCode, startCountryName from reverse geocoding first position
     // V4: startRegionName, startCity for drives; countryCode, countryName, regionName, city for charges
     // V5: endLatitude, endLongitude for trip country resolution without API call
+    // V6: elevationGain/elevationLoss are noise-filtered (ElevationStats), and
+    //     startElevation/endElevation now skip leading/trailing positions without elevation
 }

--- a/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
+++ b/app/src/main/java/com/matedroid/data/sync/SyncRepository.kt
@@ -21,6 +21,7 @@ import com.matedroid.data.local.entity.SchemaVersion
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.ElevationStats
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -387,21 +388,14 @@ class SyncRepository @Inject constructor(
         var maxPower: Int? = null
         var minPower: Int? = null
         var climateOnCount = 0
-        var elevationGain = 0
-        var elevationLoss = 0
-        var prevElevation: Int? = null
+        val elevationChange = ElevationStats.Accumulator()
 
         for (pos in positions) {
             // Elevation
             pos.elevation?.let { elev ->
                 maxElevation = maxOf(maxElevation ?: elev, elev)
                 minElevation = minOf(minElevation ?: elev, elev)
-                prevElevation?.let { prev ->
-                    val diff = elev - prev
-                    if (diff > 0) elevationGain += diff
-                    else elevationLoss += -diff
-                }
-                prevElevation = elev
+                elevationChange.add(elev)
             }
 
             // Temperature
@@ -426,8 +420,10 @@ class SyncRepository @Inject constructor(
 
         val firstPosition = positions.firstOrNull()
         val lastPosition = positions.lastOrNull()
-        val startElevation = firstPosition?.elevation
-        val endElevation = lastPosition?.elevation
+        // The first and last few positions of a drive often carry no elevation yet, so scan for
+        // the outermost ones that do instead of reading straight off the edges.
+        val startElevation = positions.firstNotNullOfOrNull { it.elevation }
+        val endElevation = positions.lastOrNull { it.elevation != null }?.elevation
         val hasElevationData = maxElevation != null
 
         // Extract start/end coordinates for geocoding and trip country resolution
@@ -446,8 +442,8 @@ class SyncRepository @Inject constructor(
             minElevation = minElevation,
             startElevation = startElevation,
             endElevation = endElevation,
-            elevationGain = if (hasElevationData) elevationGain else null,
-            elevationLoss = if (hasElevationData) elevationLoss else null,
+            elevationGain = if (hasElevationData) elevationChange.change.climb else null,
+            elevationLoss = if (hasElevationData) elevationChange.change.descent else null,
             hasElevationData = hasElevationData,
 
             maxInsideTemp = maxInsideTemp,

--- a/app/src/main/java/com/matedroid/domain/ElevationStats.kt
+++ b/app/src/main/java/com/matedroid/domain/ElevationStats.kt
@@ -1,0 +1,66 @@
+package com.matedroid.domain
+
+/**
+ * Single source of truth for the cumulative climb / descent of a drive.
+ *
+ * TeslaMate logs positions at roughly 3 Hz and stores elevation as whole metres, so summing
+ * every sample-to-sample delta also sums the GPS jitter between them. On real drives that
+ * overstates the climb by 20% or more, and the error grows with the duration of the drive
+ * rather than with the terrain. Deltas are therefore measured against a moving anchor and only
+ * counted once they exceed [THRESHOLD_M] in one direction, which is the usual hysteresis filter
+ * for altitude series; anything smaller is treated as noise and left out of both totals.
+ *
+ * Climb and descent are cumulative, NOT a net figure: a drive that ends lower than it started
+ * still reports the metres it climbed along the way, so both totals can be non-zero at once.
+ * The net change is simply end elevation minus start elevation and is computed by the caller.
+ *
+ * Elevation is handled in whatever unit the samples arrive in (metres for TeslamateAPI) and is
+ * never converted here — display conversion belongs to
+ * [com.matedroid.domain.model.UnitFormatter.formatElevation].
+ */
+object ElevationStats {
+
+    /** Minimum sustained change before it counts as real climb or descent, in metres. */
+    const val THRESHOLD_M = 5
+
+    /** Cumulative metres climbed and metres descended over a series of samples. */
+    data class Change(val climb: Int, val descent: Int)
+
+    /** Climb / descent over an already-collected list of elevation samples, in order. */
+    fun of(elevations: List<Int>): Change {
+        val accumulator = Accumulator()
+        elevations.forEach(accumulator::add)
+        return accumulator.change
+    }
+
+    /**
+     * Incremental form of [of], for callers that already walk their positions once to compute
+     * other stats and should not walk them a second time.
+     */
+    class Accumulator(private val thresholdM: Int = THRESHOLD_M) {
+        private var anchor: Int? = null
+        private var climb = 0
+        private var descent = 0
+
+        fun add(elevation: Int) {
+            val previous = anchor
+            if (previous == null) {
+                anchor = elevation
+                return
+            }
+            val diff = elevation - previous
+            when {
+                diff >= thresholdM -> {
+                    climb += diff
+                    anchor = elevation
+                }
+                diff <= -thresholdM -> {
+                    descent += -diff
+                    anchor = elevation
+                }
+            }
+        }
+
+        val change: Change get() = Change(climb, descent)
+    }
+}

--- a/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
+++ b/app/src/main/java/com/matedroid/domain/model/UnitFormatter.kt
@@ -28,6 +28,15 @@ object UnitFormatter {
     }
 
     /**
+     * Format an elevation *change* with an explicit sign, so a climb reads "+120 m" and a
+     * descent "-107 m". Negative values already carry their sign from the number formatting.
+     */
+    fun formatSignedElevation(value: Int?, units: Units?): String {
+        val formatted = formatElevation(value, units)
+        return if ((value ?: 0) > 0) "+$formatted" else formatted
+    }
+
+    /**
      * Get the elevation value
      */
     fun getElevationValue(value: Float, units: Units?): Float {

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailScreen.kt
@@ -443,12 +443,14 @@ private fun DriveStatTiles(
 ) {
     val efficiencyLabel = stringResource(R.string.efficiency)
     val temperatureLabel = stringResource(R.string.temperature)
-    val gainLabel = stringResource(R.string.gain)
+    val climbLabel = stringResource(R.string.elevation_climb)
 
     val tiles = buildList {
         add(efficiencyLabel to UnitFormatter.formatEfficiency(stats.efficiency, units))
         stats.outsideTempAvg?.let { add(temperatureLabel to UnitFormatter.formatTemperature(it, units)) }
-        if (stats.elevationGain > 0) add(gainLabel to "+%,d m".format(stats.elevationGain))
+        if (stats.elevationClimb > 0) {
+            add(climbLabel to UnitFormatter.formatSignedElevation(stats.elevationClimb, units))
+        }
     }
     if (tiles.isEmpty()) return
 
@@ -637,10 +639,11 @@ private fun DriveMoreDetails(
                         title = stringResource(R.string.elevation),
                         icon = Icons.Default.Landscape,
                         stats = listOf(
-                            StatItem(stringResource(R.string.maximum), "%,d m".format(stats.elevationMax)),
-                            StatItem(stringResource(R.string.minimum), "%,d m".format(stats.elevationMin)),
-                            StatItem(stringResource(R.string.gain), "+%,d m".format(stats.elevationGain)),
-                            StatItem(stringResource(R.string.loss), "-%,d m".format(stats.elevationLoss))
+                            StatItem(stringResource(R.string.maximum), UnitFormatter.formatElevation(stats.elevationMax, units)),
+                            StatItem(stringResource(R.string.minimum), UnitFormatter.formatElevation(stats.elevationMin, units)),
+                            StatItem(stringResource(R.string.elevation_climb), UnitFormatter.formatSignedElevation(stats.elevationClimb, units)),
+                            StatItem(stringResource(R.string.elevation_descent), UnitFormatter.formatSignedElevation(-stats.elevationDescent, units)),
+                            StatItem(stringResource(R.string.elevation_net), UnitFormatter.formatSignedElevation(stats.elevationNet, units))
                         )
                     )
                 }

--- a/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/drives/DriveDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.matedroid.data.repository.WeatherPoint
 import com.matedroid.data.repository.WeatherRepository
 import com.matedroid.domain.DriveComparison
 import com.matedroid.domain.DriveComparisonRepository
+import com.matedroid.domain.ElevationStats
 import com.matedroid.domain.LegRef
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
@@ -43,8 +44,12 @@ data class DriveDetailStats(
     val powerAvg: Double,
     val elevationMax: Int,
     val elevationMin: Int,
-    val elevationGain: Int,
-    val elevationLoss: Int,
+    /** Cumulative metres climbed over the drive, noise-filtered by [ElevationStats]. */
+    val elevationClimb: Int,
+    /** Cumulative metres descended over the drive, noise-filtered by [ElevationStats]. */
+    val elevationDescent: Int,
+    /** End elevation minus start elevation: negative on a net-downhill drive. */
+    val elevationNet: Int,
     val batteryStart: Int,
     val batteryEnd: Int,
     val batteryUsed: Int,
@@ -197,7 +202,8 @@ class DriveDetailViewModel @Inject constructor(
         val elevations = positions.mapNotNull { it.elevation }
         val elevationMax = elevations.maxOrNull() ?: 0
         val elevationMin = elevations.minOrNull() ?: 0
-        val (elevationGain, elevationLoss) = calculateElevationChange(elevations)
+        val elevationChange = ElevationStats.of(elevations)
+        val elevationNet = if (elevations.size >= 2) elevations.last() - elevations.first() else 0
 
         // Battery stats
         val batteryLevels = positions.mapNotNull { it.batteryLevel }
@@ -223,8 +229,9 @@ class DriveDetailViewModel @Inject constructor(
             powerAvg = powerAvg,
             elevationMax = elevationMax,
             elevationMin = elevationMin,
-            elevationGain = elevationGain,
-            elevationLoss = elevationLoss,
+            elevationClimb = elevationChange.climb,
+            elevationDescent = elevationChange.descent,
+            elevationNet = elevationNet,
             batteryStart = batteryStart,
             batteryEnd = batteryEnd,
             batteryUsed = batteryUsed,
@@ -236,20 +243,5 @@ class DriveDetailViewModel @Inject constructor(
             outsideTempAvg = detail.outsideTempAvg,
             insideTempAvg = detail.insideTempAvg
         )
-    }
-
-    private fun calculateElevationChange(elevations: List<Int>): Pair<Int, Int> {
-        if (elevations.size < 2) return Pair(0, 0)
-
-        var gain = 0
-        var loss = 0
-
-        for (i in 1 until elevations.size) {
-            val diff = elevations[i] - elevations[i - 1]
-            if (diff > 0) gain += diff
-            else loss += -diff
-        }
-
-        return Pair(gain, loss)
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -449,8 +449,9 @@
     <string name="energy">Energia</string>
     <string name="max_accel">Màx (accel)</string>
     <string name="min_regen">Mín (regen)</string>
-    <string name="gain">Guany</string>
-    <string name="loss">Pèrdua</string>
+    <string name="elevation_climb">Ascens</string>
+    <string name="elevation_descent">Descens</string>
+    <string name="elevation_net">Net</string>
     <string name="outside">Exterior</string>
     <string name="inside">Interior</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -450,8 +450,9 @@
     <string name="energy">Energie</string>
     <string name="max_accel">Max (Beschl.)</string>
     <string name="min_regen">Min (Reku)</string>
-    <string name="gain">Gewinn</string>
-    <string name="loss">Verlust</string>
+    <string name="elevation_climb">Anstieg</string>
+    <string name="elevation_descent">Abstieg</string>
+    <string name="elevation_net">Netto</string>
     <string name="outside">Außen</string>
     <string name="inside">Innen</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -449,8 +449,9 @@
     <string name="energy">Energía</string>
     <string name="max_accel">Máx (accel)</string>
     <string name="min_regen">Mín (regen)</string>
-    <string name="gain">Ganancia</string>
-    <string name="loss">Pérdida</string>
+    <string name="elevation_climb">Ascenso</string>
+    <string name="elevation_descent">Descenso</string>
+    <string name="elevation_net">Neto</string>
     <string name="outside">Exterior</string>
     <string name="inside">Interior</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -449,8 +449,9 @@
     <string name="energy">Energia</string>
     <string name="max_accel">Max (accel)</string>
     <string name="min_regen">Min (regen)</string>
-    <string name="gain">Guadagno</string>
-    <string name="loss">Perdita</string>
+    <string name="elevation_climb">Salita</string>
+    <string name="elevation_descent">Discesa</string>
+    <string name="elevation_net">Netto</string>
     <string name="outside">Esterna</string>
     <string name="inside">Interna</string>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -449,8 +449,9 @@
     <string name="energy">能量</string>
     <string name="max_accel">最大（加速）</string>
     <string name="min_regen">最小（回收）</string>
-    <string name="gain">增加</string>
-    <string name="loss">损耗</string>
+    <string name="elevation_climb">爬升</string>
+    <string name="elevation_descent">下降</string>
+    <string name="elevation_net">净变化</string>
     <string name="outside">车外</string>
     <string name="inside">车内</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,8 +453,12 @@
     <string name="energy">Energy</string>
     <string name="max_accel">Max (accel)</string>
     <string name="min_regen">Min (regen)</string>
-    <string name="gain">Gain</string>
-    <string name="loss">Loss</string>
+    <!-- Drive elevation: total metres climbed over the whole drive, counting every uphill stretch -->
+    <string name="elevation_climb">Climb</string>
+    <!-- Drive elevation: total metres descended over the whole drive, counting every downhill stretch -->
+    <string name="elevation_descent">Descent</string>
+    <!-- Drive elevation: difference between the end and start elevation of the drive -->
+    <string name="elevation_net">Net</string>
     <string name="outside">Outside</string>
     <string name="inside">Inside</string>
 

--- a/app/src/test/java/com/matedroid/domain/ElevationStatsTest.kt
+++ b/app/src/test/java/com/matedroid/domain/ElevationStatsTest.kt
@@ -1,0 +1,72 @@
+package com.matedroid.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ElevationStatsTest {
+
+    @Test
+    fun emptyOrSingleSample_hasNoChange() {
+        assertEquals(ElevationStats.Change(0, 0), ElevationStats.of(emptyList()))
+        assertEquals(ElevationStats.Change(0, 0), ElevationStats.of(listOf(100)))
+    }
+
+    @Test
+    fun steadyClimb_countsTheWholeAscent() {
+        // 100 -> 200 in 10 m steps, each step above the threshold.
+        val elevations = (100..200 step 10).toList()
+        assertEquals(ElevationStats.Change(100, 0), ElevationStats.of(elevations))
+    }
+
+    @Test
+    fun steadyDescent_countsTheWholeDescent() {
+        val elevations = (200 downTo 100 step 10).toList()
+        assertEquals(ElevationStats.Change(0, 100), ElevationStats.of(elevations))
+    }
+
+    @Test
+    fun jitterBelowThreshold_isNotCounted() {
+        // GPS noise around a flat road: nothing here is a real climb or descent.
+        val elevations = listOf(100, 101, 99, 102, 98, 101, 100, 102, 99, 100)
+        assertEquals(ElevationStats.Change(0, 0), ElevationStats.of(elevations))
+    }
+
+    @Test
+    fun jitterOnTopOfARealClimb_doesNotInflateIt() {
+        // Climb from 100 to 150 in 1 m steps with +/-1 m of noise on each sample. Summing every
+        // sample-to-sample delta reports 75 m for this 50 m climb; the anchor counts 48, the
+        // real climb minus the sub-threshold remainder still pending at the last sample.
+        val elevations = mutableListOf<Int>()
+        for (i in 0..50) {
+            elevations += 100 + i + (if (i % 2 == 0) 1 else -1)
+        }
+        val change = ElevationStats.of(elevations)
+        assertEquals(48, change.climb)
+        assertEquals(0, change.descent)
+    }
+
+    @Test
+    fun netDownhillDrive_stillReportsTheClimbAlongTheWay() {
+        // Down 100, up 60, down 40: ends 80 m below the start but climbs 60 m in the middle.
+        val elevations = listOf(300, 250, 200, 230, 260, 240, 220)
+        val change = ElevationStats.of(elevations)
+        assertEquals(60, change.climb)
+        assertEquals(140, change.descent)
+        assertEquals(-80, elevations.last() - elevations.first())
+    }
+
+    @Test
+    fun reversalsSmallerThanTheThreshold_doNotBreakARun() {
+        // A 2 m dip mid-climb is noise, so the climb is counted end to end.
+        val elevations = listOf(100, 110, 108, 120, 130)
+        assertEquals(ElevationStats.Change(30, 0), ElevationStats.of(elevations))
+    }
+
+    @Test
+    fun accumulator_matchesTheListForm() {
+        val elevations = listOf(100, 103, 99, 115, 112, 140, 135, 90, 95, 130)
+        val accumulator = ElevationStats.Accumulator()
+        elevations.forEach(accumulator::add)
+        assertEquals(ElevationStats.of(elevations), accumulator.change)
+    }
+}


### PR DESCRIPTION
## Summary
The drive detail "Gain" figure was both mislabelled and numerically inflated.

Fixes #338

## Root Cause

Two independent problems behind the same number:

1. **Semantics.** `gain` is cumulative ascent (total metres climbed), but the drive detail screen surfaced it as a lone headline tile labelled **GAIN +195 m**, with no descent and no net figure anywhere. On a net-downhill drive that reads as "you ended 195 m higher", which is what the reporter hit.

2. **Noise.** Both `DriveDetailViewModel.calculateElevationChange()` and `SyncRepository.computeDriveAggregate()` summed every positive sample-to-sample delta. TeslaMate logs positions at roughly 3 Hz with elevation rounded to whole metres, so every metre of GPS jitter was counted as real climbing, and the error grew with the duration of the drive rather than with the terrain.

Measured against two real drives from a live TeslaMate instance:

| drive | naive sum | 3 m threshold | 5 m threshold |
|---|---|---|---|
| 8543 | 289 m | 243 m | 225 m |
| 8544 | 265 m | 241 m | 222 m |

Roughly 20% overstatement on gentle terrain, more on the drives in the issue. Smoothing the series before accumulating changed the result by only a few metres over the threshold alone, so it isn't worth the extra pass.

## Solution

- **New `domain/ElevationStats`** as the single source of truth for climb/descent. Deltas are measured against a moving anchor and only counted once they exceed 5 m in one direction (standard hysteresis filter for altitude series). It exposes both a list form and an `Accumulator`, so `SyncRepository` keeps its existing single pass over positions.
- **`DriveDetailViewModel`** uses it and gains an `elevationNet` field (end minus start elevation).
- **`DriveDetailScreen`**: the headline tile is now labelled **Climb**; the Elevation card shows Maximum / Minimum / Climb / Descent / **Net**. The card's grid already chunks and pads, so five items lay out correctly at every width.
- **Unit handling**: those figures were hardcoded as `"%,d m"` and now go through `UnitFormatter`, which gets a new `formatSignedElevation()` for signed changes. Imperial users were seeing metres here; `HardcodedUnitLabelTest` doesn't cover `m`/`ft`, so it slipped through.
- **Strings**: `gain`/`loss` (used only here) replaced by `elevation_climb` / `elevation_descent` / `elevation_net` across all 6 locales.
- **`SchemaVersion` 5 → 6** so stored aggregates are recomputed, keeping the "Most Climbing" record in Stats consistent with the drive screen. While bumping, `startElevation`/`endElevation` now scan for the outermost positions that actually carry an elevation: the first few positions of a drive routinely have `elevation: null`, which was storing a null start elevation.

## Test Plan
- [x] `ElevationStatsTest` — 8 cases: steady climb/descent, sub-threshold jitter counted as zero, jitter layered on a real climb (naive sum reports 75 m for a 50 m climb, the filter reports 48), net-downhill drive still reporting its mid-drive climb, sub-threshold reversals not breaking a run, and `Accumulator` matching the list form
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` clean
- [ ] Manual: open a net-downhill drive, confirm the tile reads Climb and the Elevation card shows a negative Net
- [ ] Manual: switch the TeslaMate unit preference to miles, confirm elevation shows in feet

Generated with [Claude Code](https://claude.com/claude-code)