### PR TITLE
fix: Test Connection now uses the timeout the form is showing (#230)

### DIFF
--- a/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
+++ b/app/src/main/java/com/matedroid/data/repository/TeslamateRepository.kt
@@ -209,9 +209,17 @@ class TeslamateRepository @Inject constructor(
         return primaryResult ?: ApiResult.Error("Connection failed")
     }
 
-    suspend fun testConnection(serverUrl: String, acceptInvalidCerts: Boolean = false): ApiResult<Unit> {
+    /**
+     * Pings [serverUrl] with the settings the caller passes rather than the saved ones, so
+     * Settings can test the form as it stands before anything is committed to disk.
+     */
+    suspend fun testConnection(
+        serverUrl: String,
+        acceptInvalidCerts: Boolean = false,
+        connectTimeoutSeconds: Int? = null
+    ): ApiResult<Unit> {
         return try {
-            val api = apiFactory.create(serverUrl, acceptInvalidCerts)
+            val api = apiFactory.create(serverUrl, acceptInvalidCerts, connectTimeoutSeconds)
             val response = api.ping()
             if (response.isSuccessful) {
                 ApiResult.Success(Unit)

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -120,16 +120,22 @@ class TeslamateApiFactory(
      *
      * @param baseUrl The base URL for the API
      * @param acceptInvalidCerts Override for accepting invalid certificates. If null, uses the setting from DataStore.
+     * @param connectTimeoutSeconds Override for the connect timeout, already resolved. If null,
+     *   it is resolved from the settings in DataStore — see [ConnectionTimeout].
      * @return A TeslamateApi instance configured for the given URL
      */
-    suspend fun create(baseUrl: String, acceptInvalidCerts: Boolean? = null): TeslamateApi {
+    suspend fun create(
+        baseUrl: String,
+        acceptInvalidCerts: Boolean? = null,
+        connectTimeoutSeconds: Int? = null
+    ): TeslamateApi {
         val normalizedUrl = baseUrl.trimEnd('/') + "/"
         val settings = settingsDataStore.settings.first()
         val useInsecure = acceptInvalidCerts ?: settings.acceptInvalidCerts
         val apiToken = settings.apiToken
         val basicAuthUsername = settings.httpBasicAuthUsername
         val basicAuthPassword = settings.httpBasicAuthPassword
-        val connectTimeoutSeconds = ConnectionTimeout.resolveSeconds(
+        val timeoutSeconds = connectTimeoutSeconds ?: ConnectionTimeout.resolveSeconds(
             setting = settings.connectTimeoutSeconds,
             hasFallbackServer = settings.hasSecondaryServer
         )
@@ -142,7 +148,7 @@ class TeslamateApiFactory(
             apiToken,
             basicAuthUsername,
             basicAuthPassword,
-            connectTimeoutSeconds
+            timeoutSeconds
         )
 
         // Return cached API if available
@@ -154,7 +160,7 @@ class TeslamateApiFactory(
             useInsecure,
             basicAuthUsername,
             basicAuthPassword,
-            connectTimeoutSeconds
+            timeoutSeconds
         )
 
         val api = Retrofit.Builder()
@@ -184,7 +190,11 @@ class TeslamateApiFactory(
         apiCache.clear()
     }
 
-    private fun createOkHttpClient(
+    /**
+     * Internal rather than private so a unit test can assert that the configured timeout
+     * really reaches OkHttp, in the unit OkHttp expects.
+     */
+    internal fun createOkHttpClient(
         apiToken: String,
         acceptInvalidCerts: Boolean,
         basicAuthUsername: String = "",

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -300,15 +300,34 @@ class SettingsViewModel @Inject constructor(
                 return@launch
             }
 
+            // Test what the form says, not what is on disk: neither the timeout picker's
+            // "Automatic" resolution nor the secondary URL it depends on are saved yet.
+            val timeoutSeconds = ConnectionTimeout.resolveSeconds(
+                setting = _uiState.value.connectTimeoutSeconds,
+                hasFallbackServer = secondaryUrl.isNotBlank()
+            )
+
             // Test primary server
-            val primaryResult = when (val result = repository.testConnection(primaryUrl, _uiState.value.acceptInvalidCerts)) {
+            val primaryResult = when (
+                val result = repository.testConnection(
+                    primaryUrl,
+                    _uiState.value.acceptInvalidCerts,
+                    timeoutSeconds
+                )
+            ) {
                 is ApiResult.Success -> ServerTestResult.Success
                 is ApiResult.Error -> ServerTestResult.Failure(result.message)
             }
 
             // Test secondary server if configured
             val secondaryResult = if (secondaryUrl.isNotBlank()) {
-                when (val result = repository.testConnection(secondaryUrl, _uiState.value.acceptInvalidCerts)) {
+                when (
+                    val result = repository.testConnection(
+                        secondaryUrl,
+                        _uiState.value.acceptInvalidCerts,
+                        timeoutSeconds
+                    )
+                ) {
                     is ApiResult.Success -> ServerTestResult.Success
                     is ApiResult.Error -> ServerTestResult.Failure(result.message)
                 }

--- a/app/src/test/java/com/matedroid/di/TeslamateApiFactoryTest.kt
+++ b/app/src/test/java/com/matedroid/di/TeslamateApiFactoryTest.kt
@@ -1,0 +1,126 @@
+package com.matedroid.di
+
+import com.matedroid.data.local.AppSettings
+import com.matedroid.data.local.SettingsDataStore
+import com.matedroid.domain.ConnectionTimeout
+import com.squareup.moshi.Moshi
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers the two halves of the configurable connect timeout that ConnectionTimeoutTest
+ * cannot see: that the resolved value reaches OkHttp in the unit it expects, and that the
+ * API cache does not hand back a client built with the old timeout after the setting changes.
+ */
+class TeslamateApiFactoryTest {
+
+    private lateinit var settingsDataStore: SettingsDataStore
+    private lateinit var factory: TeslamateApiFactory
+
+    /** Mutable so a test can change the settings between two [TeslamateApiFactory.create] calls. */
+    private var currentSettings = AppSettings(serverUrl = PRIMARY)
+
+    @Before
+    fun setup() {
+        settingsDataStore = mockk()
+        every { settingsDataStore.settings } answers { flowOf(currentSettings) }
+        factory = TeslamateApiFactory(settingsDataStore, Moshi.Builder().build())
+    }
+
+    @Test
+    fun `the configured timeout reaches OkHttp as seconds`() {
+        val client = factory.createOkHttpClient(
+            apiToken = "",
+            acceptInvalidCerts = false,
+            connectTimeoutSeconds = 5
+        )
+
+        assertEquals(5_000, client.connectTimeoutMillis)
+    }
+
+    @Test
+    fun `the timeout setting does not disturb reads and writes`() {
+        val client = factory.createOkHttpClient(
+            apiToken = "",
+            acceptInvalidCerts = false,
+            connectTimeoutSeconds = 1
+        )
+
+        assertEquals(1_000, client.connectTimeoutMillis)
+        assertEquals(30_000, client.readTimeoutMillis)
+        assertEquals(30_000, client.writeTimeoutMillis)
+    }
+
+    @Test
+    fun `an unchanged configuration reuses the cached api`() = runTest {
+        val first = factory.create(PRIMARY)
+        val second = factory.create(PRIMARY)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `changing the timeout builds a new api instead of reusing the cached one`() = runTest {
+        currentSettings = AppSettings(serverUrl = PRIMARY, connectTimeoutSeconds = 1)
+        val before = factory.create(PRIMARY)
+
+        currentSettings = AppSettings(serverUrl = PRIMARY, connectTimeoutSeconds = 10)
+        val after = factory.create(PRIMARY)
+
+        assertNotSame(before, after)
+    }
+
+    @Test
+    fun `adding a fallback server re-resolves the automatic timeout`() = runTest {
+        currentSettings = AppSettings(serverUrl = PRIMARY, connectTimeoutSeconds = ConnectionTimeout.AUTO)
+        val singleServer = factory.create(PRIMARY)
+
+        currentSettings = currentSettings.copy(secondaryServerUrl = SECONDARY)
+        val withFallback = factory.create(PRIMARY)
+
+        // Automatic goes from 5s to 1s, so the cached client must not be reused.
+        assertNotSame(singleServer, withFallback)
+    }
+
+    @Test
+    fun `an explicit timeout is unaffected by adding a fallback server`() = runTest {
+        currentSettings = AppSettings(serverUrl = PRIMARY, connectTimeoutSeconds = 5)
+        val singleServer = factory.create(PRIMARY)
+
+        currentSettings = currentSettings.copy(secondaryServerUrl = SECONDARY)
+        val withFallback = factory.create(PRIMARY)
+
+        assertSame(singleServer, withFallback)
+    }
+
+    @Test
+    fun `an explicit override wins over the stored timeout`() = runTest {
+        currentSettings = AppSettings(serverUrl = PRIMARY, connectTimeoutSeconds = 1)
+        val fromSettings = factory.create(PRIMARY)
+        val fromOverride = factory.create(PRIMARY, connectTimeoutSeconds = 15)
+
+        assertNotSame(fromSettings, fromOverride)
+        // The override is part of the cache key like every other setting, so it still caches.
+        assertSame(fromOverride, factory.create(PRIMARY, connectTimeoutSeconds = 15))
+    }
+
+    @Test
+    fun `invalidateCache forces the next api to be rebuilt`() = runTest {
+        val before = factory.create(PRIMARY)
+        factory.invalidateCache()
+
+        assertNotSame(before, factory.create(PRIMARY))
+    }
+
+    private companion object {
+        const val PRIMARY = "https://primary.example.com"
+        const val SECONDARY = "https://secondary.example.com"
+    }
+}

--- a/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/matedroid/ui/screens/settings/SettingsViewModelTest.kt
@@ -13,6 +13,7 @@ import com.matedroid.data.repository.SentryStateRepository
 import com.matedroid.data.repository.TpmsStateRepository
 import com.matedroid.notification.SentryNotificationManager
 import com.matedroid.data.sync.SyncManager
+import com.matedroid.domain.ConnectionTimeout
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -173,7 +174,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `testConnection succeeds with valid url`() = runTest {
-        coEvery { repository.testConnection(any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.testConnection(any(), any(), any()) } returns ApiResult.Success(Unit)
         // Mock global settings fetch (called after successful connection)
         coEvery { repository.getGlobalSettings() } returns ApiResult.Success(GlobalSettingsData(settings = GlobalSettings(teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com"))))
         coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit
@@ -193,8 +194,8 @@ class SettingsViewModelTest {
 
     @Test
     fun `testConnection tests both servers when secondary is configured`() = runTest {
-        coEvery { repository.testConnection("https://primary.com", any()) } returns ApiResult.Success(Unit)
-        coEvery { repository.testConnection("https://secondary.com", any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.testConnection("https://primary.com", any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.testConnection("https://secondary.com", any(), any()) } returns ApiResult.Success(Unit)
         // Mock global settings fetch (called after successful connection)
         coEvery { repository.getGlobalSettings() } returns ApiResult.Success(GlobalSettingsData(settings = GlobalSettings(teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com"))))
         coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit
@@ -216,8 +217,8 @@ class SettingsViewModelTest {
 
     @Test
     fun `testConnection shows both results when primary fails and secondary succeeds`() = runTest {
-        coEvery { repository.testConnection("https://primary.com", any()) } returns ApiResult.Error("Connection refused")
-        coEvery { repository.testConnection("https://secondary.com", any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.testConnection("https://primary.com", any(), any()) } returns ApiResult.Error("Connection refused")
+        coEvery { repository.testConnection("https://secondary.com", any(), any()) } returns ApiResult.Success(Unit)
 
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -239,7 +240,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `testConnection shows failure when api returns error`() = runTest {
-        coEvery { repository.testConnection(any(), any()) } returns ApiResult.Error("Connection refused")
+        coEvery { repository.testConnection(any(), any(), any()) } returns ApiResult.Error("Connection refused")
 
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -285,6 +286,60 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `updateConnectTimeoutSeconds saves immediately so Test Connection uses it`() = runTest {
+        coEvery { settingsDataStore.saveConnectTimeoutSeconds(any()) } returns Unit
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.updateConnectTimeoutSeconds(10)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(10, viewModel.uiState.value.connectTimeoutSeconds)
+        coVerify { settingsDataStore.saveConnectTimeoutSeconds(10) }
+    }
+
+    @Test
+    fun `initial state loads the connect timeout from datastore`() = runTest {
+        every { settingsDataStore.settings } returns flowOf(AppSettings(connectTimeoutSeconds = 3))
+
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(3, viewModel.uiState.value.connectTimeoutSeconds)
+    }
+
+    @Test
+    fun `connect timeout defaults to automatic`() = runTest {
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ConnectionTimeout.AUTO, viewModel.uiState.value.connectTimeoutSeconds)
+    }
+
+    @Test
+    fun `testConnection resolves the timeout from the form, not the saved settings`() = runTest {
+        // Stored: no fallback server, so Automatic is 5s. On screen: a fallback server has just
+        // been typed but not saved, which makes Automatic 1s.
+        every { settingsDataStore.settings } returns flowOf(AppSettings(serverUrl = "https://primary.com"))
+        coEvery { repository.testConnection(any(), any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.getGlobalSettings() } returns ApiResult.Error("skip")
+        viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.updateSecondaryServerUrl("https://secondary.com")
+        viewModel.testConnection()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify {
+            repository.testConnection(
+                "https://primary.com",
+                false,
+                ConnectionTimeout.WITH_FALLBACK_SECONDS
+            )
+        }
+    }
+
+    @Test
     fun `updateAcceptInvalidCerts updates state`() = runTest {
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -313,7 +368,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `clearTestResult clears test result`() = runTest {
-        coEvery { repository.testConnection(any(), any()) } returns ApiResult.Success(Unit)
+        coEvery { repository.testConnection(any(), any(), any()) } returns ApiResult.Success(Unit)
         // Mock global settings fetch (called after successful connection)
         coEvery { repository.getGlobalSettings() } returns ApiResult.Success(GlobalSettingsData(settings = GlobalSettings(teslamateUrls = TeslamateUrls(baseUrl = "https://teslamate.example.com"))))
         coEvery { settingsDataStore.saveTeslamateBaseUrl(any()) } returns Unit


### PR DESCRIPTION
## Summary

Follow-up to #369 after re-reviewing the configurable connect timeout: one real inconsistency fixed, and tests pinning down the parts that were previously only reasoned about.

## The bug

`Test Connection` built its client from the **stored** settings, but the picker's `Automatic (N s)` label resolves from the **typed** secondary URL. Those disagree while the form is dirty:

| Stored secondary | Typed secondary | Label says | Probe actually used |
|---|---|---|---|
| (none) | `https://backup…` | Automatic (1 s) | 5 s — harmlessly lenient |
| `https://backup…` | (cleared) | Automatic (5 s) | **1 s** |

The second row is the trap: on a slow-TLS server the test reports failure while *saving* would have worked, which is the same "silently fails to connect" confusion #230 was about.

The resolved timeout is now threaded through `testConnection()` exactly the way `acceptInvalidCerts` already was, so the probe exercises the form as it stands. The secondary server is deliberately probed with the same resolved value, since that is what production gives it.

## Tests added

`createOkHttpClient` went from `private` to `internal` (the codebase's existing idiom; `@VisibleForTesting` is used nowhere) so the wiring is assertable:

- **`TeslamateApiFactoryTest`** (8) — 5 seconds reaches OkHttp as `connectTimeoutMillis == 5_000` and read/write stay at 30 s; an unchanged config reuses the cached API; a changed timeout does **not** (the `ApiCacheKey` claim from #369); `AUTO` re-resolves when a fallback server appears, while an explicit value is unaffected by one; an explicit override beats the stored setting and still caches.
- **`SettingsViewModelTest`** (+4) — the picker saves eagerly, the timeout loads from DataStore, it defaults to Automatic, and Test Connection resolves from the form rather than from disk.

## Also confirmed correct, no change needed

- `AppSettings` / `SettingsUiState` gained a field mid-list, but every construction site uses named arguments and a positional one would be a type error, not a silent shift.
- `connectTimeout(0)` (OkHttp's "no timeout") is unreachable: `AUTO` is the only zero and `resolveSeconds` never returns it.
- All 6 locales (en, it, es, ca, de, zh) carry matching `%1$d` format args.

## Known trade-off, by design

`AUTO` + a fallback server gives the **primary** 1 s. Someone whose primary is a slow tunnel and whose secondary is a LAN address must pick an explicit value. That is no worse than the hardcoded 1 s they had before, and the picker hint says so.

## Test Plan

- [x] `./gradlew testDebugUnitTest` — 132 tests, all green
- [x] `./gradlew lintDebug` — clean
- [x] UI verified on device by @vide on #369

Generated with [Claude Code](https://claude.com/claude-code)