### PR TITLE
Make the charge warning levels configurable (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **The high-charge warning level is now configurable, and can be turned off** (#310) (Settings → Display) — the warning triangle next to the battery percentage used to appear above a fixed 90%. Pick the level it appears at, or "Never" to hide it: cars with an LFP battery (Standard Range Model 3/Y) are meant to be charged to 100%, so the warning never applied to them. Tapping the warning now also says where to change it.
+- **The charge warning levels are now configurable, and can be turned off** (#310) (Settings → Display) — the warning triangle next to the battery percentage used to appear above a fixed 90%, and the percentage turned red below a fixed 20%. Both are now yours to pick, or set to "Never": cars with an LFP battery (Standard Range Model 3/Y) are meant to be charged to 100%, so the high warning never applied to them, and how low is "low" depends on the car and how you drive it. The low level also applies to the widget (amber still covers the 20 points just above it). Tapping the high-charge warning now says where to change it.
 - **The "short drives / charges" thresholds are now configurable** (Settings → Display) — pick the minimum drive duration, minimum drive distance and minimum charge energy that count as worth listing, instead of the previously fixed 1 min / 1 km / 0.1 kWh. Each can also be set to "no minimum". As before, hidden entries are still counted in every total, average and statistic, so changing a threshold only affects what the lists show — no resync needed.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The high-charge warning level is now configurable, and can be turned off** (#310) (Settings → Display) — the warning triangle next to the battery percentage used to appear above a fixed 90%. Pick the level it appears at, or "Never" to hide it: cars with an LFP battery (Standard Range Model 3/Y) are meant to be charged to 100%, so the warning never applied to them. Tapping the warning now also says where to change it.
 - **The "short drives / charges" thresholds are now configurable** (Settings → Display) — pick the minimum drive duration, minimum drive distance and minimum charge energy that count as worth listing, instead of the previously fixed 1 min / 1 km / 0.1 kWh. Each can also be set to "no minimum". As before, hidden entries are still counted in every total, average and statistic, so changing a threshold only affects what the lists show — no resync needed.
 
 ### Changed

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -58,6 +59,7 @@ data class AppSettings(
     val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+    val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
     val teslamateBaseUrl: String = "",
     val lastSelectedCarId: Int? = null
 ) {
@@ -83,6 +85,7 @@ class SettingsDataStore @Inject constructor(
     private val shortDriveMinDurationKey = intPreferencesKey("short_drive_min_duration_min")
     private val shortDriveMinDistanceKey = doublePreferencesKey("short_drive_min_distance")
     private val shortChargeMinEnergyKey = doublePreferencesKey("short_charge_min_energy_kwh")
+    private val highSocWarningThresholdKey = intPreferencesKey("high_soc_warning_threshold")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
@@ -120,6 +123,8 @@ class SettingsDataStore @Inject constructor(
                 ?: ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
             shortChargeMinEnergyKwh = preferences[shortChargeMinEnergyKey]
                 ?: ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+            highSocWarningThreshold = preferences[highSocWarningThresholdKey]
+                ?: HighSocWarning.DEFAULT_THRESHOLD,
             teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
             lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
@@ -227,6 +232,16 @@ class SettingsDataStore @Inject constructor(
             preferences[shortDriveMinDurationKey] = driveMinDurationMin
             preferences[shortDriveMinDistanceKey] = driveMinDistance
             preferences[shortChargeMinEnergyKey] = chargeMinEnergyKwh
+        }
+    }
+
+    /**
+     * Battery level above which the dashboard flags a high state of charge.
+     * [HighSocWarning.DISABLED] hides the warning altogether — see [HighSocWarning].
+     */
+    suspend fun saveHighSocWarningThreshold(threshold: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[highSocWarningThresholdKey] = threshold
         }
     }
 

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -60,6 +61,7 @@ data class AppSettings(
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
     val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
+    val lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
     val teslamateBaseUrl: String = "",
     val lastSelectedCarId: Int? = null
 ) {
@@ -86,6 +88,7 @@ class SettingsDataStore @Inject constructor(
     private val shortDriveMinDistanceKey = doublePreferencesKey("short_drive_min_distance")
     private val shortChargeMinEnergyKey = doublePreferencesKey("short_charge_min_energy_kwh")
     private val highSocWarningThresholdKey = intPreferencesKey("high_soc_warning_threshold")
+    private val lowSocWarningThresholdKey = intPreferencesKey("low_soc_warning_threshold")
     private val teslamateBaseUrlKey = stringPreferencesKey("teslamate_base_url")
     private val lastSelectedCarIdKey = intPreferencesKey("last_selected_car_id")
     private val carImageOverridesKey = stringPreferencesKey("car_image_overrides")
@@ -125,6 +128,8 @@ class SettingsDataStore @Inject constructor(
                 ?: ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
             highSocWarningThreshold = preferences[highSocWarningThresholdKey]
                 ?: HighSocWarning.DEFAULT_THRESHOLD,
+            lowSocWarningThreshold = preferences[lowSocWarningThresholdKey]
+                ?: LowSocWarning.DEFAULT_THRESHOLD,
             teslamateBaseUrl = preferences[teslamateBaseUrlKey] ?: "",
             lastSelectedCarId = preferences[lastSelectedCarIdKey]
         )
@@ -242,6 +247,16 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveHighSocWarningThreshold(threshold: Int) {
         context.dataStore.edit { preferences ->
             preferences[highSocWarningThresholdKey] = threshold
+        }
+    }
+
+    /**
+     * Battery level below which the percentage reads as low (red).
+     * [LowSocWarning.DISABLED] leaves it in the palette colour — see [LowSocWarning].
+     */
+    suspend fun saveLowSocWarningThreshold(threshold: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[lowSocWarningThresholdKey] = threshold
         }
     }
 

--- a/app/src/main/java/com/matedroid/domain/HighSocWarning.kt
+++ b/app/src/main/java/com/matedroid/domain/HighSocWarning.kt
@@ -1,0 +1,31 @@
+package com.matedroid.domain
+
+/**
+ * The "high state of charge" warning that sits next to the battery percentage on the
+ * dashboard (Settings → Display → "Warn above").
+ *
+ * The level it appears at is user-configurable because the right answer depends on the pack:
+ * NMC cars are happiest below 90% for daily use, while LFP cars (Standard Range Model 3/Y)
+ * are meant to be charged to 100% regularly and should never be nagged about it — that is what
+ * [DISABLED] is for. The trim badging TeslamateAPI reports is not a reliable way to tell the two
+ * apart across markets and model years, so this is a setting rather than a detection.
+ */
+object HighSocWarning {
+    /** Threshold that turns the warning off entirely. Rendered as "Never" in the picker. */
+    const val DISABLED = 0
+
+    /** Warn above 90%, the fixed behaviour the app had before this was configurable. */
+    const val DEFAULT_THRESHOLD = 90
+
+    /** Values offered in the Settings picker. [DISABLED] is offered first, as "Never". */
+    val PRESETS = listOf(DISABLED, 70, 75, 80, 85, 90, 95)
+
+    /**
+     * True when the dashboard should flag the current charge level.
+     *
+     * A charging car is never flagged: it is on its way to the limit the user set in the car,
+     * so the warning would fire on every charge to 100% instead of on sitting there full.
+     */
+    fun shouldWarn(batteryLevel: Int, isCharging: Boolean, threshold: Int): Boolean =
+        threshold != DISABLED && !isCharging && batteryLevel > threshold
+}

--- a/app/src/main/java/com/matedroid/domain/HighSocWarning.kt
+++ b/app/src/main/java/com/matedroid/domain/HighSocWarning.kt
@@ -17,8 +17,8 @@ object HighSocWarning {
     /** Warn above 90%, the fixed behaviour the app had before this was configurable. */
     const val DEFAULT_THRESHOLD = 90
 
-    /** Values offered in the Settings picker. [DISABLED] is offered first, as "Never". */
-    val PRESETS = listOf(DISABLED, 70, 75, 80, 85, 90, 95)
+    /** Values offered in the Settings picker, ascending, with [DISABLED] last as "Never". */
+    val PRESETS = listOf(70, 75, 80, 85, 90, 99, DISABLED)
 
     /**
      * True when the dashboard should flag the current charge level.

--- a/app/src/main/java/com/matedroid/domain/LowSocWarning.kt
+++ b/app/src/main/java/com/matedroid/domain/LowSocWarning.kt
@@ -1,0 +1,38 @@
+package com.matedroid.domain
+
+/**
+ * The low-charge colouring of the battery percentage on the dashboard and the widget
+ * (Settings → Display → "Warn below").
+ *
+ * The counterpart to [HighSocWarning]: red below the threshold, amber for the
+ * [AMBER_MARGIN] points just above it, the palette colour otherwise. Both levels used to be
+ * hardcoded (red below 20%, amber below 40%), which is the wrong line for a short-range car
+ * used for commuting and for a long-range one that never sees a Supercharger.
+ */
+object LowSocWarning {
+    /** Threshold that leaves the percentage in the palette colour at any level. */
+    const val DISABLED = 0
+
+    /** Red below 20%, the fixed behaviour the app had before this was configurable. */
+    const val DEFAULT_THRESHOLD = 20
+
+    /**
+     * How far above the threshold the amber band reaches. At the default this puts amber
+     * below 40%, exactly where it used to sit.
+     */
+    const val AMBER_MARGIN = 20
+
+    /** Values offered in the Settings picker. [DISABLED] is offered first, as "Never". */
+    val PRESETS = listOf(DISABLED, 10, 15, 20, 25, 30, 40)
+
+    /** True when the level should read as low (red). */
+    fun isLow(batteryLevel: Int, threshold: Int): Boolean =
+        threshold != DISABLED && batteryLevel < threshold
+
+    /**
+     * True when the level is close to low (amber). Call sites check [isLow] first — this
+     * range deliberately includes it, mirroring the `when` chain it replaced.
+     */
+    fun isGettingLow(batteryLevel: Int, threshold: Int): Boolean =
+        threshold != DISABLED && batteryLevel < threshold + AMBER_MARGIN
+}

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/BatteryCard.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/BatteryCard.kt
@@ -52,6 +52,7 @@ import com.matedroid.data.api.models.ChargingDetails
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.CarImageOverride
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.model.BatteryTypeHelper
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.calculateAcGaugeProgress
@@ -80,6 +81,7 @@ internal fun BatteryCard(
     isCurrentChargeAvailable: Boolean = false,
     sentryEventCount: Int = 0,
     highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
+    lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
     onNavigateToBattery: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToCurrentCharge: () -> Unit = {},
@@ -91,8 +93,8 @@ internal fun BatteryCard(
 
     val batteryLevel = status.batteryLevel ?: 0
     val batteryColor = when {
-        batteryLevel < 20 -> StatusError
-        batteryLevel < 40 -> StatusWarning
+        LowSocWarning.isLow(batteryLevel, lowSocWarningThreshold) -> StatusError
+        LowSocWarning.isGettingLow(batteryLevel, lowSocWarningThreshold) -> StatusWarning
         else -> palette.onSurface
     }
     val chargeLimit = status.chargeLimitSoc ?: 100

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/BatteryCard.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/BatteryCard.kt
@@ -51,6 +51,7 @@ import com.matedroid.data.api.models.CarStatus
 import com.matedroid.data.api.models.ChargingDetails
 import com.matedroid.data.api.models.Units
 import com.matedroid.data.local.CarImageOverride
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.model.BatteryTypeHelper
 import com.matedroid.domain.model.UnitFormatter
 import com.matedroid.ui.components.calculateAcGaugeProgress
@@ -78,6 +79,7 @@ internal fun BatteryCard(
     carImageOverrides: Map<Int, CarImageOverride> = emptyMap(),
     isCurrentChargeAvailable: Boolean = false,
     sentryEventCount: Int = 0,
+    highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
     onNavigateToBattery: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToCurrentCharge: () -> Unit = {},
@@ -107,10 +109,20 @@ internal fun BatteryCard(
                 )
             },
             text = {
-                Text(
-                    text = stringResource(R.string.high_soc_warning_message),
-                    style = MaterialTheme.typography.bodyMedium
-                )
+                Column {
+                    Text(
+                        text = stringResource(R.string.high_soc_warning_message),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    // The LFP owners this warning does not apply to are exactly the people
+                    // reading this dialog, so point them at the setting that turns it off.
+                    Text(
+                        text = stringResource(R.string.high_soc_warning_settings_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             },
             confirmButton = {
                 TextButton(onClick = { showHighSocDialog = false }) {
@@ -198,7 +210,7 @@ internal fun BatteryCard(
                             )
                         }
                     }
-                    if (batteryLevel > 90 && !status.isCharging) {
+                    if (HighSocWarning.shouldWarn(batteryLevel, status.isCharging, highSocWarningThreshold)) {
                         Spacer(modifier = Modifier.width(6.dp))
                         Icon(
                             imageVector = Icons.Filled.Warning,
@@ -639,6 +651,28 @@ private fun BatteryCardDcChargingLfpPreview() {
             ),
             units = null,
             carTrimBadging = "50"  // LFP battery, max 170kW
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Parked Full - Warning Off")
+@Composable
+private fun BatteryCardFullWarningDisabledPreview() {
+    MateDroidTheme {
+        BatteryCard(
+            status = CarStatus(
+                displayName = "My Tesla",
+                state = "asleep",
+                batteryDetails = BatteryDetails(
+                    batteryLevel = 100,
+                    ratedBatteryRange = 400.0
+                ),
+                chargingDetails = ChargingDetails(chargeLimitSoc = 100)
+            ),
+            units = null,
+            carTrimBadging = "50",
+            // What an LFP owner sees once the warning is turned off (issue #310)
+            highSocWarningThreshold = HighSocWarning.DISABLED
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Warning
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.model.Trip
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -268,6 +269,7 @@ fun DashboardScreen(
                         isCurrentChargeAvailable = uiState.isCurrentChargeAvailable,
                         sentryEventCount = uiState.sentryEventCount,
                         dcFinishedPluggedIn = uiState.dcFinishedPluggedIn,
+                        highSocWarningThreshold = uiState.highSocWarningThreshold,
                         onNavigateToCharges = {
                             uiState.selectedCarId?.let { carId ->
                                 onNavigateToCharges(carId, uiState.selectedCarExterior?.exteriorColor)
@@ -563,6 +565,7 @@ private fun DashboardContent(
     isCurrentChargeAvailable: Boolean = false,
     sentryEventCount: Int = 0,
     dcFinishedPluggedIn: Boolean = false,
+    highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
     onNavigateToCharges: () -> Unit = {},
     onNavigateToDrives: () -> Unit = {},
     onNavigateToBattery: () -> Unit = {},
@@ -620,6 +623,7 @@ private fun DashboardContent(
             carImageOverrides = carImageOverrides,
             isCurrentChargeAvailable = isCurrentChargeAvailable,
             sentryEventCount = sentryEventCount,
+            highSocWarningThreshold = highSocWarningThreshold,
             onNavigateToBattery = onNavigateToBattery,
             onNavigateToStats = onNavigateToStats,
             onNavigateToCurrentCharge = onNavigateToCurrentCharge,

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Warning
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.model.Trip
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -270,6 +271,7 @@ fun DashboardScreen(
                         sentryEventCount = uiState.sentryEventCount,
                         dcFinishedPluggedIn = uiState.dcFinishedPluggedIn,
                         highSocWarningThreshold = uiState.highSocWarningThreshold,
+                        lowSocWarningThreshold = uiState.lowSocWarningThreshold,
                         onNavigateToCharges = {
                             uiState.selectedCarId?.let { carId ->
                                 onNavigateToCharges(carId, uiState.selectedCarExterior?.exteriorColor)
@@ -566,6 +568,7 @@ private fun DashboardContent(
     sentryEventCount: Int = 0,
     dcFinishedPluggedIn: Boolean = false,
     highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
+    lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
     onNavigateToCharges: () -> Unit = {},
     onNavigateToDrives: () -> Unit = {},
     onNavigateToBattery: () -> Unit = {},
@@ -624,6 +627,7 @@ private fun DashboardContent(
             isCurrentChargeAvailable = isCurrentChargeAvailable,
             sentryEventCount = sentryEventCount,
             highSocWarningThreshold = highSocWarningThreshold,
+            lowSocWarningThreshold = lowSocWarningThreshold,
             onNavigateToBattery = onNavigateToBattery,
             onNavigateToStats = onNavigateToStats,
             onNavigateToCurrentCharge = onNavigateToCurrentCharge,

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -10,6 +10,7 @@ import com.matedroid.data.local.CarImageOverride
 import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TripCountCache
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
 import com.matedroid.data.repository.ApiResult
@@ -23,6 +24,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -47,7 +50,9 @@ data class DashboardUiState(
     val totalTrips: Int? = null,
     /** Most recent detected trip (newest first), for the dashboard's Trips hero teaser. */
     val latestTrip: Trip? = null,
-    val dcFinishedPluggedIn: Boolean = false
+    val dcFinishedPluggedIn: Boolean = false,
+    /** Battery level above which a parked car is flagged; see [HighSocWarning]. */
+    val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD
 ) {
     private val selectedCar: CarData?
         get() = cars.find { it.carId == selectedCarId }
@@ -104,6 +109,19 @@ class DashboardViewModel @Inject constructor(
             loadCars()
         }
         observeCarImageOverrides()
+        observeHighSocWarningThreshold()
+    }
+
+    /** Kept live rather than read once, so a change in Settings shows on the way back. */
+    private fun observeHighSocWarningThreshold() {
+        viewModelScope.launch {
+            settingsDataStore.settings
+                .map { it.highSocWarningThreshold }
+                .distinctUntilChanged()
+                .collect { threshold ->
+                    _uiState.update { it.copy(highSocWarningThreshold = threshold) }
+                }
+        }
     }
 
     private fun observeCarImageOverrides() {

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -11,6 +11,7 @@ import com.matedroid.data.local.ChargeSessionStateDataStore
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TripCountCache
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.TripRepository
 import com.matedroid.domain.model.Trip
 import com.matedroid.data.repository.ApiResult
@@ -52,7 +53,9 @@ data class DashboardUiState(
     val latestTrip: Trip? = null,
     val dcFinishedPluggedIn: Boolean = false,
     /** Battery level above which a parked car is flagged; see [HighSocWarning]. */
-    val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD
+    val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
+    /** Battery level below which the percentage reads as low; see [LowSocWarning]. */
+    val lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD
 ) {
     private val selectedCar: CarData?
         get() = cars.find { it.carId == selectedCarId }
@@ -109,17 +112,19 @@ class DashboardViewModel @Inject constructor(
             loadCars()
         }
         observeCarImageOverrides()
-        observeHighSocWarningThreshold()
+        observeSocWarningThresholds()
     }
 
     /** Kept live rather than read once, so a change in Settings shows on the way back. */
-    private fun observeHighSocWarningThreshold() {
+    private fun observeSocWarningThresholds() {
         viewModelScope.launch {
             settingsDataStore.settings
-                .map { it.highSocWarningThreshold }
+                .map { it.highSocWarningThreshold to it.lowSocWarningThreshold }
                 .distinctUntilChanged()
-                .collect { threshold ->
-                    _uiState.update { it.copy(highSocWarningThreshold = threshold) }
+                .collect { (high, low) ->
+                    _uiState.update {
+                        it.copy(highSocWarningThreshold = high, lowSocWarningThreshold = low)
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TirePosition
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TpmsStateRepository
@@ -46,6 +47,7 @@ data class SettingsUiState(
     val shortDriveMinDurationMin: Int = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+    val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
     val isLoading: Boolean = true,
     val isTesting: Boolean = false,
     val isSaving: Boolean = false,
@@ -112,6 +114,7 @@ class SettingsViewModel @Inject constructor(
                 shortDriveMinDurationMin = settings.shortDriveMinDurationMin,
                 shortDriveMinDistance = settings.shortDriveMinDistance,
                 shortChargeMinEnergyKwh = settings.shortChargeMinEnergyKwh,
+                highSocWarningThreshold = settings.highSocWarningThreshold,
                 isLoading = false
             )
         }
@@ -200,6 +203,13 @@ class SettingsViewModel @Inject constructor(
     fun updateShortChargeMinEnergy(energyKwh: Double) {
         _uiState.value = _uiState.value.copy(shortChargeMinEnergyKwh = energyKwh)
         persistShortEntryThresholds()
+    }
+
+    fun updateHighSocWarningThreshold(threshold: Int) {
+        _uiState.value = _uiState.value.copy(highSocWarningThreshold = threshold)
+        viewModelScope.launch {
+            settingsDataStore.saveHighSocWarningThreshold(threshold)
+        }
     }
 
     /**

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import com.matedroid.data.local.TirePosition
 import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.TeslamateRepository
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TpmsStateRepository
@@ -48,6 +49,7 @@ data class SettingsUiState(
     val shortDriveMinDistance: Double = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
     val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
+    val lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
     val isLoading: Boolean = true,
     val isTesting: Boolean = false,
     val isSaving: Boolean = false,
@@ -115,6 +117,7 @@ class SettingsViewModel @Inject constructor(
                 shortDriveMinDistance = settings.shortDriveMinDistance,
                 shortChargeMinEnergyKwh = settings.shortChargeMinEnergyKwh,
                 highSocWarningThreshold = settings.highSocWarningThreshold,
+                lowSocWarningThreshold = settings.lowSocWarningThreshold,
                 isLoading = false
             )
         }
@@ -209,6 +212,13 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(highSocWarningThreshold = threshold)
         viewModelScope.launch {
             settingsDataStore.saveHighSocWarningThreshold(threshold)
+        }
+    }
+
+    fun updateLowSocWarningThreshold(threshold: Int) {
+        _uiState.value = _uiState.value.copy(lowSocWarningThreshold = threshold)
+        viewModelScope.launch {
+            settingsDataStore.saveLowSocWarningThreshold(threshold)
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.matedroid.R
 import com.matedroid.data.model.Currency
+import com.matedroid.domain.HighSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.domain.UnitSystem
 import com.matedroid.ui.screens.settings.SettingsGroupHeader
@@ -58,13 +59,15 @@ fun DisplaySettingsScreen(
         shortDriveMinDurationMin = uiState.shortDriveMinDurationMin,
         shortDriveMinDistance = uiState.shortDriveMinDistance,
         shortChargeMinEnergyKwh = uiState.shortChargeMinEnergyKwh,
+        highSocWarningThreshold = uiState.highSocWarningThreshold,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack,
         onCurrencyChange = viewModel::updateCurrency,
         onShowShortDrivesChargesChange = viewModel::updateShowShortDrivesCharges,
         onShortDriveMinDurationChange = viewModel::updateShortDriveMinDuration,
         onShortDriveMinDistanceChange = viewModel::updateShortDriveMinDistance,
-        onShortChargeMinEnergyChange = viewModel::updateShortChargeMinEnergy
+        onShortChargeMinEnergyChange = viewModel::updateShortChargeMinEnergy,
+        onHighSocWarningThresholdChange = viewModel::updateHighSocWarningThreshold
     )
 }
 
@@ -75,13 +78,15 @@ private fun DisplaySettingsContent(
     shortDriveMinDurationMin: Int,
     shortDriveMinDistance: Double,
     shortChargeMinEnergyKwh: Double,
+    highSocWarningThreshold: Int,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
     onCurrencyChange: (String) -> Unit,
     onShowShortDrivesChargesChange: (Boolean) -> Unit,
     onShortDriveMinDurationChange: (Int) -> Unit,
     onShortDriveMinDistanceChange: (Double) -> Unit,
-    onShortChargeMinEnergyChange: (Double) -> Unit
+    onShortChargeMinEnergyChange: (Double) -> Unit,
+    onHighSocWarningThresholdChange: (Int) -> Unit
 ) {
     var currencyDropdownExpanded by remember { mutableStateOf(false) }
     var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
@@ -238,6 +243,33 @@ private fun DisplaySettingsContent(
             },
             onValueChange = onShortChargeMinEnergyChange
         )
+
+        SettingsSpacer(24)
+
+        SettingsGroupHeader(stringResource(R.string.settings_group_battery))
+
+        Text(
+            text = stringResource(R.string.settings_high_soc_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        SettingsSpacer()
+
+        ThresholdPicker(
+            label = stringResource(R.string.settings_high_soc_threshold_label),
+            value = highSocWarningThreshold,
+            options = HighSocWarning.PRESETS,
+            enabled = true,
+            optionLabel = { level ->
+                if (level == HighSocWarning.DISABLED) {
+                    stringResource(R.string.settings_high_soc_never)
+                } else {
+                    stringResource(R.string.settings_high_soc_value, level)
+                }
+            },
+            onValueChange = onHighSocWarningThresholdChange
+        )
     }
 }
 
@@ -313,13 +345,15 @@ private fun DisplaySettingsPreview() {
             shortDriveMinDurationMin = ShortEntryFilter.DEFAULT_MIN_DRIVE_DURATION_MIN,
             shortDriveMinDistance = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
             shortChargeMinEnergyKwh = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
+            highSocWarningThreshold = HighSocWarning.DEFAULT_THRESHOLD,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
             onCurrencyChange = {},
             onShowShortDrivesChargesChange = {},
             onShortDriveMinDurationChange = {},
             onShortDriveMinDistanceChange = {},
-            onShortChargeMinEnergyChange = {}
+            onShortChargeMinEnergyChange = {},
+            onHighSocWarningThresholdChange = {}
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/DisplaySettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.matedroid.R
 import com.matedroid.data.model.Currency
 import com.matedroid.domain.HighSocWarning
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.ShortEntryFilter
 import com.matedroid.domain.UnitSystem
 import com.matedroid.ui.screens.settings.SettingsGroupHeader
@@ -60,6 +61,7 @@ fun DisplaySettingsScreen(
         shortDriveMinDistance = uiState.shortDriveMinDistance,
         shortChargeMinEnergyKwh = uiState.shortChargeMinEnergyKwh,
         highSocWarningThreshold = uiState.highSocWarningThreshold,
+        lowSocWarningThreshold = uiState.lowSocWarningThreshold,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack,
         onCurrencyChange = viewModel::updateCurrency,
@@ -67,7 +69,8 @@ fun DisplaySettingsScreen(
         onShortDriveMinDurationChange = viewModel::updateShortDriveMinDuration,
         onShortDriveMinDistanceChange = viewModel::updateShortDriveMinDistance,
         onShortChargeMinEnergyChange = viewModel::updateShortChargeMinEnergy,
-        onHighSocWarningThresholdChange = viewModel::updateHighSocWarningThreshold
+        onHighSocWarningThresholdChange = viewModel::updateHighSocWarningThreshold,
+        onLowSocWarningThresholdChange = viewModel::updateLowSocWarningThreshold
     )
 }
 
@@ -79,6 +82,7 @@ private fun DisplaySettingsContent(
     shortDriveMinDistance: Double,
     shortChargeMinEnergyKwh: Double,
     highSocWarningThreshold: Int,
+    lowSocWarningThreshold: Int,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: () -> Unit,
     onCurrencyChange: (String) -> Unit,
@@ -86,7 +90,8 @@ private fun DisplaySettingsContent(
     onShortDriveMinDurationChange: (Int) -> Unit,
     onShortDriveMinDistanceChange: (Double) -> Unit,
     onShortChargeMinEnergyChange: (Double) -> Unit,
-    onHighSocWarningThresholdChange: (Int) -> Unit
+    onHighSocWarningThresholdChange: (Int) -> Unit,
+    onLowSocWarningThresholdChange: (Int) -> Unit
 ) {
     var currencyDropdownExpanded by remember { mutableStateOf(false) }
     var showShortDrivesChargesInfoDialog by remember { mutableStateOf(false) }
@@ -263,12 +268,37 @@ private fun DisplaySettingsContent(
             enabled = true,
             optionLabel = { level ->
                 if (level == HighSocWarning.DISABLED) {
-                    stringResource(R.string.settings_high_soc_never)
+                    stringResource(R.string.settings_soc_warning_never)
                 } else {
                     stringResource(R.string.settings_high_soc_value, level)
                 }
             },
             onValueChange = onHighSocWarningThresholdChange
+        )
+
+        SettingsSpacer()
+
+        Text(
+            text = stringResource(R.string.settings_low_soc_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        SettingsSpacer()
+
+        ThresholdPicker(
+            label = stringResource(R.string.settings_low_soc_threshold_label),
+            value = lowSocWarningThreshold,
+            options = LowSocWarning.PRESETS,
+            enabled = true,
+            optionLabel = { level ->
+                if (level == LowSocWarning.DISABLED) {
+                    stringResource(R.string.settings_soc_warning_never)
+                } else {
+                    stringResource(R.string.settings_low_soc_value, level)
+                }
+            },
+            onValueChange = onLowSocWarningThresholdChange
         )
     }
 }
@@ -346,6 +376,7 @@ private fun DisplaySettingsPreview() {
             shortDriveMinDistance = ShortEntryFilter.DEFAULT_MIN_DRIVE_DISTANCE,
             shortChargeMinEnergyKwh = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
             highSocWarningThreshold = HighSocWarning.DEFAULT_THRESHOLD,
+            lowSocWarningThreshold = LowSocWarning.DEFAULT_THRESHOLD,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
             onCurrencyChange = {},
@@ -353,7 +384,8 @@ private fun DisplaySettingsPreview() {
             onShortDriveMinDurationChange = {},
             onShortDriveMinDistanceChange = {},
             onShortChargeMinEnergyChange = {},
-            onHighSocWarningThresholdChange = {}
+            onHighSocWarningThresholdChange = {},
+            onLowSocWarningThresholdChange = {}
         )
     }
 }

--- a/app/src/main/java/com/matedroid/widget/CarWidget.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidget.kt
@@ -60,6 +60,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.matedroid.MainActivity
+import com.matedroid.domain.LowSocWarning
 import com.matedroid.domain.model.CarImageResolver
 import com.matedroid.ui.theme.CarColorPalette
 import com.matedroid.ui.theme.CarColorPalettes
@@ -133,6 +134,7 @@ class CarWidget : GlanceAppWidget() {
         val IMAGE_OVERRIDE_WHEEL_KEY = stringPreferencesKey("image_override_wheel")
         val LOCATION_TEXT_KEY = stringPreferencesKey("location_text")
         val IS_IMPERIAL_KEY = booleanPreferencesKey("is_imperial")
+        val LOW_SOC_THRESHOLD_KEY = intPreferencesKey("low_soc_warning_threshold")
     }
 
     override val stateDefinition: GlanceStateDefinition<*> = PreferencesGlanceStateDefinition
@@ -209,6 +211,8 @@ class CarWidget : GlanceAppWidget() {
                             val carName = prefs[CAR_NAME_KEY] ?: ""
                             val ratedRange = prefs[RATED_RANGE_KEY]?.takeIf { it >= 0f }
                             val isImperial = prefs[IS_IMPERIAL_KEY] ?: false
+                            val lowSocThreshold = prefs[LOW_SOC_THRESHOLD_KEY]
+                                ?: LowSocWarning.DEFAULT_THRESHOLD
                             val chargeLimit = prefs[CHARGE_LIMIT_KEY]?.takeIf { it >= 0 }
                             val locationText = prefs[LOCATION_TEXT_KEY]
                             val chargeEnergyAdded = prefs[CHARGE_ENERGY_ADDED_KEY]?.takeIf { it >= 0f }
@@ -425,8 +429,8 @@ class CarWidget : GlanceAppWidget() {
 
                                 // Battery % + AC/DC badge | range + charge limit
                                 val batteryColor = when {
-                                    batteryLevel < 20 -> Color(0xFFEF5350)
-                                    batteryLevel < 40 -> Color(0xFFFF9800)
+                                    LowSocWarning.isLow(batteryLevel, lowSocThreshold) -> Color(0xFFEF5350)
+                                    LowSocWarning.isGettingLow(batteryLevel, lowSocThreshold) -> Color(0xFFFF9800)
                                     else -> Color.White
                                 }
                                 val batteryFontSize = when {
@@ -576,10 +580,10 @@ class CarWidget : GlanceAppWidget() {
                             // Progress bar at the very bottom
                             val barHeight = if (isCompact) 4.dp else 6.dp
                             val progressBitmap = remember(
-                                batteryLevel, chargeLimit, isCharging, isDcCharging, palette
+                                batteryLevel, chargeLimit, isCharging, isDcCharging, palette, lowSocThreshold
                             ) {
                                 buildProgressBarBitmap(
-                                    batteryLevel, chargeLimit, isCharging, isDcCharging, palette
+                                    batteryLevel, chargeLimit, isCharging, isDcCharging, palette, lowSocThreshold
                                 )
                             }
                             Box(
@@ -636,6 +640,7 @@ class CarWidget : GlanceAppWidget() {
                 this[AC_PHASES_KEY] = data.acPhases ?: -1
                 this[SENTRY_EVENT_COUNT_KEY] = data.sentryEventCount
                 this[IS_IMPERIAL_KEY] = data.isImperial
+                this[LOW_SOC_THRESHOLD_KEY] = data.lowSocWarningThreshold
                 if (data.imageOverride != null) {
                     this[IMAGE_OVERRIDE_VARIANT_KEY] = data.imageOverride.variant
                     this[IMAGE_OVERRIDE_WHEEL_KEY] = data.imageOverride.wheelCode
@@ -838,7 +843,8 @@ class CarWidget : GlanceAppWidget() {
         chargeLimit: Int?,
         isCharging: Boolean,
         isDcCharging: Boolean,
-        palette: CarColorPalette
+        palette: CarColorPalette,
+        lowSocThreshold: Int
     ): Bitmap {
         val w = PROGRESS_BAR_W
         val h = PROGRESS_BAR_H
@@ -871,8 +877,8 @@ class CarWidget : GlanceAppWidget() {
         val fillColor = when {
             isCharging && isDcCharging -> palette.dcColor
             isCharging -> palette.acColor
-            batteryLevel < 20 -> Color(0xFFEF5350)
-            batteryLevel < 40 -> Color(0xFFFF9800)
+            LowSocWarning.isLow(batteryLevel, lowSocThreshold) -> Color(0xFFEF5350)
+            LowSocWarning.isGettingLow(batteryLevel, lowSocThreshold) -> Color(0xFFFF9800)
             else -> palette.accent
         }
         paint.color = android.graphics.Color.argb(

--- a/app/src/main/java/com/matedroid/widget/CarWidgetDisplayData.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidgetDisplayData.kt
@@ -3,6 +3,7 @@ package com.matedroid.widget
 import com.matedroid.data.api.models.CarData
 import com.matedroid.data.api.models.CarStatus
 import com.matedroid.data.local.CarImageOverride
+import com.matedroid.domain.LowSocWarning
 
 /**
  * Data class encapsulating all fields shown on the dashboard battery card.
@@ -47,6 +48,8 @@ data class CarWidgetDisplayData(
     val locationText: String? = null,
     // --- Unit preference ---
     val isImperial: Boolean = false,
+    /** Level below which the percentage reads as low; see [com.matedroid.domain.LowSocWarning]. */
+    val lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
 ) {
     companion object {
         fun from(carData: CarData, status: CarStatus): CarWidgetDisplayData {

--- a/app/src/main/java/com/matedroid/widget/CarWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/matedroid/widget/CarWidgetUpdateWorker.kt
@@ -22,6 +22,7 @@ import com.matedroid.data.repository.ApiResult
 import com.matedroid.data.repository.GeocodingRepository
 import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TeslamateRepository
+import com.matedroid.domain.LowSocWarning
 import kotlinx.coroutines.flow.firstOrNull
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -134,6 +135,10 @@ class CarWidgetUpdateWorker @AssistedInject constructor(
         // Read image overrides once (same source as the dashboard)
         val imageOverrides = settingsDataStore.carImageOverrides.firstOrNull() ?: emptyMap()
 
+        // The low-charge colouring follows the same preference as the dashboard
+        val lowSocWarningThreshold = settingsDataStore.settings.firstOrNull()?.lowSocWarningThreshold
+            ?: LowSocWarning.DEFAULT_THRESHOLD
+
         // Fetch all cars once to avoid redundant API calls
         val carsResult = teslamateRepository.getCars()
         val cars = when (carsResult) {
@@ -166,7 +171,8 @@ class CarWidgetUpdateWorker @AssistedInject constructor(
                     sentryEventCount = sentryEventCount,
                     imageOverride = imageOverrides[carId],
                     locationText = locationText,
-                    isImperial = isImperial
+                    isImperial = isImperial,
+                    lowSocWarningThreshold = lowSocWarningThreshold
                 )
                 CarWidget().updateWidget(appContext, glanceId, displayData)
                 Log.d(TAG, "Updated widget for car $carId (${car.displayName})")

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -236,10 +236,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">La pantalla principal marca una càrrega elevada quan el cotxe està aparcat per sobre d\'aquest nivell. Les bateries LFP (Standard Range) estan dissenyades per mantenir-se a plena càrrega, així que tria Mai si és el cas del teu cotxe.</string>
     <string name="settings_high_soc_threshold_label">Avisa per sobre de</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">Mai</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">Mai</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">Per sobre del %1$d%%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">Per sota d\'aquest nivell el percentatge de bateria es mostra en vermell a la pantalla principal i al widget, i en ambre en els 20 punts just per sobre.</string>
+    <string name="settings_low_soc_threshold_label">Avisa per sota de</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">Per sota del %1$d%%</string>
 
     <string name="settings_group_costs">Costos</string>
     <string name="settings_group_lists">Llistes</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -115,12 +115,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">Nivell de càrrega alt</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">Nivell de càrrega elevat</string>
     <string name="high_soc_warning_message">Mantenir la bateria al 100% o prop d\'aquest valor durant períodes prolongats pot accelerar la degradació.\n\n• Bateries NCM (la majoria dels models Tesla): es recomana carregar fins al 80–90% per a l\'ús diari. Carrega al 100% només abans de viatges llargs.\n• Bateries LFP (Model 3/Y Standard Range): dissenyades per carregar-se regularment al 100% — Tesla ho recomana per a la calibració de la bateria.\n\nEvita deixar el cotxe aparcat amb la càrrega completa durant períodes llargs sempre que sigui possible.</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">Pots canviar el nivell en què apareix aquest avís — o desactivar-lo — a Configuració → Pantalla.</string>
 
     <!-- Location card section title -->
     <string name="location">Ubicació</string>
@@ -231,8 +233,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">La pantalla principal marca una càrrega elevada quan el cotxe està aparcat per sobre d\'aquest nivell. Les bateries LFP (Standard Range) estan dissenyades per mantenir-se a plena càrrega, així que tria Mai si és el cas del teu cotxe.</string>
+    <string name="settings_high_soc_threshold_label">Avisa per sobre de</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">Mai</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">Per sobre del %1$d%%</string>
+
     <string name="settings_group_costs">Costos</string>
     <string name="settings_group_lists">Llistes</string>
+    <string name="settings_group_battery">Bateria</string>
     <string name="settings_group_channels">Canals de notificació</string>
     <string name="settings_group_maintenance">Manteniment</string>
     <string name="settings_group_support">Suport</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -115,12 +115,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">Hoher Ladezustand</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">Hoher Ladezustand</string>
     <string name="high_soc_warning_message">Ein dauerhaft hoher Ladezustand nahe 100 % kann die Degradation der Batterie beschleunigen.\n\n• NCM-Batterien (die meisten Tesla-Modelle): Für den täglichen Gebrauch auf 80–90 % laden. Auf 100 % nur vor längeren Fahrten laden.\n• LFP-Batterien (Standard Range Model 3/Y): Dafür ausgelegt, regelmäßig auf 100 % geladen zu werden – Tesla empfiehlt dies zur Batteriekalibrierung.\n\nVermeide es nach Möglichkeit, das Auto über längere Zeit mit voller Ladung abgestellt zu lassen.</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">Den Wert, ab dem dieser Hinweis erscheint, kannst du unter Einstellungen → Anzeige ändern oder ganz abschalten.</string>
 
     <!-- Location card section title -->
     <string name="location">Standort</string>
@@ -231,8 +233,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">Das Dashboard weist auf einen hohen Ladezustand hin, wenn das Auto oberhalb dieses Werts abgestellt ist. LFP-Batterien (Standard Range) sind dafür ausgelegt, voll geladen zu bleiben – wähle dann Nie.</string>
+    <string name="settings_high_soc_threshold_label">Warnen über</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">Nie</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">Über %1$d %%</string>
+
     <string name="settings_group_costs">Kosten</string>
     <string name="settings_group_lists">Listen</string>
+    <string name="settings_group_battery">Batterie</string>
     <string name="settings_group_channels">Benachrichtigungskanäle</string>
     <string name="settings_group_maintenance">Wartung</string>
     <string name="settings_group_support">Support</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -236,10 +236,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">Das Dashboard weist auf einen hohen Ladezustand hin, wenn das Auto oberhalb dieses Werts abgestellt ist. LFP-Batterien (Standard Range) sind dafür ausgelegt, voll geladen zu bleiben – wähle dann Nie.</string>
     <string name="settings_high_soc_threshold_label">Warnen über</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">Nie</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">Nie</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">Über %1$d %%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">Unterhalb dieses Werts wird der Batteriestand auf dem Dashboard und im Widget rot dargestellt, in den 20 Punkten darüber gelb.</string>
+    <string name="settings_low_soc_threshold_label">Warnen unter</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">Unter %1$d %%</string>
 
     <string name="settings_group_costs">Kosten</string>
     <string name="settings_group_lists">Listen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -236,10 +236,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">La pantalla principal marca una carga elevada cuando el coche está aparcado por encima de este nivel. Las baterías LFP (Standard Range) están diseñadas para permanecer a plena carga, así que elige Nunca si es el caso de tu coche.</string>
     <string name="settings_high_soc_threshold_label">Avisar por encima de</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">Nunca</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">Nunca</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">Por encima del %1$d%%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">Por debajo de este nivel el porcentaje de batería se muestra en rojo en la pantalla principal y en el widget, y en ámbar en los 20 puntos justo por encima.</string>
+    <string name="settings_low_soc_threshold_label">Avisar por debajo de</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">Por debajo del %1$d%%</string>
 
     <string name="settings_group_costs">Costes</string>
     <string name="settings_group_lists">Listas</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -115,12 +115,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">Nivel de carga alto</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">Estado de carga elevado</string>
     <string name="high_soc_warning_message">Mantener la batería al 100% o cerca de ese valor durante períodos prolongados puede acelerar la degradación.\n\n• Baterías NCM (la mayoría de los modelos Tesla): se recomienda cargar al 80–90% para el uso diario. Carga al 100% solo antes de viajes largos.\n• Baterías LFP (Model 3/Y Standard Range): diseñadas para cargarse regularmente al 100% — Tesla lo recomienda para la calibración de la batería.\n\nEvita dejar el coche aparcado con la carga completa durante períodos prolongados siempre que sea posible.</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">Puedes cambiar el nivel al que aparece este aviso — o desactivarlo — en Ajustes → Pantalla.</string>
 
     <!-- Location card section title -->
     <string name="location">Ubicación</string>
@@ -231,8 +233,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">La pantalla principal marca una carga elevada cuando el coche está aparcado por encima de este nivel. Las baterías LFP (Standard Range) están diseñadas para permanecer a plena carga, así que elige Nunca si es el caso de tu coche.</string>
+    <string name="settings_high_soc_threshold_label">Avisar por encima de</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">Nunca</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">Por encima del %1$d%%</string>
+
     <string name="settings_group_costs">Costes</string>
     <string name="settings_group_lists">Listas</string>
+    <string name="settings_group_battery">Batería</string>
     <string name="settings_group_channels">Canales de notificación</string>
     <string name="settings_group_maintenance">Mantenimiento</string>
     <string name="settings_group_support">Soporte</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -236,10 +236,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">La schermata principale segnala una carica elevata quando l\'auto è parcheggiata sopra questo livello. Le batterie LFP (Standard Range) sono progettate per restare a piena carica, quindi scegli Mai se è il caso della tua auto.</string>
     <string name="settings_high_soc_threshold_label">Avvisa sopra</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">Mai</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">Mai</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">Sopra il %1$d%%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">Sotto questo livello la percentuale della batteria diventa rossa sulla schermata principale e sul widget, e ambra nei 20 punti appena sopra.</string>
+    <string name="settings_low_soc_threshold_label">Avvisa sotto</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">Sotto il %1$d%%</string>
 
     <string name="settings_group_costs">Costi</string>
     <string name="settings_group_lists">Elenchi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -115,12 +115,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">Livello carica elevato</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">Stato di carica elevato</string>
     <string name="high_soc_warning_message">Mantenere la batteria al 100% o in prossimità di tale valore per periodi prolungati può accelerare il degrado.\n\n• Batterie NCM (la maggior parte dei modelli Tesla): si consiglia di caricare all\'80–90% per l\'uso quotidiano. Caricare al 100% solo prima di lunghi viaggi.\n• Batterie LFP (Model 3/Y Standard Range): progettate per essere caricate regolarmente al 100% — Tesla lo consiglia per la calibrazione della batteria.\n\nEvita di lasciare l\'auto parcheggiata a piena carica per lunghi periodi quando possibile.</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">Puoi cambiare il livello a cui compare questo avviso — o disattivarlo — in Impostazioni → Visualizzazione.</string>
 
     <!-- Location card section title -->
     <string name="location">Posizione</string>
@@ -231,8 +233,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">La schermata principale segnala una carica elevata quando l\'auto è parcheggiata sopra questo livello. Le batterie LFP (Standard Range) sono progettate per restare a piena carica, quindi scegli Mai se è il caso della tua auto.</string>
+    <string name="settings_high_soc_threshold_label">Avvisa sopra</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">Mai</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">Sopra il %1$d%%</string>
+
     <string name="settings_group_costs">Costi</string>
     <string name="settings_group_lists">Elenchi</string>
+    <string name="settings_group_battery">Batteria</string>
     <string name="settings_group_channels">Canali di notifica</string>
     <string name="settings_group_maintenance">Manutenzione</string>
     <string name="settings_group_support">Assistenza</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -115,12 +115,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">电量过高</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">高电量状态</string>
     <string name="high_soc_warning_message">长时间将电池保持在 100% 或接近满电状态可能会加速电池老化。\n\n• NCM 电池（大多数 Tesla 车型）：日常使用建议充电至 80–90%。仅在长途出行前充至 100%。\n• LFP 电池（标准续航版 Model 3/Y）：可以经常充至 100%——Tesla 建议定期满充以校准电池。\n\n请尽量避免车辆长时间停放在满电状态。</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">你可以在「设置 → 显示」中调整该提示出现的电量，或将其关闭。</string>
 
     <!-- Location card section title -->
     <string name="location">位置</string>
@@ -231,8 +233,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">当车辆停放且电量高于此水平时，主界面会标记高电量状态。LFP 电池（标准续航版）本就适合保持满电，如果你的车是这种电池，请选择「从不」。</string>
+    <string name="settings_high_soc_threshold_label">高于此电量时提醒</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">从不</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">高于 %1$d%%</string>
+
     <string name="settings_group_costs">费用</string>
     <string name="settings_group_lists">列表</string>
+    <string name="settings_group_battery">电池</string>
     <string name="settings_group_channels">通知渠道</string>
     <string name="settings_group_maintenance">维护</string>
     <string name="settings_group_support">支持</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -236,10 +236,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">当车辆停放且电量高于此水平时，主界面会标记高电量状态。LFP 电池（标准续航版）本就适合保持满电，如果你的车是这种电池，请选择「从不」。</string>
     <string name="settings_high_soc_threshold_label">高于此电量时提醒</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">从不</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">从不</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">高于 %1$d%%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">低于此电量时，主界面和小组件上的电量百分比显示为红色，往上 20 个百分点内显示为琥珀色。</string>
+    <string name="settings_low_soc_threshold_label">低于此电量时提醒</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">低于 %1$d%%</string>
 
     <string name="settings_group_costs">费用</string>
     <string name="settings_group_lists">列表</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,12 +118,14 @@
     <!-- AC (Alternating Current) charging indicator badge -->
     <string name="charging_ac">AC</string>
 
-    <!-- Content description for warning icon when battery is above 90% -->
+    <!-- Content description for warning icon when battery is above the configured warning level -->
     <string name="high_charge_level">High charge level</string>
 
     <!-- Title and message for the high SoC info dialog shown when tapping the warning icon -->
     <string name="high_soc_warning_title">High State of Charge</string>
     <string name="high_soc_warning_message">Keeping your battery at or near 100% for extended periods can accelerate degradation.\n\n• NCM batteries (most Tesla models): charge to 80–90% for daily use. Only charge to 100% before long trips.\n• LFP batteries (Standard Range Model 3/Y): designed to be charged to 100% regularly — Tesla recommends it for battery calibration.\n\nAvoid leaving the car parked at full charge for long periods whenever possible.</string>
+    <!-- Footer of the same dialog, pointing at the setting that changes or hides the warning -->
+    <string name="high_soc_warning_settings_hint">You can change the level this warning appears at — or turn it off — in Settings → Display.</string>
 
     <!-- Location card section title -->
     <string name="location">Location</string>
@@ -234,8 +236,17 @@
     <string name="settings_threshold_value_mi">%1$s mi</string>
     <string name="settings_threshold_value_kwh">%1$s kWh</string>
 
+    <!-- Configurable level for the dashboard high-charge warning (Display section) -->
+    <string name="settings_high_soc_hint">The dashboard flags a high state of charge when the car is parked above this level. LFP batteries (Standard Range) are designed to sit at full charge, so pick Never if that is your car.</string>
+    <string name="settings_high_soc_threshold_label">Warn above</string>
+    <!-- Shown when the high-charge warning is switched off -->
+    <string name="settings_high_soc_never">Never</string>
+    <!-- A high-charge warning level, e.g. "Above 90%" -->
+    <string name="settings_high_soc_value">Above %1$d%%</string>
+
     <string name="settings_group_costs">Costs</string>
     <string name="settings_group_lists">Lists</string>
+    <string name="settings_group_battery">Battery</string>
     <string name="settings_group_channels">Notification channels</string>
     <string name="settings_group_maintenance">Maintenance</string>
     <string name="settings_group_support">Support</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,10 +239,15 @@
     <!-- Configurable level for the dashboard high-charge warning (Display section) -->
     <string name="settings_high_soc_hint">The dashboard flags a high state of charge when the car is parked above this level. LFP batteries (Standard Range) are designed to sit at full charge, so pick Never if that is your car.</string>
     <string name="settings_high_soc_threshold_label">Warn above</string>
-    <!-- Shown when the high-charge warning is switched off -->
-    <string name="settings_high_soc_never">Never</string>
+    <!-- Shown when a charge warning is switched off -->
+    <string name="settings_soc_warning_never">Never</string>
     <!-- A high-charge warning level, e.g. "Above 90%" -->
     <string name="settings_high_soc_value">Above %1$d%%</string>
+    <!-- Configurable level for the low-charge colouring (Display section) -->
+    <string name="settings_low_soc_hint">Below this level the battery percentage turns red on the dashboard and the widget, and amber for the 20 points just above it.</string>
+    <string name="settings_low_soc_threshold_label">Warn below</string>
+    <!-- A low-charge warning level, e.g. "Below 20%" -->
+    <string name="settings_low_soc_value">Below %1$d%%</string>
 
     <string name="settings_group_costs">Costs</string>
     <string name="settings_group_lists">Lists</string>

--- a/app/src/test/java/com/matedroid/domain/HighSocWarningTest.kt
+++ b/app/src/test/java/com/matedroid/domain/HighSocWarningTest.kt
@@ -1,0 +1,50 @@
+package com.matedroid.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HighSocWarningTest {
+
+    @Test
+    fun `warns above the threshold when parked`() {
+        assertTrue(HighSocWarning.shouldWarn(batteryLevel = 95, isCharging = false, threshold = 90))
+    }
+
+    @Test
+    fun `does not warn at the threshold itself`() {
+        assertFalse(HighSocWarning.shouldWarn(batteryLevel = 90, isCharging = false, threshold = 90))
+    }
+
+    @Test
+    fun `never warns while charging`() {
+        assertFalse(HighSocWarning.shouldWarn(batteryLevel = 100, isCharging = true, threshold = 90))
+    }
+
+    @Test
+    fun `disabled threshold silences the warning even at full charge`() {
+        assertFalse(
+            HighSocWarning.shouldWarn(
+                batteryLevel = 100,
+                isCharging = false,
+                threshold = HighSocWarning.DISABLED
+            )
+        )
+    }
+
+    @Test
+    fun `default threshold keeps the previous above-90 behaviour`() {
+        assertFalse(
+            HighSocWarning.shouldWarn(90, isCharging = false, threshold = HighSocWarning.DEFAULT_THRESHOLD)
+        )
+        assertTrue(
+            HighSocWarning.shouldWarn(91, isCharging = false, threshold = HighSocWarning.DEFAULT_THRESHOLD)
+        )
+    }
+
+    @Test
+    fun `presets offer the disabled option first`() {
+        assertTrue(HighSocWarning.PRESETS.first() == HighSocWarning.DISABLED)
+        assertTrue(HighSocWarning.PRESETS.contains(HighSocWarning.DEFAULT_THRESHOLD))
+    }
+}

--- a/app/src/test/java/com/matedroid/domain/HighSocWarningTest.kt
+++ b/app/src/test/java/com/matedroid/domain/HighSocWarningTest.kt
@@ -1,5 +1,6 @@
 package com.matedroid.domain
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -43,8 +44,16 @@ class HighSocWarningTest {
     }
 
     @Test
-    fun `presets offer the disabled option first`() {
-        assertTrue(HighSocWarning.PRESETS.first() == HighSocWarning.DISABLED)
+    fun `presets ascend with the disabled option last`() {
+        assertTrue(HighSocWarning.PRESETS.last() == HighSocWarning.DISABLED)
         assertTrue(HighSocWarning.PRESETS.contains(HighSocWarning.DEFAULT_THRESHOLD))
+        val levels = HighSocWarning.PRESETS.dropLast(1)
+        assertEquals(levels.sorted(), levels)
+    }
+
+    @Test
+    fun `warning still fires one point below a full charge`() {
+        assertTrue(HighSocWarning.shouldWarn(batteryLevel = 100, isCharging = false, threshold = 99))
+        assertFalse(HighSocWarning.shouldWarn(batteryLevel = 99, isCharging = false, threshold = 99))
     }
 }

--- a/app/src/test/java/com/matedroid/domain/LowSocWarningTest.kt
+++ b/app/src/test/java/com/matedroid/domain/LowSocWarningTest.kt
@@ -1,0 +1,45 @@
+package com.matedroid.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LowSocWarningTest {
+
+    @Test
+    fun `reads as low below the threshold`() {
+        assertTrue(LowSocWarning.isLow(batteryLevel = 15, threshold = 20))
+    }
+
+    @Test
+    fun `does not read as low at the threshold itself`() {
+        assertFalse(LowSocWarning.isLow(batteryLevel = 20, threshold = 20))
+    }
+
+    @Test
+    fun `amber band covers the points just above the threshold`() {
+        assertTrue(LowSocWarning.isGettingLow(batteryLevel = 30, threshold = 20))
+        assertFalse(LowSocWarning.isGettingLow(batteryLevel = 40, threshold = 20))
+    }
+
+    @Test
+    fun `disabled threshold leaves every level alone`() {
+        assertFalse(LowSocWarning.isLow(batteryLevel = 1, threshold = LowSocWarning.DISABLED))
+        assertFalse(LowSocWarning.isGettingLow(batteryLevel = 1, threshold = LowSocWarning.DISABLED))
+    }
+
+    @Test
+    fun `default threshold keeps the previous red-under-20 amber-under-40 behaviour`() {
+        val default = LowSocWarning.DEFAULT_THRESHOLD
+        assertTrue(LowSocWarning.isLow(19, default))
+        assertFalse(LowSocWarning.isLow(20, default))
+        assertTrue(LowSocWarning.isGettingLow(39, default))
+        assertFalse(LowSocWarning.isGettingLow(40, default))
+    }
+
+    @Test
+    fun `presets offer the disabled option first`() {
+        assertTrue(LowSocWarning.PRESETS.first() == LowSocWarning.DISABLED)
+        assertTrue(LowSocWarning.PRESETS.contains(LowSocWarning.DEFAULT_THRESHOLD))
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,7 +79,7 @@ Settings is a **category list → detail page** structure (the pattern Android a
 3. Create the composable in `ui/screens/settings/sections/`, wrapping the content in `SettingsSectionScaffold`.
 4. Add the branch to the `when` in `NavGraph.kt`'s `composable<Screen.SettingsSection>`.
 
-#### High state-of-charge warning
+#### State-of-charge warning levels
 
 The warning triangle next to the battery percentage on the dashboard fires above a
 **user-configurable level** (Settings → Display → "Warn above", default 90%, presets in
@@ -95,6 +95,18 @@ The predicate lives in `HighSocWarning.shouldWarn(batteryLevel, isCharging, thre
 car is never flagged, since it is on its way to the limit set in the car. The threshold reaches
 `BatteryCard` through `DashboardUiState`, which `DashboardViewModel` keeps in sync with the DataStore
 flow (not a one-shot read) so a change applies on the way back from Settings.
+
+The low end is the mirror image: `domain/LowSocWarning.kt` (Settings → Display → "Warn below",
+default 20%) decides when the battery percentage turns red, with an amber band covering the
+`AMBER_MARGIN` (20) points just above — at the default that is red under 20% and amber under 40%,
+exactly where both used to be hardcoded. `isLow()` / `isGettingLow()` are checked in that order, and
+`DISABLED` leaves the percentage in the palette colour at any level.
+
+Unlike the high warning, this one also drives the **widget**: it renders in its own process from
+Glance state, so the threshold is read once per run by `CarWidgetUpdateWorker`, carried in
+`CarWidgetDisplayData` and persisted to `CarWidget.LOW_SOC_THRESHOLD_KEY`. Both widget colour sites
+(the percentage text and `buildProgressBarBitmap`) read it from there — the bar bitmap is cached, so
+the threshold must stay in its `remember` keys or a changed setting won't repaint it.
 
 ### Localization (i18n)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,6 +79,23 @@ Settings is a **category list → detail page** structure (the pattern Android a
 3. Create the composable in `ui/screens/settings/sections/`, wrapping the content in `SettingsSectionScaffold`.
 4. Add the branch to the `when` in `NavGraph.kt`'s `composable<Screen.SettingsSection>`.
 
+#### High state-of-charge warning
+
+The warning triangle next to the battery percentage on the dashboard fires above a
+**user-configurable level** (Settings → Display → "Warn above", default 90%, presets in
+`domain/HighSocWarning.kt`). `HighSocWarning.DISABLED` (`0`) is the "Never" option and hides it
+entirely — that is the LFP case (#310): those packs are meant to be charged to 100% regularly, so
+the warning is wrong for them.
+
+The chemistry is **not** auto-detected. `BatteryTypeHelper` infers LFP from `trim_badging == "50"`
+for the DC power ceiling, but that badging is not reliable enough across markets and model years to
+silence a battery-health warning on, so the level is a preference instead.
+
+The predicate lives in `HighSocWarning.shouldWarn(batteryLevel, isCharging, threshold)` — a charging
+car is never flagged, since it is on its way to the limit set in the car. The threshold reaches
+`BatteryCard` through `DashboardUiState`, which `DashboardViewModel` keeps in sync with the DataStore
+flow (not a one-shot read) so a change applies on the way back from Settings.
+
 ### Localization (i18n)
 
 The app supports multiple languages using Android's standard resource-based localization system. Currently supported languages:


### PR DESCRIPTION
Closes #310.

## The problem

Two battery levels were hardcoded:

- the warning triangle next to the battery percentage fired above a fixed **90%** — permanent and wrong for LFP cars (Standard Range Model 3/Y), which Tesla says to charge to 100% regularly;
- the percentage turned **red below 20%** and amber below 40%, on both the dashboard and the widget — the wrong line for a short-range car used for commuting, and for a long-range one that never sees a Supercharger.

The issue asked for a battery-type setting or auto-detection. Per follow-up discussion this ships as **threshold settings** instead, which covers the LFP case and also lets anyone tune both ends.

Chemistry is deliberately not auto-detected: `BatteryTypeHelper` infers LFP from `trim_badging == "50"` for the DC power ceiling, but that badging isn't reliable enough across markets and model years to silence a battery-health warning on.

## What changed

**Settings → Display → Battery** now has two pickers, both writing through immediately:

- **"Warn above"** — Never / 70 / 75 / 80 / 85 / 90 / 95%, default 90 (the previous fixed behaviour).
- **"Warn below"** — Never / 10 / 15 / 20 / 25 / 30 / 40%, default 20. Amber follows 20 points above the red level, so the default reproduces red-under-20 / amber-under-40 exactly.

Also:

- `domain/HighSocWarning.kt` — presets, default, `DISABLED` sentinel, `shouldWarn(batteryLevel, isCharging, threshold)`. A charging car is still never flagged.
- `domain/LowSocWarning.kt` — the mirror image: `isLow()` / `isGettingLow()` and `AMBER_MARGIN`.
- Dashboard: both thresholds reach `BatteryCard` through `DashboardUiState`; `DashboardViewModel` collects them from the DataStore flow (not a one-shot read) so changes apply on the way back from Settings.
- Widget: it renders in its own process from Glance state, so the low threshold is read once per run by `CarWidgetUpdateWorker`, carried in `CarWidgetDisplayData` and persisted to `LOW_SOC_THRESHOLD_KEY`. Both colour sites use it — the percentage text and `buildProgressBarBitmap`, where it is also a `remember` key so the cached bar repaints on a change.
- The info dialog behind the warning icon gained a footer pointing at the setting — the LFP owners this doesn't apply to are exactly the people who open that dialog.
- Strings in all six locales; `docs/DEVELOPMENT.md` documents both rules and why detection was rejected.

## Testing

- `HighSocWarningTest` (6 cases) and `LowSocWarningTest` (6 cases), both including "the default preserves the old hardcoded behaviour".
- `./gradlew testDebugUnitTest lintDebug assembleDebug` pass; installed on device for manual checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
