### PR TITLE
feat: demo mode — try the app on a generated year of sample data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Demo mode** — a **Try the demo** button on the first setup screen fills the app with a year of realistic sample data from a demonstration car, so you can see what MateDroid does before deciding whether to set up Teslamate. Drives, charges, a live charging session, statistics, battery health and three countries visited, all of it working exactly as it would against your own server. A **Demo** badge next to the car name means sample data is never mistaken for your own, and you can leave the demo at any time from Settings → Connection.
+
 ## [1.11.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A native Android application for viewing Tesla vehicle data from your self-hoste
 - **Visited countries stats** - Show your friends all the places you visited with your car!
 - **Car color based themes** - Light/dark themes with palette based on the car color
 - **Multi-language** - Available in English, Italian, Spanish, Catalan, German, and Chinese (Simplified)
+- **Demo mode** - Try the whole app on a year of sample data before setting up Teslamate
 
 ### Gallery
 
@@ -77,6 +78,10 @@ Update history with installation dates, time between updates, and a chart of upd
 #### Visited Countries
 
 Every country you've driven through, with flags, distance, energy, and charge count. Sort however you like and tap a country to see its regions.
+
+#### Demo Mode
+
+No Teslamate server yet? Tap **Try the demo** on the first setup screen and the app fills itself with a year of realistic sample data from a demonstration car — drives, charges, a live charging session, statistics, battery health and three countries visited. Everything works exactly as it would against a real server, because it runs the same code; a **Demo** badge sits next to the car name so sample data is never mistaken for your own. Leave it any time from Settings → Connection.
 
 #### Theming & Notifications
 

--- a/app/src/main/java/com/matedroid/data/demo/DemoDataSet.kt
+++ b/app/src/main/java/com/matedroid/data/demo/DemoDataSet.kt
@@ -1,0 +1,1063 @@
+package com.matedroid.data.demo
+
+import com.matedroid.data.api.models.BatteryDetails
+import com.matedroid.data.api.models.BatteryHealth
+import com.matedroid.data.api.models.CarData
+import com.matedroid.data.api.models.CarDetails
+import com.matedroid.data.api.models.CarExterior
+import com.matedroid.data.api.models.CarGeodata
+import com.matedroid.data.api.models.CarSettings
+import com.matedroid.data.api.models.CarStatus
+import com.matedroid.data.api.models.CarStatusDetails
+import com.matedroid.data.api.models.CarVersions
+import com.matedroid.data.api.models.ChargeBatteryDetails
+import com.matedroid.data.api.models.ChargeBatteryInfo
+import com.matedroid.data.api.models.ChargeData
+import com.matedroid.data.api.models.ChargeDetail
+import com.matedroid.data.api.models.ChargePoint
+import com.matedroid.data.api.models.ChargeRange
+import com.matedroid.data.api.models.ChargerDetails
+import com.matedroid.data.api.models.ChargingDetails
+import com.matedroid.data.api.models.ClimateDetails
+import com.matedroid.data.api.models.DriveBatteryDetails
+import com.matedroid.data.api.models.DriveBatteryInfo
+import com.matedroid.data.api.models.DriveClimateInfo
+import com.matedroid.data.api.models.DriveData
+import com.matedroid.data.api.models.DriveDetail
+import com.matedroid.data.api.models.DriveOdometerDetails
+import com.matedroid.data.api.models.DrivePosition
+import com.matedroid.data.api.models.DriveRange
+import com.matedroid.data.api.models.DrivingDetails
+import com.matedroid.data.api.models.TeslamateStats
+import com.matedroid.data.api.models.TpmsDetails
+import com.matedroid.data.api.models.Units
+import com.matedroid.data.api.models.UpdateData
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * The sample dataset behind [DemoMode], generated rather than shipped as a JSON asset.
+ *
+ * Generating it buys the one property a canned file cannot have: the history always ends
+ * *today*. A bundled dataset would be visibly stale the first time someone opened the demo a
+ * year after the release that contained it, and every "last 30 days" filter in the app would
+ * come back empty. Everything here is anchored to [anchor], so the newest drive is always
+ * yesterday's and the year filters always have two years to choose between.
+ *
+ * The history is a simulation rather than a pile of independent random rows: one running
+ * state-of-charge and one running odometer are carried through the whole year, drives spend
+ * energy and charges put it back. That is what keeps the derived screens honest — battery
+ * levels line up end-to-end between consecutive drives, the odometer only ever increases,
+ * and charge costs match the energy actually delivered.
+ *
+ * Deterministic given [anchor]: a fixed seed drives every random choice, so the same day
+ * produces the same history and drive ids stay stable while the process lives.
+ *
+ * Everything is metric. TeslamateAPI converts to the user's unit system server-side and the
+ * app never converts (see `UnitFormatter`), so the demo does what a metric TeslaMate would:
+ * it reports km / bar / °C and says so in [units].
+ */
+@Suppress("LargeClass")
+internal class DemoDataSet(private val anchor: Instant, private val zone: ZoneId) {
+
+    companion object {
+        private const val SEED = 20_260_601L
+
+        /** How much history to simulate. A year spans two calendar years, so year filters have a choice. */
+        private const val HISTORY_DAYS = 365L
+
+        /** Model Y Juniper Long Range AWD, as new and as it is now. */
+        private const val CAPACITY_NEW_KWH = 78.4
+        private const val CAPACITY_NOW_KWH = 74.6
+        private const val RANGE_NEW_KM = 533.0
+        private const val RANGE_NOW_KM = 507.1
+
+        private const val ODOMETER_START_KM = 46_500.0
+
+        /** SoC the car charges up to at home, and the level that prompts plugging in. */
+        private const val CHARGE_LIMIT_SOC = 80
+        private const val PLUG_IN_BELOW_SOC = 38
+
+        /**
+         * The live session runs on a wall-clock cycle so the demo shows both of the states
+         * that matter: a charge in progress (the app's live charging view and notification)
+         * and a car parked at its charge limit. Without the cycle one of the two would never
+         * be reachable, and which one you got would depend on when the release was built.
+         */
+        private const val CYCLE_SECONDS = 4 * 60 * 60L
+
+        /** 45% → 80% of 74.6 kWh at 11 kW works out at this much of the cycle. */
+        private const val CHARGE_PHASE_SECONDS = 8_540L
+        private const val LIVE_START_SOC = 45
+
+        private val TIMESTAMP: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+        /** Sampling interval for the position and charge-point traces behind the detail charts. */
+        private const val DRIVE_SAMPLE_SECONDS = 20
+        private const val CHARGE_SAMPLE_SECONDS = 120
+
+        /** How long the car takes to reach cruising speed, and to brake back out of it. */
+        private const val PULL_AWAY_SECONDS = 22.0
+
+        /** How much of a drive is spent getting out of, and back into, a town. */
+        private const val URBAN_TAIL_FRACTION = 0.12
+        private const val TOWN_SPEED_FRACTION = 0.34
+
+        /** How much of the tail is the join itself, rather than town speed. */
+        private const val URBAN_TAIL_JOIN = 0.035
+
+        /** Kerb weight of a Model Y with someone in it, for the hill and acceleration terms. */
+        private const val KERB_WEIGHT_KG = 2050.0
+        private const val GRAVITY = 9.81
+
+        // Rolling resistance and aero drag, sized so a Model Y at 120 km/h draws the ~18 kW
+        // that its ~158 Wh/km motorway consumption implies.
+        private const val ROLLING_RESISTANCE_N = 201.0
+        private const val AERO_DRAG_N_S2_M2 = 0.331
+
+        /** Climate, screen and the rest of the car, drawn whether or not it is moving. */
+        private const val AUX_LOAD_KW = 0.7
+
+        /**
+         * How long a traffic slowdown lasts. Held in seconds rather than as a fraction of the
+         * drive so that a long motorway run and a short errand are slowed by the same kind of
+         * event, and the profile's average speed stays comparable between them.
+         */
+        private const val SLOWDOWN_SECONDS = 45.0
+    }
+
+    val units = Units(unitOfLength = "km", unitOfPressure = "bar", unitOfTemperature = "C")
+
+    private val random = Random(SEED)
+
+    // ---------------------------------------------------------------- history
+
+    private data class DriveRecord(
+        val id: Int,
+        val route: DemoRoute,
+        val start: Instant,
+        val durationMin: Int,
+        val startSoc: Int,
+        val endSoc: Int,
+        val odometerStart: Double,
+        val energyKwh: Double,
+        val outsideTemp: Double,
+        val insideTemp: Double
+    ) {
+        val end: Instant get() = start.plus(durationMin.toLong(), ChronoUnit.MINUTES)
+        val odometerEnd: Double get() = odometerStart + route.distanceKm
+    }
+
+    private data class ChargeRecord(
+        val id: Int,
+        val site: DemoChargerSite,
+        val start: Instant,
+        val durationMin: Int,
+        val startSoc: Int,
+        val endSoc: Int,
+        val odometer: Double,
+        val outsideTemp: Double
+    ) {
+        val end: Instant get() = start.plus(durationMin.toLong(), ChronoUnit.MINUTES)
+    }
+
+    private val driveRecords = mutableListOf<DriveRecord>()
+    private val chargeRecords = mutableListOf<ChargeRecord>()
+
+    /** The live session's id sits above every historical one so it never collides. */
+    private val liveChargeId: Int
+
+    init {
+        simulateHistory()
+        liveChargeId = (chargeRecords.maxOfOrNull { it.id } ?: 0) + 1
+    }
+
+    // ---------------------------------------------------------------- the car
+
+    val car: CarData = CarData(
+        carId = DemoMode.CAR_ID,
+        name = "Elektra",
+        carDetails = CarDetails(
+            model = "Y",
+            trimBadging = "74",
+            vin = "XP7YGCEK9SB000042",
+            // kWh/km, matching what TeslamateAPI reports for this field.
+            efficiency = 0.148
+        ),
+        carExterior = CarExterior(
+            exteriorColor = "UltraRed",
+            spoilerType = "None",
+            wheelType = "Crossflow19"
+        ),
+        carSettings = CarSettings(freeSupercharging = false),
+        teslamateStats = TeslamateStats(
+            totalCharges = chargeRecords.size,
+            totalDrives = driveRecords.size
+        )
+    )
+
+    val batteryHealth = BatteryHealth(
+        maxRange = RANGE_NEW_KM,
+        currentRange = RANGE_NOW_KM,
+        maxCapacity = CAPACITY_NEW_KWH,
+        currentCapacity = CAPACITY_NOW_KWH,
+        // kWh/100 km, as TeslamateAPI reports it: capacity over range.
+        ratedEfficiency = (CAPACITY_NOW_KWH / RANGE_NOW_KM * 100).round(1),
+        batteryHealthPercentage = (CAPACITY_NOW_KWH / CAPACITY_NEW_KWH * 100).round(2)
+    )
+
+    /**
+     * Software history, with versions derived from their own install date so they age with
+     * the dataset instead of naming a year that has since passed.
+     */
+    val updates: List<UpdateData> = buildUpdates()
+
+    // ---------------------------------------------------------------- public API
+
+    val drives: List<DriveData> = driveRecords
+        .sortedByDescending { it.start }
+        .map { it.toSummary() }
+
+    /**
+     * Completed charges, newest first. The live session joins the list only once it has
+     * finished — an in-progress charge belongs to `/charges/current`, and listing it too
+     * would double-count its energy in every total on the charges screen.
+     */
+    fun charges(now: Instant): List<ChargeData> {
+        val history = chargeRecords.sortedByDescending { it.start }.map { it.toSummary() }
+        val live = liveSession(now)
+        return if (live.charging) history else listOf(live.toSummary()) + history
+    }
+
+    fun driveDetail(driveId: Int): DriveDetail? =
+        driveRecords.firstOrNull { it.id == driveId }?.toDetail()
+
+    fun chargeDetail(chargeId: Int, now: Instant): ChargeDetail? {
+        if (chargeId == liveChargeId) return liveSession(now).toDetail()
+        return chargeRecords.firstOrNull { it.id == chargeId }?.toDetail()
+    }
+
+    /** Null when nothing is plugged in — the caller turns that into the API's "no active charge". */
+    fun currentCharge(now: Instant): ChargeDetail? =
+        liveSession(now).takeIf { it.charging }?.toDetail()
+
+    fun status(now: Instant): CarStatus {
+        val live = liveSession(now)
+        val soc = live.soc
+        val rangeKm = socToRangeKm(soc)
+        val outside = outsideTempAt(now)
+        val lastDrive = driveRecords.maxByOrNull { it.start }
+
+        return CarStatus(
+            displayName = car.name,
+            state = if (live.charging) "charging" else "asleep",
+            stateSince = (if (live.charging) live.start else live.end).format(),
+            odometer = ((lastDrive?.odometerEnd) ?: ODOMETER_START_KM).round(2),
+            carStatus = CarStatusDetails(
+                healthy = true,
+                locked = true,
+                sentryMode = true,
+                windowsOpen = false,
+                doorsOpen = false,
+                trunkOpen = false,
+                frunkOpen = false,
+                isUserPresent = false,
+                centerDisplayState = "0"
+            ),
+            carGeodata = CarGeodata(
+                geofence = "Home",
+                latitude = DemoRoutes.HOME.lat,
+                longitude = DemoRoutes.HOME.lon
+            ),
+            carVersions = CarVersions(
+                version = updates.firstOrNull()?.version,
+                updateAvailable = false,
+                updateVersion = ""
+            ),
+            drivingDetails = DrivingDetails(
+                shiftState = "",
+                power = if (live.charging) -live.powerKw else 0,
+                speed = 0,
+                heading = 214,
+                elevation = DemoRoutes.HOME.elevationM
+            ),
+            climateDetails = ClimateDetails(
+                isClimateOn = false,
+                insideTemp = (outside + 2.4).round(1),
+                outsideTemp = outside.round(1),
+                isPreconditioning = false
+            ),
+            batteryDetails = BatteryDetails(
+                batteryLevel = soc,
+                usableBatteryLevel = soc,
+                estBatteryRange = (rangeKm * 0.88).round(2),
+                ratedBatteryRange = rangeKm.round(2),
+                idealBatteryRange = rangeKm.round(2)
+            ),
+            chargingDetails = if (live.charging) {
+                ChargingDetails(
+                    pluggedIn = true,
+                    chargingState = "charging",
+                    chargeEnergyAdded = live.energyAddedKwh.round(2),
+                    chargeLimitSoc = CHARGE_LIMIT_SOC,
+                    chargePortDoorOpen = true,
+                    chargerActualCurrent = DemoChargers.HOME.maxCurrent,
+                    chargerPhases = DemoChargers.HOME.phases,
+                    chargerPower = live.powerKw,
+                    chargerVoltage = DemoChargers.HOME.voltage,
+                    chargeCurrentRequest = DemoChargers.HOME.maxCurrent,
+                    chargeCurrentRequestMax = DemoChargers.HOME.maxCurrent,
+                    timeToFullCharge = live.hoursToFull.round(2)
+                )
+            } else {
+                ChargingDetails(
+                    pluggedIn = false,
+                    chargingState = "Disconnected",
+                    chargeEnergyAdded = 0.0,
+                    chargeLimitSoc = CHARGE_LIMIT_SOC,
+                    chargePortDoorOpen = false,
+                    timeToFullCharge = 0.0
+                )
+            },
+            tpmsDetails = TpmsDetails(
+                pressureFl = 2.925,
+                pressureFr = 2.900,
+                pressureRl = 2.975,
+                pressureRr = 2.950,
+                warningFl = false,
+                warningFr = false,
+                warningRl = false,
+                warningRr = false
+            )
+        )
+    }
+
+    // ---------------------------------------------------------------- live session
+
+    private data class LiveSession(
+        val id: Int,
+        val charging: Boolean,
+        val start: Instant,
+        val end: Instant,
+        val soc: Int,
+        val energyAddedKwh: Double,
+        val powerKw: Int,
+        val hoursToFull: Double,
+        val outsideTemp: Double,
+        val odometer: Double
+    )
+
+    private fun liveSession(now: Instant): LiveSession {
+        val phase = Math.floorMod(now.epochSecond, CYCLE_SECONDS)
+        val charging = phase < CHARGE_PHASE_SECONDS
+        val elapsed = min(phase, CHARGE_PHASE_SECONDS)
+        val progress = elapsed.toDouble() / CHARGE_PHASE_SECONDS
+        val soc = (LIVE_START_SOC + (CHARGE_LIMIT_SOC - LIVE_START_SOC) * progress).roundToInt()
+        val energyAdded = (soc - LIVE_START_SOC) / 100.0 * CAPACITY_NOW_KWH
+        // The session started when this cycle did, and ended when the charging phase of the
+        // cycle ran out — the car has been sitting at its limit ever since.
+        val start = now.minusSeconds(phase)
+        val end = start.plusSeconds(elapsed)
+        val remainingHours = (CHARGE_PHASE_SECONDS - elapsed) / 3600.0
+
+        return LiveSession(
+            id = liveChargeId,
+            charging = charging,
+            start = start,
+            end = end,
+            soc = soc,
+            energyAddedKwh = energyAdded,
+            powerKw = DemoChargers.HOME.peakPowerKw,
+            hoursToFull = remainingHours,
+            outsideTemp = outsideTempAt(now),
+            odometer = driveRecords.maxByOrNull { it.start }?.odometerEnd ?: ODOMETER_START_KM
+        )
+    }
+
+    private fun LiveSession.toChargeRecord() = ChargeRecord(
+        id = id,
+        site = DemoChargers.HOME,
+        start = start,
+        durationMin = Duration.between(start, end).toMinutes().toInt().coerceAtLeast(1),
+        startSoc = LIVE_START_SOC,
+        endSoc = soc,
+        odometer = odometer,
+        outsideTemp = outsideTemp
+    )
+
+    private fun LiveSession.toSummary() = toChargeRecord().toSummary()
+
+    private fun LiveSession.toDetail() = toChargeRecord().toDetail(isCharging = charging)
+
+    // ---------------------------------------------------------------- simulation
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun simulateHistory() {
+        val today = anchor.atZone(zone).toLocalDate()
+        val firstDay = today.minusDays(HISTORY_DAYS)
+
+        var soc = 74
+        var odometer = ODOMETER_START_KM
+        var driveId = 1
+        var chargeId = 1
+
+        // Border runs are planned up front so both legs of a trip land on adjacent days.
+        val franceTrips = pickTripDays(firstDay, today, count = 6)
+        val andorraTrips = pickTripDays(firstDay, today, count = 3, avoid = franceTrips)
+
+        var day = firstDay
+        while (!day.isAfter(today)) {
+            val legs = planDay(day, franceTrips, andorraTrips)
+
+            for (leg in legs) {
+                // A leg that names a charger always stops at it — that is what makes the
+                // trip coherent. Otherwise the car only plugs in when the charge would not
+                // comfortably cover what is ahead.
+                val plannedSite = leg.chargeSiteBefore
+                val lowForLeg = soc < (leg.route.distanceKm * 0.20).roundToInt() + 14
+                if (plannedSite != null || lowForLeg || soc < PLUG_IN_BELOW_SOC) {
+                    val site = plannedSite ?: DemoChargers.HOME
+                    val target = chargeTargetFor(site, leg.route.distanceKm)
+                    if (target > soc + 2) {
+                        val chargeStart = leg.departure.minus(
+                            durationMinutes(site, soc, target).toLong() + 15, ChronoUnit.MINUTES
+                        )
+                        chargeRecords += ChargeRecord(
+                            id = chargeId++,
+                            site = site,
+                            start = chargeStart,
+                            durationMin = durationMinutes(site, soc, target),
+                            startSoc = soc,
+                            endSoc = target,
+                            odometer = odometer,
+                            outsideTemp = outsideTempAt(chargeStart)
+                        )
+                        soc = target
+                    }
+                }
+
+                val outside = outsideTempAt(leg.departure)
+                val consumption = leg.route.baseConsumptionWhKm * seasonalFactor(outside) *
+                    (0.94 + random.nextDouble() * 0.12)
+                val energy = leg.route.distanceKm * consumption / 1000.0
+                val drop = (energy / CAPACITY_NOW_KWH * 100).roundToInt().coerceAtLeast(1)
+                val endSoc = (soc - drop).coerceAtLeast(6)
+
+                driveRecords += DriveRecord(
+                    id = driveId++,
+                    route = leg.route,
+                    start = leg.departure,
+                    durationMin = (leg.route.durationMin * random.nextDouble(0.94, 1.18))
+                        .roundToInt().coerceAtLeast(2),
+                    startSoc = soc,
+                    endSoc = endSoc,
+                    odometerStart = odometer,
+                    energyKwh = energy,
+                    outsideTemp = outside,
+                    insideTemp = (max(19.0, min(24.5, outside + 3)) + random.nextDouble(-0.8, 0.8))
+                )
+
+                soc = endSoc
+                odometer += leg.route.distanceKm
+            }
+
+            // Plug in overnight once the car is home and low enough to bother.
+            val lastLeg = legs.lastOrNull()
+            if (lastLeg != null && lastLeg.endsAtHome && soc < PLUG_IN_BELOW_SOC + 12) {
+                val chargeStart = day.atTime(22, 40).atZone(zone).toInstant()
+                    .plusSeconds(random.nextLong(0, 3600))
+                if (chargeStart.isBefore(anchor)) {
+                    chargeRecords += ChargeRecord(
+                        id = chargeId++,
+                        site = DemoChargers.HOME,
+                        start = chargeStart,
+                        durationMin = durationMinutes(DemoChargers.HOME, soc, CHARGE_LIMIT_SOC),
+                        startSoc = soc,
+                        endSoc = CHARGE_LIMIT_SOC,
+                        odometer = odometer,
+                        outsideTemp = outsideTempAt(chargeStart)
+                    )
+                    soc = CHARGE_LIMIT_SOC
+                }
+            }
+
+            day = day.plusDays(1)
+        }
+
+        // Anything the loop placed past "now" (a late leg on the final day) is not history yet.
+        driveRecords.removeAll { !it.end.isBefore(anchor) }
+        chargeRecords.removeAll { !it.end.isBefore(anchor) }
+    }
+
+    /** One leg of a day's driving, with where the car would have charged before setting off. */
+    private data class Leg(
+        val route: DemoRoute,
+        val departure: Instant,
+        val chargeSiteBefore: DemoChargerSite? = null,
+        val endsAtHome: Boolean = true
+    )
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun planDay(
+        day: LocalDate,
+        franceTrips: Set<LocalDate>,
+        andorraTrips: Set<LocalDate>
+    ): List<Leg> {
+        fun at(hour: Int, minute: Int): Instant =
+            day.atTime(hour, minute).atZone(zone).toInstant()
+                .plusSeconds(random.nextLong(-900, 900))
+
+        // Border runs: out on the first day, back on the next.
+        if (day in franceTrips) {
+            return listOf(Leg(DemoRoutes.FRANCE_OUT, at(9, 30), endsAtHome = false))
+        }
+        if (day.minusDays(1) in franceTrips) {
+            return listOf(
+                Leg(
+                    DemoRoutes.FRANCE_BACK, at(17, 15),
+                    chargeSiteBefore = DemoChargers.PERPIGNAN
+                )
+            )
+        }
+
+        if (day in andorraTrips) {
+            return listOf(Leg(DemoRoutes.ANDORRA_OUT, at(8, 45), endsAtHome = false))
+        }
+        if (day.minusDays(1) in andorraTrips) {
+            return listOf(
+                Leg(
+                    DemoRoutes.ANDORRA_BACK, at(16, 30),
+                    chargeSiteBefore = DemoChargers.ANDORRA_HOTEL
+                )
+            )
+        }
+
+        val legs = mutableListOf<Leg>()
+        val weekday = day.dayOfWeek.value <= 5
+        val roll = random.nextDouble()
+
+        if (weekday) {
+            when {
+                roll < 0.52 -> {
+                    legs += Leg(DemoRoutes.COMMUTE_OUT, at(7, 50), endsAtHome = false)
+                    // Now and then the way home takes in a Supercharger stop at Maçanet,
+                    // which is why the return trip is two legs rather than one.
+                    if (random.nextDouble() < 0.22) {
+                        legs += Leg(DemoRoutes.COMMUTE_BACK_TO_MACANET, at(17, 45), endsAtHome = false)
+                        legs += Leg(
+                            DemoRoutes.MACANET_TO_HOME, at(19, 5),
+                            chargeSiteBefore = DemoChargers.MACANET
+                        )
+                    } else {
+                        legs += Leg(DemoRoutes.COMMUTE_BACK, at(17, 50))
+                    }
+                }
+                roll < 0.78 -> {
+                    legs += Leg(DemoRoutes.ERRAND, at(18, 20), endsAtHome = false)
+                    legs += Leg(DemoRoutes.ERRAND_BACK, at(19, 10))
+                }
+            }
+        } else {
+            when {
+                roll < 0.46 -> {
+                    legs += Leg(DemoRoutes.BEACH_OUT, at(10, 15), endsAtHome = false)
+                    if (random.nextDouble() < 0.55) {
+                        legs += Leg(DemoRoutes.COASTAL, at(12, 40), endsAtHome = false)
+                    }
+                    legs += Leg(DemoRoutes.BEACH_BACK, at(19, 20))
+                }
+                roll < 0.68 -> {
+                    legs += Leg(DemoRoutes.ERRAND, at(11, 10), endsAtHome = false)
+                    legs += Leg(DemoRoutes.ERRAND_BACK, at(12, 5))
+                }
+            }
+        }
+
+        return legs
+    }
+
+    private fun pickTripDays(
+        from: LocalDate,
+        to: LocalDate,
+        count: Int,
+        avoid: Set<LocalDate> = emptySet()
+    ): Set<LocalDate> {
+        val span = ChronoUnit.DAYS.between(from, to).toInt()
+        val picked = mutableSetOf<LocalDate>()
+        var guard = 0
+        while (picked.size < count && guard++ < count * 20) {
+            // Leave room for the return leg the next day.
+            val candidate = from.plusDays(random.nextInt(0, max(1, span - 2)).toLong())
+            val clashes = candidate in avoid || candidate.plusDays(1) in avoid ||
+                candidate.minusDays(1) in avoid ||
+                picked.any { abs(ChronoUnit.DAYS.between(it, candidate)) < 14 }
+            if (!clashes) picked += candidate
+        }
+        return picked
+    }
+
+    private fun chargeTargetFor(site: DemoChargerSite, upcomingKm: Double): Int {
+        val needed = (upcomingKm * 0.20).roundToInt() + 22
+        // Nobody sits at a Supercharger to 100%; at home the car just charges to its limit.
+        val cap = if (site.isDc) 80 else CHARGE_LIMIT_SOC
+        return min(cap, max(needed, if (site.isDc) 72 else CHARGE_LIMIT_SOC))
+    }
+
+    // ---------------------------------------------------------------- mapping
+
+    private fun DriveRecord.toSummary(): DriveData {
+        val trace = trace(this)
+        return DriveData(
+            driveId = id,
+            startDate = start.format(),
+            endDate = end.format(),
+            startAddress = route.startAddress,
+            endAddress = route.endAddress,
+            odometerDetails = DriveOdometerDetails(
+                odometerStart = odometerStart.round(2),
+                odometerEnd = odometerEnd.round(2),
+                distance = route.distanceKm.round(2)
+            ),
+            durationMin = durationMin,
+            durationStr = durationMin.toDurationString(),
+            speedMax = trace.speeds.max().roundToInt(),
+            speedAvg = (route.distanceKm / durationMin * 60).round(2),
+            powerMax = trace.powers.max(),
+            powerMin = trace.powers.min(),
+            batteryDetails = DriveBatteryDetails(
+                startBatteryLevel = startSoc,
+                endBatteryLevel = endSoc,
+                isRangeIdeal = false
+            ),
+            rangeIdeal = driveRange(),
+            rangeRated = driveRange(),
+            outsideTempAvg = outsideTemp.round(1),
+            insideTempAvg = insideTemp.round(1),
+            energyConsumedNet = energyKwh.round(3),
+            consumptionNet = (energyKwh * 1000 / route.distanceKm).round(2)
+        )
+    }
+
+    private fun DriveRecord.driveRange(): DriveRange {
+        val startRange = socToRangeKm(startSoc)
+        val endRange = socToRangeKm(endSoc)
+        return DriveRange(
+            startRange = startRange.round(2),
+            endRange = endRange.round(2),
+            rangeDiff = (startRange - endRange).round(2)
+        )
+    }
+
+    private fun DriveRecord.toDetail(): DriveDetail {
+        val summary = toSummary()
+        return DriveDetail(
+            driveId = id,
+            startDate = summary.startDate,
+            endDate = summary.endDate,
+            startAddress = summary.startAddress,
+            endAddress = summary.endAddress,
+            odometerDetails = summary.odometerDetails,
+            durationMin = summary.durationMin,
+            durationStr = summary.durationStr,
+            speedMax = summary.speedMax,
+            speedAvg = summary.speedAvg,
+            powerMax = summary.powerMax,
+            powerMin = summary.powerMin,
+            batteryDetails = summary.batteryDetails,
+            rangeIdeal = summary.rangeIdeal,
+            rangeRated = summary.rangeRated,
+            outsideTempAvg = summary.outsideTempAvg,
+            insideTempAvg = summary.insideTempAvg,
+            energyConsumedNet = summary.energyConsumedNet,
+            consumptionNet = summary.consumptionNet,
+            positions = positions(this)
+        )
+    }
+
+    private fun ChargeRecord.toSummary(): ChargeData {
+        val added = (endSoc - startSoc) / 100.0 * CAPACITY_NOW_KWH
+        val used = added / chargingEfficiency(site)
+        return ChargeData(
+            chargeId = id,
+            startDate = start.format(),
+            endDate = end.format(),
+            address = site.address,
+            chargeEnergyAdded = added.round(2),
+            chargeEnergyUsed = used.round(2),
+            cost = (used * site.pricePerKwh).round(2),
+            durationMin = durationMin,
+            durationStr = durationMin.toDurationString(),
+            batteryDetails = ChargeBatteryDetails(
+                startBatteryLevel = startSoc,
+                endBatteryLevel = endSoc
+            ),
+            rangeIdeal = chargeRange(),
+            rangeRated = chargeRange(),
+            outsideTempAvg = outsideTemp.round(1),
+            odometer = odometer.round(2),
+            latitude = site.point.lat,
+            longitude = site.point.lon
+        )
+    }
+
+    private fun ChargeRecord.chargeRange() = ChargeRange(
+        startRange = socToRangeKm(startSoc).round(2),
+        endRange = socToRangeKm(endSoc).round(2)
+    )
+
+    private fun ChargeRecord.toDetail(isCharging: Boolean = false): ChargeDetail {
+        val summary = toSummary()
+        return ChargeDetail(
+            chargeId = id,
+            startDate = summary.startDate,
+            endDate = summary.endDate,
+            address = summary.address,
+            chargeEnergyAdded = summary.chargeEnergyAdded,
+            chargeEnergyUsed = summary.chargeEnergyUsed,
+            cost = summary.cost,
+            durationMin = summary.durationMin,
+            durationStr = summary.durationStr,
+            batteryDetails = ChargeBatteryDetails(
+                startBatteryLevel = startSoc,
+                endBatteryLevel = if (isCharging) null else endSoc,
+                currentBatteryLevel = if (isCharging) endSoc else null
+            ),
+            rangeIdeal = summary.rangeIdeal,
+            rangeRated = summary.rangeRated,
+            outsideTempAvg = summary.outsideTempAvg,
+            odometer = summary.odometer,
+            latitude = summary.latitude,
+            longitude = summary.longitude,
+            chargePoints = chargePoints(this),
+            isCharging = isCharging
+        )
+    }
+
+    // ---------------------------------------------------------------- traces
+
+    /**
+     * The position trace behind the map and the drive charts.
+     *
+     * Speed comes first, from a trapezoid that ramps out of the start and brakes into the
+     * end; distance is then the running integral of that speed, and the car is placed at
+     * that distance along the polyline. Doing it in that order is what keeps the map, the
+     * speed chart and the reported distance describing the same drive.
+     */
+    /**
+     * The sampled trace behind a drive: where the car was, how fast, and what it was drawing.
+     *
+     * Kept as plain numbers so a drive summary can read its speed and power extremes without
+     * building the position objects it would only throw away — the summary list is built for
+     * every drive in the history at once, and that adds up.
+     */
+    private class DriveTrace(
+        val stepSeconds: Double,
+        val routeKm: Double,
+        val alongKm: DoubleArray,
+        val speeds: DoubleArray,
+        val powers: IntArray,
+        val points: List<Interpolated>
+    ) {
+        val size get() = speeds.size
+    }
+
+    private fun trace(record: DriveRecord): DriveTrace {
+        val route = record.route
+        val totalSeconds = record.durationMin * 60
+        val steps = (totalSeconds / DRIVE_SAMPLE_SECONDS).coerceIn(8, 500)
+        val stepSeconds = totalSeconds.toDouble() / steps
+        val jitter = Random(record.id * 7919L)
+
+        val cumulative = DoubleArray(route.waypoints.size)
+        var running = 0.0
+        route.waypoints.zipWithNext().forEachIndexed { index, (a, b) ->
+            running += haversineKm(a, b)
+            cumulative[index + 1] = running
+        }
+        val routeKm = running
+
+        // Speed first: a trapezoid that pulls away from the start and brakes into the end,
+        // dipped by a slowdown every 25 km or so. The dips are what make the drive look
+        // driven rather than simulated — and they are where regen comes from, because
+        // braking out of cruising speed gives back more than drag was taking.
+        val slowdowns = List(max(1, (routeKm / 25).roundToInt())) {
+            jitter.nextDouble(0.12, 0.88) to jitter.nextDouble(0.28, 0.6)
+        }
+        val slowdownWidth = SLOWDOWN_SECONDS / totalSeconds
+        val rampWidth = min(0.25, PULL_AWAY_SECONDS / totalSeconds)
+        val rawSpeeds = DoubleArray(steps + 1) { step ->
+            val f = step.toDouble() / steps
+            val ramp = min(1.0, min(f / rampWidth, (1.0 - f) / rampWidth))
+            // Every journey starts and ends in a town. Holding the first and last stretch
+            // down to town speed is what pulls the average below the open-road speed — and
+            // the joins at each end are the hardest acceleration in the drive.
+            val edge = min(f, 1.0 - f)
+            val urban = if (edge < URBAN_TAIL_FRACTION) {
+                val ramped = min(1.0, (URBAN_TAIL_FRACTION - edge) / URBAN_TAIL_JOIN)
+                1.0 - (1.0 - TOWN_SPEED_FRACTION) * ramped
+            } else {
+                1.0
+            }
+            val traffic = slowdowns.fold(1.0) { acc, (centre, depth) ->
+                val d = (f - centre) / slowdownWidth
+                acc * (1.0 - (1.0 - depth) * exp(-d * d))
+            }
+            val wobble = 1.0 + sin(f * PI * 6) * 0.04 + jitter.nextDouble(-0.03, 0.03)
+            max(0.0, route.cruiseKmh * ramp * urban * traffic * wobble)
+        }
+
+        // Scale the profile so its integral is exactly the route distance: the map line, the
+        // speed chart and the distance on the drive card then all describe the same drive.
+        val rawKm = rawSpeeds.sum() * stepSeconds / 3600.0
+        val speedScale = if (rawKm > 0) routeKm / rawKm else 1.0
+        val speeds = DoubleArray(steps + 1) { rawSpeeds[it] * speedScale }
+
+        var travelled = 0.0
+        val alongKm = DoubleArray(steps + 1) { step ->
+            if (step > 0) travelled += speeds[step] * stepSeconds / 3600.0
+            min(travelled, routeKm)
+        }
+        val points = alongKm.map { pointAlong(route, cumulative, it) }
+
+        // Demand at each sample: rolling resistance and aero drag at that speed, plus what
+        // the hill and the accelerator are asking for, plus the car's own hotel load.
+        val resistanceKw = DoubleArray(steps + 1) { step ->
+            val v = speeds[step] / 3.6
+            (ROLLING_RESISTANCE_N * v + AERO_DRAG_N_S2_M2 * v * v * v) / 1000.0 + AUX_LOAD_KW
+        }
+        val dynamicKw = DoubleArray(steps + 1) { step ->
+            if (step == 0) return@DoubleArray 0.0
+            val climb = (points[step].elevation - points[step - 1].elevation) / stepSeconds *
+                KERB_WEIGHT_KG * GRAVITY / 1000.0
+            // Power to accelerate is mass × acceleration × speed, and the speed that belongs
+            // in it is the average over the step. Using the speed at the *end* of the step
+            // reads zero at a standstill, which silently erased the regen from every stop.
+            val accelMs2 = (speeds[step] - speeds[step - 1]) / 3.6 / stepSeconds
+            val meanMs = (speeds[step] + speeds[step - 1]) / 2 / 3.6
+            climb + accelMs2 * meanMs * KERB_WEIGHT_KG / 1000.0
+        }
+
+        // Trim the resistance side until the trace integrates to the energy the summary
+        // reports, so the power chart and the consumption figure cannot disagree.
+        val hours = stepSeconds / 3600.0
+        val resistanceKwh = resistanceKw.sum() * hours
+        val dynamicKwh = dynamicKw.sum() * hours
+        val energyScale = if (resistanceKwh > 0) {
+            ((record.energyKwh - dynamicKwh) / resistanceKwh).coerceIn(0.6, 1.6)
+        } else {
+            1.0
+        }
+
+        val powers = IntArray(steps + 1) { step ->
+            (resistanceKw[step] * energyScale + dynamicKw[step]).roundToInt().coerceIn(-75, 275)
+        }
+
+        return DriveTrace(stepSeconds, routeKm, alongKm, speeds, powers, points)
+    }
+
+    private fun positions(record: DriveRecord): List<DrivePosition> {
+        val trace = trace(record)
+        return (0 until trace.size).map { step ->
+            val point = trace.points[step]
+            val fraction = if (trace.routeKm > 0) trace.alongKm[step] / trace.routeKm else 0.0
+
+            DrivePosition(
+                date = record.start.plusSeconds((step * trace.stepSeconds).toLong()).format(),
+                latitude = point.lat.round(6),
+                longitude = point.lon.round(6),
+                speed = trace.speeds[step].roundToInt(),
+                power = trace.powers[step],
+                batteryLevel = (record.startSoc - (record.startSoc - record.endSoc) * fraction)
+                    .roundToInt(),
+                elevation = point.elevation.roundToInt(),
+                climateInfo = DriveClimateInfo(
+                    insideTemp = record.insideTemp.round(1),
+                    outsideTemp = (record.outsideTemp + sin(fraction * PI) * 1.2).round(1),
+                    isClimateOn = abs(record.outsideTemp - 21) > 5,
+                    fanStatus = 3,
+                    driverTempSetting = 21.0,
+                    passengerTempSetting = 21.0
+                ),
+                batteryInfo = DriveBatteryInfo(
+                    batteryHeater = record.outsideTemp < 6,
+                    batteryHeaterOn = record.outsideTemp < 6,
+                    batteryHeaterNoPower = false
+                )
+            )
+        }
+    }
+
+    private data class Interpolated(val lat: Double, val lon: Double, val elevation: Double)
+
+    private fun pointAlong(
+        route: DemoRoute,
+        cumulative: DoubleArray,
+        alongKm: Double
+    ): Interpolated {
+        val last = route.waypoints.lastIndex
+        if (alongKm <= 0) {
+            val p = route.waypoints.first()
+            return Interpolated(p.lat, p.lon, p.elevationM.toDouble())
+        }
+        for (i in 0 until last) {
+            if (alongKm <= cumulative[i + 1] || i == last - 1) {
+                val segment = cumulative[i + 1] - cumulative[i]
+                val t = if (segment > 0) ((alongKm - cumulative[i]) / segment).coerceIn(0.0, 1.0) else 1.0
+                val a = route.waypoints[i]
+                val b = route.waypoints[i + 1]
+                return Interpolated(
+                    lat = a.lat + (b.lat - a.lat) * t,
+                    lon = a.lon + (b.lon - a.lon) * t,
+                    elevation = a.elevationM + (b.elevationM - a.elevationM) * t
+                )
+            }
+        }
+        val p = route.waypoints.last()
+        return Interpolated(p.lat, p.lon, p.elevationM.toDouble())
+    }
+
+    /** The power/voltage/temperature trace behind the charge detail charts. */
+    private fun chargePoints(record: ChargeRecord): List<ChargePoint> {
+        val totalSeconds = record.durationMin * 60
+        val steps = (totalSeconds / CHARGE_SAMPLE_SECONDS).coerceIn(12, 240)
+        val jitter = Random(record.id * 6151L)
+        var energyAdded = 0.0
+        var previousSoc = record.startSoc.toDouble()
+
+        return (0..steps).map { step ->
+            val f = step.toDouble() / steps
+            val soc = record.startSoc + (record.endSoc - record.startSoc) * f
+            energyAdded += (soc - previousSoc) / 100.0 * CAPACITY_NOW_KWH
+            previousSoc = soc
+
+            val power = powerAtSoc(record.site, soc) * (1.0 + jitter.nextDouble(-0.03, 0.03))
+            val voltage = record.site.voltage + jitter.nextInt(-4, 5)
+            val current = if (record.site.isDc) {
+                (power * 1000 / voltage).roundToInt()
+            } else {
+                // Three-phase AC: the reported current is per phase.
+                (power * 1000 / (voltage * 3)).roundToInt()
+            }
+
+            ChargePoint(
+                date = record.start.plusSeconds((f * totalSeconds).toLong()).format(),
+                batteryLevel = soc.roundToInt(),
+                chargeEnergyAdded = energyAdded.round(2),
+                chargerDetails = ChargerDetails(
+                    chargerPower = power.roundToInt(),
+                    chargerVoltage = voltage,
+                    chargerActualCurrent = current,
+                    chargerPhases = record.site.phases,
+                    fastChargerPresent = record.site.isDc,
+                    fastChargerBrand = if (record.site.isDc) "Tesla" else "<invalid>",
+                    fastChargerType = if (record.site.isDc) "Combo" else "<invalid>"
+                ),
+                outsideTemp = (record.outsideTemp + sin(f * PI) * 0.9).round(1),
+                batteryInfo = ChargeBatteryInfo(
+                    idealBatteryRangeKm = socToRangeKm(soc).round(2),
+                    ratedBatteryRangeKm = socToRangeKm(soc).round(2),
+                    usableBatteryLevel = soc.roundToInt()
+                )
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- physics-ish helpers
+
+    /** DC power tapers hard with state of charge; AC holds flat until the last few percent. */
+    private fun powerAtSoc(site: DemoChargerSite, soc: Double): Double {
+        if (!site.isDc) {
+            val taper = if (soc > CHARGE_LIMIT_SOC - 3) {
+                max(0.18, 1.0 - (soc - (CHARGE_LIMIT_SOC - 3)) / 4.0)
+            } else {
+                1.0
+            }
+            return site.peakPowerKw * taper
+        }
+        val curve = 1.0 - ((soc - 8).coerceAtLeast(0.0) / 72.0).pow(1.7)
+        return site.peakPowerKw * curve.coerceIn(0.14, 1.0)
+    }
+
+    private fun durationMinutes(site: DemoChargerSite, fromSoc: Int, toSoc: Int): Int {
+        if (toSoc <= fromSoc) return 1
+        var minutes = 0.0
+        for (soc in fromSoc until toSoc) {
+            minutes += (CAPACITY_NOW_KWH / 100.0) / powerAtSoc(site, soc + 0.5) * 60
+        }
+        return minutes.roundToInt().coerceAtLeast(1)
+    }
+
+    private fun chargingEfficiency(site: DemoChargerSite): Double = if (site.isDc) 0.965 else 0.905
+
+    private fun socToRangeKm(soc: Number): Double = soc.toDouble() / 100.0 * RANGE_NOW_KM
+
+    /** Girona's year: about 8 °C in mid-January, about 24 °C in mid-July, warmer after lunch. */
+    private fun outsideTempAt(instant: Instant): Double {
+        val local = OffsetDateTime.ofInstant(instant, zone)
+        val seasonal = 16.0 - 8.0 * cos(2 * PI * (local.dayOfYear - 15) / 365.0)
+        val daily = 4.0 * sin(2 * PI * (local.hour - 9) / 24.0)
+        val noise = Random(local.toLocalDate().toEpochDay() * 31 + local.hour).nextDouble(-1.6, 1.6)
+        return seasonal + daily + noise
+    }
+
+    /** Cold costs range: consumption climbs once it drops below shirtsleeve weather. */
+    private fun seasonalFactor(outsideTemp: Double): Double =
+        1.0 + max(0.0, 16.0 - outsideTemp) * 0.018
+
+    private fun buildUpdates(): List<UpdateData> {
+        val installs = mutableListOf<Pair<Instant, UpdateData>>()
+        val today = anchor.atZone(zone).toLocalDate()
+        var day = today.minusDays(HISTORY_DAYS - 12)
+        var id = 1
+        while (day.isBefore(today.minusDays(3))) {
+            val start = day.atTime(2, 14).atZone(zone).toInstant()
+                .plusSeconds(random.nextLong(0, 5400))
+            val minutes = random.nextLong(18, 47)
+            installs += start to UpdateData(
+                id = id++,
+                version = versionFor(day),
+                startDate = start.format(),
+                endDate = start.plus(minutes, ChronoUnit.MINUTES).format()
+            )
+            day = day.plusDays(random.nextLong(26, 52))
+        }
+        return installs.sortedByDescending { it.first }.map { it.second }
+    }
+
+    /**
+     * Tesla-style `YYYY.WW.P` derived from the install date, so the demo never advertises a
+     * version from a year that has already gone by.
+     */
+    private fun versionFor(day: LocalDate): String {
+        val week = ((day.dayOfYear - 1) / 7 + 1).coerceIn(1, 52)
+        val patch = Random(day.toEpochDay()).nextInt(1, 9)
+        return "${day.year}.$week.$patch"
+    }
+
+    // ---------------------------------------------------------------- formatting
+
+    private fun Instant.format(): String =
+        OffsetDateTime.ofInstant(this, zone).truncatedTo(ChronoUnit.SECONDS).format(TIMESTAMP)
+
+    private fun Int.toDurationString(): String = "%02d:%02d".format(this / 60, this % 60)
+
+    private fun Double.round(decimals: Int): Double {
+        val factor = 10.0.pow(decimals)
+        return (this * factor).roundToInt() / factor
+    }
+}

--- a/app/src/main/java/com/matedroid/data/demo/DemoGeography.kt
+++ b/app/src/main/java/com/matedroid/data/demo/DemoGeography.kt
@@ -1,0 +1,282 @@
+package com.matedroid.data.demo
+
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/** A point on a demo route: real coordinates, with the elevation that belongs to them. */
+internal data class DemoPoint(val lat: Double, val lon: Double, val elevationM: Int)
+
+/**
+ * A route the demo car drives, as a coarse polyline through real places.
+ *
+ * Distance is measured from [waypoints] rather than stored alongside them, so the number
+ * on the drive card can never disagree with the line drawn on the map.
+ */
+internal data class DemoRoute(
+    val name: String,
+    val startAddress: String,
+    val endAddress: String,
+    val waypoints: List<DemoPoint>,
+    /** Cruising speed, used to derive both duration and the per-position speed trace. */
+    val cruiseKmh: Int,
+    /** Fair-weather consumption; the generator adds a seasonal penalty on top. */
+    val baseConsumptionWhKm: Double
+) {
+    val distanceKm: Double by lazy {
+        waypoints.zipWithNext().sumOf { (a, b) -> haversineKm(a, b) }
+    }
+
+    /**
+     * Average speed is below cruising: every route has junctions, towns and a stop at each
+     * end. The factor is tuned against the speed profile the generator builds, so that the
+     * profile needs almost no rescaling to cover the distance in this time — rescaling is
+     * what used to push motorway peaks past 140 km/h.
+     */
+    val durationMin: Int
+        get() = ((distanceKm / (cruiseKmh * AVERAGE_SPEED_FACTOR)) * 60).toInt().coerceAtLeast(1)
+
+    fun reversed(name: String): DemoRoute = copy(
+        name = name,
+        startAddress = endAddress,
+        endAddress = startAddress,
+        waypoints = waypoints.reversed()
+    )
+
+    /**
+     * A stretch of this route, both ends inclusive. Splitting a drive at a charger is how a
+     * Supercharger stop mid-journey stays coherent: two drives with a charge between them,
+     * which is also how TeslaMate records it.
+     */
+    fun segment(name: String, fromIndex: Int, toIndex: Int, startAddress: String, endAddress: String) =
+        copy(
+            name = name,
+            startAddress = startAddress,
+            endAddress = endAddress,
+            waypoints = waypoints.subList(fromIndex, toIndex + 1)
+        )
+
+    private companion object {
+        const val AVERAGE_SPEED_FACTOR = 0.72
+    }
+}
+
+internal fun haversineKm(a: DemoPoint, b: DemoPoint): Double {
+    val earthRadiusKm = 6371.0
+    val dLat = Math.toRadians(b.lat - a.lat)
+    val dLon = Math.toRadians(b.lon - a.lon)
+    val h = sin(dLat / 2) * sin(dLat / 2) +
+        cos(Math.toRadians(a.lat)) * cos(Math.toRadians(b.lat)) * sin(dLon / 2) * sin(dLon / 2)
+    return 2 * earthRadiusKm * asin(min(1.0, sqrt(h)))
+}
+
+/**
+ * The demo car lives in Girona and drives the Costa Brava, with the Barcelona commute,
+ * the odd run over the border to Perpignan, and a couple of trips up to Andorra.
+ *
+ * Three countries is the point of the France and Andorra routes: Visited Countries has
+ * nothing to show from a dataset that never leaves one.
+ */
+internal object DemoRoutes {
+
+    // Home, and the anchor for the home charger and the parked-car status.
+    val HOME = DemoPoint(41.9794, 2.8214, 70)
+    const val HOME_ADDRESS = "Carrer de la Rutlla, Girona"
+
+    private val GIRONA_TO_BARCELONA = DemoRoute(
+        name = "Girona → Barcelona",
+        startAddress = HOME_ADDRESS,
+        endAddress = "Avinguda Diagonal, Barcelona",
+        waypoints = listOf(
+            HOME,
+            DemoPoint(41.8875, 2.7842, 110),  // Riudellots de la Selva
+            DemoPoint(41.7717, 2.7350, 85),   // Maçanet de la Selva
+            DemoPoint(41.7486, 2.6367, 60),   // Hostalric
+            DemoPoint(41.6897, 2.4919, 140),  // Sant Celoni
+            DemoPoint(41.6083, 2.2875, 145),  // Granollers
+            DemoPoint(41.5397, 2.2130, 65),   // Mollet del Vallès
+            DemoPoint(41.4416, 2.1867, 40),   // Nus de la Trinitat
+            DemoPoint(41.3936, 2.1400, 25)    // Avinguda Diagonal
+        ),
+        cruiseKmh = 118,
+        baseConsumptionWhKm = 158.0
+    )
+
+    private val GIRONA_TO_PALS = DemoRoute(
+        name = "Girona → Pals",
+        startAddress = HOME_ADDRESS,
+        endAddress = "Avinguda del Mediterrani, Pals",
+        waypoints = listOf(
+            HOME,
+            DemoPoint(42.0206, 2.8892, 45),   // Celrà
+            DemoPoint(42.0347, 2.9403, 30),   // Bordils
+            DemoPoint(42.0617, 3.0433, 20),   // Verges
+            DemoPoint(42.0432, 3.1274, 15),   // Torroella de Montgrí
+            DemoPoint(41.9683, 3.1467, 25)    // Pals
+        ),
+        cruiseKmh = 85,
+        baseConsumptionWhKm = 146.0
+    )
+
+    private val COSTA_BRAVA_LOOP = DemoRoute(
+        name = "Costa Brava loop",
+        startAddress = "Avinguda del Mediterrani, Pals",
+        endAddress = "Avinguda del Mediterrani, Pals",
+        waypoints = listOf(
+            DemoPoint(41.9683, 3.1467, 25),   // Pals
+            DemoPoint(41.9542, 3.2078, 200),  // Begur
+            DemoPoint(41.9175, 3.1631, 85),   // Palafrugell
+            DemoPoint(41.9683, 3.1467, 25)    // Pals
+        ),
+        cruiseKmh = 62,
+        baseConsumptionWhKm = 171.0
+    )
+
+    private val GIRONA_TO_PERPIGNAN = DemoRoute(
+        name = "Girona → Perpignan",
+        startAddress = HOME_ADDRESS,
+        endAddress = "Boulevard Wilson, Perpignan",
+        waypoints = listOf(
+            HOME,
+            DemoPoint(42.1108, 2.9330, 50),   // Báscara
+            DemoPoint(42.2662, 2.9622, 40),   // Figueres
+            DemoPoint(42.4194, 2.8760, 110),  // La Jonquera — the border
+            DemoPoint(42.5261, 2.8342, 90),   // Le Boulou
+            DemoPoint(42.6987, 2.8955, 40)    // Perpignan
+        ),
+        cruiseKmh = 120,
+        baseConsumptionWhKm = 168.0
+    )
+
+    private val GIRONA_TO_ANDORRA = DemoRoute(
+        name = "Girona → Andorra la Vella",
+        startAddress = HOME_ADDRESS,
+        endAddress = "Avinguda Meritxell, Andorra la Vella",
+        waypoints = listOf(
+            HOME,
+            DemoPoint(41.9301, 2.2545, 494),  // Vic
+            DemoPoint(42.1017, 1.8461, 715),  // Berga
+            DemoPoint(42.2661, 1.7625, 1100), // Túnel del Cadí
+            DemoPoint(42.3697, 1.7767, 1050), // Bellver de Cerdanya
+            DemoPoint(42.3582, 1.4590, 691),  // La Seu d'Urgell
+            DemoPoint(42.5063, 1.5218, 1023)  // Andorra la Vella
+        ),
+        cruiseKmh = 92,
+        baseConsumptionWhKm = 189.0
+    )
+
+    private val GIRONA_ERRAND = DemoRoute(
+        name = "Girona errand",
+        startAddress = HOME_ADDRESS,
+        endAddress = "Carrer de Santa Clara, Girona",
+        waypoints = listOf(
+            HOME,
+            DemoPoint(41.9861, 2.8250, 75),   // Parc de la Devesa
+            DemoPoint(41.9930, 2.8300, 80),   // Pont Major
+            DemoPoint(41.9836, 2.8235, 72)    // Carrer de Santa Clara
+        ),
+        cruiseKmh = 34,
+        baseConsumptionWhKm = 194.0
+    )
+
+    val COMMUTE_OUT = GIRONA_TO_BARCELONA
+    val COMMUTE_BACK = GIRONA_TO_BARCELONA.reversed("Barcelona → Girona")
+    val BEACH_OUT = GIRONA_TO_PALS
+    val BEACH_BACK = GIRONA_TO_PALS.reversed("Pals → Girona")
+    val COASTAL = COSTA_BRAVA_LOOP
+    val FRANCE_OUT = GIRONA_TO_PERPIGNAN
+    val FRANCE_BACK = GIRONA_TO_PERPIGNAN.reversed("Perpignan → Girona")
+    val ANDORRA_OUT = GIRONA_TO_ANDORRA
+    val ANDORRA_BACK = GIRONA_TO_ANDORRA.reversed("Andorra la Vella → Girona")
+    val ERRAND = GIRONA_ERRAND
+    val ERRAND_BACK = GIRONA_ERRAND.reversed("Girona → home")
+
+    // The Barcelona commute, split at the Maçanet Supercharger (waypoint 6 of the return
+    // leg) for the days the car stops to charge on the way home.
+    val COMMUTE_BACK_TO_MACANET = COMMUTE_BACK.segment(
+        name = "Barcelona → Maçanet de la Selva",
+        fromIndex = 0,
+        toIndex = 6,
+        startAddress = "Avinguda Diagonal, Barcelona",
+        endAddress = "Supercharger Maçanet de la Selva"
+    )
+
+    val MACANET_TO_HOME = COMMUTE_BACK.segment(
+        name = "Maçanet de la Selva → Girona",
+        fromIndex = 6,
+        toIndex = 8,
+        startAddress = "Supercharger Maçanet de la Selva",
+        endAddress = HOME_ADDRESS
+    )
+}
+
+/** Where the demo car charges. Superchargers are DC; home and the hotel are AC. */
+internal data class DemoChargerSite(
+    val address: String,
+    val point: DemoPoint,
+    val isDc: Boolean,
+    val peakPowerKw: Int,
+    val pricePerKwh: Double,
+    val phases: Int?,
+    val voltage: Int,
+    val maxCurrent: Int
+)
+
+internal object DemoChargers {
+    val HOME = DemoChargerSite(
+        address = "Home",
+        point = DemoRoutes.HOME,
+        isDc = false,
+        peakPowerKw = 11,
+        pricePerKwh = 0.1450,
+        phases = 2,
+        voltage = 233,
+        maxCurrent = 16
+    )
+
+    val MACANET = DemoChargerSite(
+        address = "Supercharger Maçanet de la Selva",
+        point = DemoPoint(41.7845, 2.7333, 90),
+        isDc = true,
+        peakPowerKw = 197,
+        pricePerKwh = 0.3900,
+        phases = 0,
+        voltage = 396,
+        maxCurrent = 497
+    )
+
+    val FIGUERES = DemoChargerSite(
+        address = "Supercharger Figueres",
+        point = DemoPoint(42.2620, 2.9750, 42),
+        isDc = true,
+        peakPowerKw = 172,
+        pricePerKwh = 0.4100,
+        phases = 0,
+        voltage = 391,
+        maxCurrent = 440
+    )
+
+    val PERPIGNAN = DemoChargerSite(
+        address = "Supercharger Perpignan Sud",
+        point = DemoPoint(42.6633, 2.8794, 45),
+        isDc = true,
+        peakPowerKw = 148,
+        pricePerKwh = 0.4700,
+        phases = 0,
+        voltage = 388,
+        maxCurrent = 381
+    )
+
+    val ANDORRA_HOTEL = DemoChargerSite(
+        address = "Hotel, Avinguda Meritxell, Andorra la Vella",
+        point = DemoPoint(42.5063, 1.5218, 1023),
+        isDc = false,
+        peakPowerKw = 22,
+        pricePerKwh = 0.0,
+        phases = 2,
+        voltage = 231,
+        maxCurrent = 32
+    )
+}

--- a/app/src/main/java/com/matedroid/data/demo/DemoMode.kt
+++ b/app/src/main/java/com/matedroid/data/demo/DemoMode.kt
@@ -1,0 +1,31 @@
+package com.matedroid.data.demo
+
+/**
+ * Demo mode: the app running against a self-contained sample dataset instead of a
+ * TeslaMate server.
+ *
+ * It exists so the app can be evaluated — by someone deciding whether TeslaMate is worth
+ * setting up, and by app-store reviewers, who have no server to point the connection form
+ * at and would otherwise never get past onboarding.
+ *
+ * The switch lives in the settings alongside the server URL rather than in a build flavour:
+ * demo mode has to be reachable from the shipped release build, and has to be leavable
+ * again without a reinstall.
+ */
+object DemoMode {
+    /**
+     * Stored as the server URL while demo mode is on.
+     *
+     * A sentinel rather than an extra "is the app configured?" condition: every gate that
+     * decides whether onboarding is done already asks whether the server URL is blank, and
+     * a scheme no real server can use keeps this value from ever being dialled. It is
+     * [TeslamateApiFactory][com.matedroid.di.TeslamateApiFactory] that intercepts it, so no
+     * request is ever built from this string.
+     */
+    const val SERVER_URL: String = "demo://matedroid"
+
+    /** The demo dataset describes a single car, and the app addresses it by id. */
+    const val CAR_ID: Int = 1
+
+    fun isDemoUrl(url: String?): Boolean = url?.trim()?.trimEnd('/') == SERVER_URL
+}

--- a/app/src/main/java/com/matedroid/data/demo/DemoTeslamateApi.kt
+++ b/app/src/main/java/com/matedroid/data/demo/DemoTeslamateApi.kt
@@ -1,0 +1,212 @@
+package com.matedroid.data.demo
+
+import com.matedroid.data.api.TeslamateApi
+import com.matedroid.data.api.models.BatteryHealthData
+import com.matedroid.data.api.models.BatteryHealthResponse
+import com.matedroid.data.api.models.CarStatusData
+import com.matedroid.data.api.models.CarStatusResponse
+import com.matedroid.data.api.models.CarsData
+import com.matedroid.data.api.models.CarsResponse
+import com.matedroid.data.api.models.ChargeDetailCar
+import com.matedroid.data.api.models.ChargeDetailData
+import com.matedroid.data.api.models.ChargeDetailResponse
+import com.matedroid.data.api.models.ChargesData
+import com.matedroid.data.api.models.ChargesResponse
+import com.matedroid.data.api.models.DriveDetailCar
+import com.matedroid.data.api.models.DriveDetailData
+import com.matedroid.data.api.models.DriveDetailResponse
+import com.matedroid.data.api.models.DrivesData
+import com.matedroid.data.api.models.DrivesResponse
+import com.matedroid.data.api.models.GlobalSettings
+import com.matedroid.data.api.models.GlobalSettingsData
+import com.matedroid.data.api.models.GlobalSettingsResponse
+import com.matedroid.data.api.models.PingResponse
+import com.matedroid.data.api.models.TeslamateUnits
+import com.matedroid.data.api.models.TeslamateUrls
+import com.matedroid.data.api.models.UpdatesResponse
+import com.matedroid.data.api.models.UpdatesResponseData
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.Response
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+/**
+ * A [TeslamateApi] that answers from [DemoDataSet] instead of the network.
+ *
+ * Implementing the Retrofit interface — rather than short-circuiting somewhere in the
+ * repository — is what keeps demo mode honest: every screen, worker and notification path
+ * runs exactly the code it runs against a real server, including the query parameters, the
+ * pagination and the "no active charge" reply that is a 200 with an error field rather than
+ * a failure. Nothing downstream knows or needs to know that the server isn't there.
+ */
+internal class DemoTeslamateApi : TeslamateApi {
+
+    /**
+     * Built once per process. The dataset is anchored to the moment it is created, and
+     * rebuilding it mid-session would renumber every drive under the screens holding those
+     * ids — a process that survives long enough for the anchor to drift is rarer than that
+     * would be confusing.
+     */
+    private val data: DemoDataSet by lazy {
+        DemoDataSet(Instant.now(), ZoneId.systemDefault())
+    }
+
+    private val carRef get() = DriveDetailCar(carId = data.car.carId, carName = data.car.name)
+
+    override suspend fun ping(): Response<PingResponse> =
+        Response.success(PingResponse(ping = "pong"))
+
+    override suspend fun getCars(): Response<CarsResponse> =
+        Response.success(CarsResponse(CarsData(cars = listOf(data.car))))
+
+    override suspend fun getCar(carId: Int): Response<CarsResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        return Response.success(CarsResponse(CarsData(cars = listOf(data.car))))
+    }
+
+    override suspend fun getCarStatus(carId: Int): Response<CarStatusResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        return Response.success(
+            CarStatusResponse(
+                CarStatusData(status = data.status(Instant.now()), units = data.units)
+            )
+        )
+    }
+
+    override suspend fun getCharges(
+        carId: Int,
+        startDate: String?,
+        endDate: String?,
+        page: Int?,
+        show: Int?
+    ): Response<ChargesResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        val charges = data.charges(Instant.now())
+            .filter { inRange(it.startDate, startDate, endDate) }
+            .paginate(page, show)
+        return Response.success(ChargesResponse(ChargesData(charges = charges)))
+    }
+
+    override suspend fun getChargeDetail(carId: Int, chargeId: Int): Response<ChargeDetailResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        val charge = data.chargeDetail(chargeId, Instant.now()) ?: return notFound()
+        return Response.success(
+            ChargeDetailResponse(
+                ChargeDetailData(
+                    car = ChargeDetailCar(carId = data.car.carId, carName = data.car.name),
+                    charge = charge
+                )
+            )
+        )
+    }
+
+    override suspend fun getCurrentCharge(carId: Int): Response<ChargeDetailResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        val charge = data.currentCharge(Instant.now())
+            // TeslamateAPI answers 200 with an error field, not a 4xx, when nothing is
+            // plugged in. The repository relies on that to tell "idle" from "unreachable".
+            ?: return Response.success(
+                ChargeDetailResponse(error = "No active charging in progress.")
+            )
+        return Response.success(
+            ChargeDetailResponse(
+                ChargeDetailData(
+                    car = ChargeDetailCar(carId = data.car.carId, carName = data.car.name),
+                    charge = charge
+                )
+            )
+        )
+    }
+
+    override suspend fun getDrives(
+        carId: Int,
+        startDate: String?,
+        endDate: String?,
+        page: Int?,
+        show: Int?
+    ): Response<DrivesResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        val drives = data.drives
+            .filter { inRange(it.startDate, startDate, endDate) }
+            .paginate(page, show)
+        return Response.success(DrivesResponse(DrivesData(drives = drives)))
+    }
+
+    override suspend fun getDriveDetail(carId: Int, driveId: Int): Response<DriveDetailResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        val drive = data.driveDetail(driveId) ?: return notFound()
+        return Response.success(
+            DriveDetailResponse(DriveDetailData(car = carRef, drive = drive))
+        )
+    }
+
+    override suspend fun getBatteryHealth(carId: Int): Response<BatteryHealthResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        return Response.success(
+            BatteryHealthResponse(BatteryHealthData(batteryHealth = data.batteryHealth))
+        )
+    }
+
+    override suspend fun getUpdates(
+        carId: Int,
+        page: Int?,
+        show: Int?
+    ): Response<UpdatesResponse> {
+        if (carId != DemoMode.CAR_ID) return notFound()
+        return Response.success(
+            UpdatesResponse(UpdatesResponseData(updates = data.updates.paginate(page, show)))
+        )
+    }
+
+    override suspend fun getGlobalSettings(): Response<GlobalSettingsResponse> =
+        Response.success(
+            GlobalSettingsResponse(
+                GlobalSettingsData(
+                    GlobalSettings(
+                        // Deliberately empty: there is no TeslaMate web UI behind the demo,
+                        // and a base URL here would put "edit cost in TeslaMate" links on
+                        // the charge screens that could only lead nowhere.
+                        teslamateUrls = TeslamateUrls(baseUrl = null, grafanaUrl = null),
+                        teslamateUnits = TeslamateUnits(unitOfLength = "km", unitOfTemperature = "C")
+                    )
+                )
+            )
+        )
+
+    // ---------------------------------------------------------------- helpers
+
+    private fun <T> notFound(): Response<T> =
+        Response.error(404, """{"error":"not found"}""".toResponseBody(JSON))
+
+    private fun <T> List<T>.paginate(page: Int?, show: Int?): List<T> {
+        if (show == null || show <= 0) return this
+        val index = (page ?: 1).coerceAtLeast(1) - 1
+        return drop(index * show).take(show)
+    }
+
+    private fun inRange(date: String?, from: String?, to: String?): Boolean {
+        val at = date?.let(::parseTimestamp) ?: return true
+        val after = from?.let(::parseTimestamp)?.let { !at.isBefore(it) } ?: true
+        val before = to?.let(::parseTimestamp)?.let { !at.isAfter(it) } ?: true
+        return after && before
+    }
+
+    /**
+     * Accepts what TeslamateAPI's own `parseDateParam` accepts: RFC3339 with an offset, and
+     * the offset-less `2006-01-02 15:04:05` form, which is read as local time.
+     */
+    private fun parseTimestamp(value: String): Instant? = runCatching {
+        OffsetDateTime.parse(value).toInstant()
+    }.recoverCatching {
+        LocalDateTime.parse(value.trim().replace(' ', 'T'))
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+    }.getOrNull()
+
+    private companion object {
+        private val JSON = "application/json".toMediaType()
+    }
+}

--- a/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
+++ b/app/src/main/java/com/matedroid/data/local/SettingsDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.matedroid.data.demo.DemoMode
 import com.matedroid.domain.ConnectionTimeout
 import com.matedroid.domain.CostPerKwhBasis
 import com.matedroid.domain.HighSocWarning
@@ -71,6 +72,14 @@ data class AppSettings(
 ) {
     val isConfigured: Boolean
         get() = serverUrl.isNotBlank()
+
+    /**
+     * True while the app is showing the built-in sample dataset instead of talking to a
+     * server. Derived from [serverUrl] rather than stored separately, so the two can never
+     * disagree — see [DemoMode.SERVER_URL].
+     */
+    val isDemoMode: Boolean
+        get() = DemoMode.isDemoUrl(serverUrl)
 
     val hasSecondaryServer: Boolean
         get() = secondaryServerUrl.isNotBlank()
@@ -221,6 +230,36 @@ class SettingsDataStore @Inject constructor(
     suspend fun saveConnectTimeoutSeconds(seconds: Int) {
         context.dataStore.edit { preferences ->
             preferences[connectTimeoutSecondsKey] = seconds
+        }
+    }
+
+    /**
+     * Enter demo mode, replacing whatever connection was configured.
+     *
+     * The previous server URL and credentials are cleared rather than parked somewhere for
+     * later: demo mode is entered from onboarding, where there is nothing to preserve, and
+     * keeping a shadow copy of someone's API token around for a restore that may never come
+     * is not a trade worth making. Leaving demo mode returns to onboarding.
+     */
+    suspend fun enterDemoMode() {
+        context.dataStore.edit { preferences ->
+            preferences[serverUrlKey] = DemoMode.SERVER_URL
+            preferences[secondaryServerUrlKey] = ""
+            preferences[apiTokenKey] = ""
+            preferences[httpBasicAuthUsernameKey] = ""
+            preferences[httpBasicAuthPasswordKey] = ""
+            preferences[teslamateBaseUrlKey] = ""
+            preferences.remove(lastSelectedCarIdKey)
+        }
+    }
+
+    /** Leave demo mode, putting the app back in its unconfigured first-run state. */
+    suspend fun exitDemoMode() {
+        context.dataStore.edit { preferences ->
+            preferences[serverUrlKey] = ""
+            preferences[teslamateBaseUrlKey] = ""
+            preferences.remove(lastSelectedCarIdKey)
+            preferences.remove(carImageOverridesKey)
         }
     }
 

--- a/app/src/main/java/com/matedroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/matedroid/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.matedroid.BuildConfig
 import com.matedroid.data.api.NominatimApi
 import com.matedroid.data.api.OpenMeteoApi
 import com.matedroid.data.api.TeslamateApi
+import com.matedroid.data.demo.DemoTeslamateApi
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.domain.ConnectionTimeout
 import com.squareup.moshi.Moshi
@@ -116,6 +117,12 @@ class TeslamateApiFactory(
     private val apiCache = mutableMapOf<ApiCacheKey, TeslamateApi>()
 
     /**
+     * Kept outside [apiCache] on purpose: it holds a generated dataset whose drive and charge
+     * ids screens are already holding, so it must survive [invalidateCache].
+     */
+    private val demoApi: TeslamateApi by lazy { DemoTeslamateApi() }
+
+    /**
      * Creates or returns a cached TeslamateApi instance for the given URL.
      *
      * @param baseUrl The base URL for the API
@@ -129,8 +136,14 @@ class TeslamateApiFactory(
         acceptInvalidCerts: Boolean? = null,
         connectTimeoutSeconds: Int? = null
     ): TeslamateApi {
-        val normalizedUrl = baseUrl.trimEnd('/') + "/"
         val settings = settingsDataStore.settings.first()
+
+        // Demo mode answers every request in-process. Checked before anything is built so
+        // that Test Connection, the workers and the widget all take the same path as the
+        // screens, and no URL derived from the sentinel is ever dialled.
+        if (settings.isDemoMode) return demoApi
+
+        val normalizedUrl = baseUrl.trimEnd('/') + "/"
         val useInsecure = acceptInvalidCerts ?: settings.acceptInvalidCerts
         val apiToken = settings.apiToken
         val basicAuthUsername = settings.httpBasicAuthUsername

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -155,19 +156,28 @@ fun DashboardScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(
-                        text = uiState.selectedCarName ?: "MateDroid",
-                        modifier = if (BuildConfig.DEBUG) {
-                            Modifier.combinedClickable(
-                                onClick = {},
-                                onDoubleClick = {
-                                    uiState.selectedCarId?.let { carId ->
-                                        onNavigateToSentryHistory(carId, uiState.selectedCarExterior?.exteriorColor)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = uiState.selectedCarName ?: "MateDroid",
+                            modifier = if (BuildConfig.DEBUG) {
+                                Modifier.combinedClickable(
+                                    onClick = {},
+                                    onDoubleClick = {
+                                        uiState.selectedCarId?.let { carId ->
+                                            onNavigateToSentryHistory(carId, uiState.selectedCarExterior?.exteriorColor)
+                                        }
                                     }
-                                }
-                            )
-                        } else Modifier
-                    )
+                                )
+                            } else Modifier
+                        )
+                        // Sample data is convincing enough that it has to say so somewhere
+                        // permanent. Next to the car name is where the eye already is, and
+                        // it travels with the name into every screenshot.
+                        if (uiState.isDemoMode) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            DemoBadge()
+                        }
+                    }
                 },
                 actions = {
                     val carSelected = uiState.selectedCarId != null
@@ -781,6 +791,28 @@ private fun DashboardPreview() {
                 )
             ),
             carTrimBadging = "74D"
+        )
+    }
+}
+
+/**
+ * The "Demo" marker beside the car name.
+ *
+ * Deliberately always on screen while the sample data is in use, rather than a dismissible
+ * banner: the demo is convincing enough that a screenshot of it would otherwise pass for a
+ * real car, and nobody should be left wondering whose Tesla they are looking at.
+ */
+@Composable
+private fun DemoBadge() {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = MaterialTheme.shapes.small
+    ) {
+        Text(
+            text = stringResource(R.string.demo_mode_badge),
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
         )
     }
 }

--- a/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/dashboard/DashboardViewModel.kt
@@ -49,6 +49,8 @@ data class DashboardUiState(
     val carImageOverride: CarImageOverride? = null,
     val carImageOverrides: Map<Int, CarImageOverride> = emptyMap(),
     val isCurrentChargeAvailable: Boolean = false,
+    /** True while the dashboard is showing the built-in sample data rather than a real car. */
+    val isDemoMode: Boolean = false,
     val sentryEventCount: Int = 0,
     val totalTrips: Int? = null,
     /** Most recent detected trip (newest first), for the dashboard's Trips hero teaser. */
@@ -131,6 +133,13 @@ class DashboardViewModel @Inject constructor(
                         it.copy(highSocWarningThreshold = high, lowSocWarningThreshold = low)
                     }
                 }
+        }
+
+        viewModelScope.launch {
+            settingsDataStore.settings
+                .map { it.isDemoMode }
+                .distinctUntilChanged()
+                .collect { demo -> _uiState.update { it.copy(isDemoMode = demo) } }
         }
     }
 

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsScreen.kt
@@ -97,10 +97,15 @@ private fun SettingsHubContent(
 @Composable
 private fun sectionSummary(section: SettingsSection, settings: AppSettings): String =
     when (section) {
-        SettingsSection.CONNECTION -> settings.serverUrl.takeIf { it.isNotBlank() }
-            ?.removePrefix("https://")
-            ?.removePrefix("http://")
-            ?: stringResource(R.string.settings_not_configured)
+        // The demo's server URL is a sentinel, not an address — showing it raw would put
+        // "demo://matedroid" on the hub as if it were something the user had typed.
+        SettingsSection.CONNECTION -> when {
+            settings.isDemoMode -> stringResource(R.string.settings_demo_summary)
+            settings.serverUrl.isNotBlank() -> settings.serverUrl
+                .removePrefix("https://")
+                .removePrefix("http://")
+            else -> stringResource(R.string.settings_not_configured)
+        }
 
         SettingsSection.DISPLAY -> Currency.findByCode(settings.currencyCode).let {
             "${it.symbol} ${it.code}"

--- a/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import com.matedroid.R
+import com.matedroid.data.demo.DemoMode
 import com.matedroid.data.local.SettingsDataStore
 import com.matedroid.data.local.TirePosition
 import com.matedroid.data.repository.ApiResult
@@ -54,6 +55,7 @@ data class SettingsUiState(
     val shortChargeMinEnergyKwh: Double = ShortEntryFilter.DEFAULT_MIN_CHARGE_ENERGY_KWH,
     val highSocWarningThreshold: Int = HighSocWarning.DEFAULT_THRESHOLD,
     val lowSocWarningThreshold: Int = LowSocWarning.DEFAULT_THRESHOLD,
+    val isDemoMode: Boolean = false,
     val isLoading: Boolean = true,
     val isTesting: Boolean = false,
     val isSaving: Boolean = false,
@@ -124,6 +126,7 @@ class SettingsViewModel @Inject constructor(
                 shortChargeMinEnergyKwh = settings.shortChargeMinEnergyKwh,
                 highSocWarningThreshold = settings.highSocWarningThreshold,
                 lowSocWarningThreshold = settings.lowSocWarningThreshold,
+                isDemoMode = settings.isDemoMode,
                 isLoading = false
             )
         }
@@ -379,6 +382,57 @@ class SettingsViewModel @Inject constructor(
             is ApiResult.Error -> {
                 // Silent fail - this is optional functionality
                 // Older Teslamate API versions may not have this endpoint
+            }
+        }
+    }
+
+    /**
+     * Switch to the built-in sample dataset and go straight to the dashboard.
+     *
+     * Offered only from first-run onboarding, so there is no configured server to trample
+     * and no cached data to clear on the way in — the reset below is there for the case
+     * where someone reaches this from a half-finished setup.
+     */
+    fun enterDemoMode(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, error = null)
+            try {
+                syncManager.fullResetSync(DemoMode.CAR_ID)
+                settingsDataStore.enterDemoMode()
+                loadSettings()
+                triggerImmediateSync()
+                _uiState.value = _uiState.value.copy(isSaving = false)
+                onSuccess()
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSaving = false,
+                    error = e.message ?: context.getString(R.string.settings_error_save_failed)
+                )
+            }
+        }
+    }
+
+    /**
+     * Leave the demo and return to onboarding.
+     *
+     * The sample drives and charges are deleted rather than left in place: they are keyed by
+     * the same car id a real TeslaMate would use, so anything left behind would be merged
+     * into the real car's history the moment a server is configured.
+     */
+    fun exitDemoMode(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, error = null)
+            try {
+                syncManager.fullResetSync(DemoMode.CAR_ID)
+                settingsDataStore.exitDemoMode()
+                loadSettings()
+                _uiState.value = _uiState.value.copy(isSaving = false)
+                onSuccess()
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSaving = false,
+                    error = e.message ?: context.getString(R.string.settings_error_save_failed)
+                )
             }
         }
     }

--- a/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/matedroid/ui/screens/settings/sections/ConnectionSettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
@@ -105,6 +107,8 @@ fun ConnectionSettingsScreen(
         isOnboarding = isOnboarding,
         snackbarHostState = snackbarHostState,
         onNavigateBack = onNavigateBack.takeIf { !isOnboarding },
+        onTryDemo = { viewModel.enterDemoMode(onNavigateToDashboard) },
+        onExitDemo = { viewModel.exitDemoMode(onNavigateBack) },
         onServerUrlChange = viewModel::updateServerUrl,
         onSecondaryServerUrlChange = viewModel::updateSecondaryServerUrl,
         onApiTokenChange = viewModel::updateApiToken,
@@ -131,6 +135,8 @@ private fun ConnectionSettingsContent(
     isOnboarding: Boolean,
     snackbarHostState: SnackbarHostState,
     onNavigateBack: (() -> Unit)?,
+    onTryDemo: () -> Unit,
+    onExitDemo: () -> Unit,
     onServerUrlChange: (String) -> Unit,
     onSecondaryServerUrlChange: (String) -> Unit,
     onApiTokenChange: (String) -> Unit,
@@ -150,19 +156,36 @@ private fun ConnectionSettingsContent(
         onBack = onNavigateBack,
         snackbarHostState = snackbarHostState,
         bottomBar = {
-            ConnectionActionBar(
-                uiState = uiState,
-                isOnboarding = isOnboarding,
-                onTestConnection = onTestConnection,
-                onSave = onSave
-            )
+            if (uiState.isDemoMode) {
+                ExitDemoActionBar(isBusy = uiState.isSaving, onExitDemo = onExitDemo)
+            } else {
+                ConnectionActionBar(
+                    uiState = uiState,
+                    isOnboarding = isOnboarding,
+                    onTestConnection = onTestConnection,
+                    onSave = onSave
+                )
+            }
         }
     ) {
+        // While the demo owns the connection there is nothing on this page to configure, so
+        // the form is replaced rather than disabled: a greyed-out server field next to live
+        // sample data only invites the question of which one the app is actually using.
+        if (uiState.isDemoMode) {
+            DemoModeActiveCard()
+            return@SettingsSectionScaffold
+        }
+
         Text(
             text = stringResource(R.string.settings_connect_description),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        if (isOnboarding) {
+            SettingsSpacer(20)
+            DemoOfferCard(enabled = fieldsEnabled, onTryDemo = onTryDemo)
+        }
 
         SettingsSpacer(24)
 
@@ -365,6 +388,121 @@ private fun ConnectionSettingsContent(
     }
 }
 
+/**
+ * The way past the connection wall for someone who has no TeslaMate server to type in.
+ *
+ * It sits directly under the page description, above the first field, because that is the
+ * only place it is certain to be seen: the form below it is long enough that the buttons at
+ * the bottom are off-screen on a small phone, and anyone who has nothing to enter has no
+ * reason to scroll down to find them.
+ */
+@Composable
+private fun DemoOfferCard(enabled: Boolean, onTryDemo: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Science,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.settings_demo_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            SettingsSpacer(8)
+            Text(
+                text = stringResource(R.string.settings_demo_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            SettingsSpacer(12)
+            Button(
+                onClick = onTryDemo,
+                enabled = enabled,
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .testTag("tryDemoButton")
+            ) {
+                Text(stringResource(R.string.settings_demo_action))
+            }
+        }
+    }
+}
+
+/** Replaces the connection form while the sample dataset is in use. */
+@Composable
+private fun DemoModeActiveCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Science,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.settings_demo_active_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            SettingsSpacer(8)
+            Text(
+                text = stringResource(R.string.settings_demo_active_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExitDemoActionBar(isBusy: Boolean, onExitDemo: () -> Unit) {
+    Surface(tonalElevation = 3.dp) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(16.dp)
+        ) {
+            Button(
+                onClick = onExitDemo,
+                enabled = !isBusy,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("exitDemoButton")
+            ) {
+                if (isBusy) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.settings_demo_exit_action))
+            }
+        }
+    }
+}
+
 /** Test and Save pinned to the bottom so they stay reachable with the form scrolled. */
 @Composable
 private fun ConnectionActionBar(
@@ -537,6 +675,8 @@ private fun ConnectionSettingsPreview() {
             isOnboarding = false,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
+            onTryDemo = {},
+            onExitDemo = {},
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
@@ -559,6 +699,32 @@ private fun ConnectionSettingsOnboardingPreview() {
             isOnboarding = true,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = null,
+            onTryDemo = {},
+            onExitDemo = {},
+            onServerUrlChange = {},
+            onSecondaryServerUrlChange = {},
+            onApiTokenChange = {},
+            onHttpBasicAuthUsernameChange = {},
+            onHttpBasicAuthPasswordChange = {},
+            onAcceptInvalidCertsChange = {},
+            onConnectTimeoutChange = {},
+            onTestConnection = {},
+            onSave = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ConnectionSettingsDemoModePreview() {
+    MateDroidTheme {
+        ConnectionSettingsContent(
+            uiState = SettingsUiState(isLoading = false, isDemoMode = true),
+            isOnboarding = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onNavigateBack = {},
+            onTryDemo = {},
+            onExitDemo = {},
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},
@@ -590,6 +756,8 @@ private fun ConnectionSettingsWithResultPreview() {
             isOnboarding = false,
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateBack = {},
+            onTryDemo = {},
+            onExitDemo = {},
             onServerUrlChange = {},
             onSecondaryServerUrlChange = {},
             onApiTokenChange = {},

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -285,6 +285,16 @@
     <string name="settings_connect_title">Connecta a TeslamateApi</string>
     <string name="settings_connect_description">Introdueix l\'URL del teu servidor TeslamateApi per connectar.</string>
 
+    <string name="settings_demo_title">No tens cap servidor?</string>
+    <string name="settings_demo_description">Explora MateDroid amb un any de dades d\'exemple d\'un cotxe de demostració. Podràs connectar el teu TeslaMate més endavant.</string>
+    <string name="settings_demo_action">Prova la demo</string>
+
+    <string name="settings_demo_active_title">Mode demo</string>
+    <string name="settings_demo_active_description">Estàs veient dades d\'exemple d\'un cotxe de demostració, no d\'un vehicle real. Surt de la demo per connectar el teu servidor TeslamateApi.</string>
+    <string name="settings_demo_exit_action">Surt del mode demo</string>
+    <string name="settings_demo_summary">Mode demo — dades d\'exemple</string>
+    <string name="demo_mode_badge">Demo</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del servidor</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -285,6 +285,16 @@
     <string name="settings_connect_title">Mit TeslamateApi verbinden</string>
     <string name="settings_connect_description">Gib die URL deines TeslamateApi-Servers ein, um eine Verbindung herzustellen.</string>
 
+    <string name="settings_demo_title">Kein Server zur Hand?</string>
+    <string name="settings_demo_description">Sieh dich in MateDroid mit einem Jahr Beispieldaten eines Demofahrzeugs um. Dein eigenes TeslaMate kannst du später verbinden.</string>
+    <string name="settings_demo_action">Demo ausprobieren</string>
+
+    <string name="settings_demo_active_title">Demomodus</string>
+    <string name="settings_demo_active_description">Du siehst Beispieldaten eines Demofahrzeugs, nicht die eines echten Autos. Verlasse die Demo, um deinen eigenen TeslamateApi-Server zu verbinden.</string>
+    <string name="settings_demo_exit_action">Demomodus verlassen</string>
+    <string name="settings_demo_summary">Demomodus — Beispieldaten</string>
+    <string name="demo_mode_badge">Demo</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">Server-URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -285,6 +285,16 @@
     <string name="settings_connect_title">Conectar a TeslamateApi</string>
     <string name="settings_connect_description">Introduce la URL de tu servidor TeslamateApi para conectar.</string>
 
+    <string name="settings_demo_title">¿No tienes un servidor?</string>
+    <string name="settings_demo_description">Explora MateDroid con un año de datos de ejemplo de un coche de demostración. Podrás conectar tu propio TeslaMate más adelante.</string>
+    <string name="settings_demo_action">Probar la demo</string>
+
+    <string name="settings_demo_active_title">Modo demo</string>
+    <string name="settings_demo_active_description">Estás viendo datos de ejemplo de un coche de demostración, no de un vehículo real. Sal de la demo para conectar tu servidor TeslamateApi.</string>
+    <string name="settings_demo_exit_action">Salir del modo demo</string>
+    <string name="settings_demo_summary">Modo demo — datos de ejemplo</string>
+    <string name="demo_mode_badge">Demo</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del servidor</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -285,6 +285,16 @@
     <string name="settings_connect_title">Connetti a TeslamateApi</string>
     <string name="settings_connect_description">Inserisci l\'URL del server TeslamateApi per connetterti.</string>
 
+    <string name="settings_demo_title">Non hai un server?</string>
+    <string name="settings_demo_description">Esplora MateDroid con un anno di dati di esempio di un\'auto dimostrativa. Potrai collegare il tuo TeslaMate in seguito.</string>
+    <string name="settings_demo_action">Prova la demo</string>
+
+    <string name="settings_demo_active_title">Modalità demo</string>
+    <string name="settings_demo_active_description">Stai vedendo dati di esempio di un\'auto dimostrativa, non di un veicolo reale. Esci dalla demo per collegare il tuo server TeslamateApi.</string>
+    <string name="settings_demo_exit_action">Esci dalla demo</string>
+    <string name="settings_demo_summary">Modalità demo — dati di esempio</string>
+    <string name="demo_mode_badge">Demo</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">URL del server</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -285,6 +285,16 @@
     <string name="settings_connect_title">连接 TeslamateApi</string>
     <string name="settings_connect_description">输入你的 TeslamateApi 服务器 URL 以连接。</string>
 
+    <string name="settings_demo_title">还没有服务器？</string>
+    <string name="settings_demo_description">用演示车辆一年的示例数据浏览 MateDroid。你可以稍后再连接自己的 TeslaMate。</string>
+    <string name="settings_demo_action">试用演示</string>
+
+    <string name="settings_demo_active_title">演示模式</string>
+    <string name="settings_demo_active_description">你看到的是演示车辆的示例数据，并非真实车辆。退出演示即可连接你自己的 TeslamateApi 服务器。</string>
+    <string name="settings_demo_exit_action">退出演示模式</string>
+    <string name="settings_demo_summary">演示模式 — 示例数据</string>
+    <string name="demo_mode_badge">演示</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">服务器 URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,6 +288,21 @@
     <string name="settings_connect_title">Connect to TeslamateApi</string>
     <string name="settings_connect_description">Enter your TeslamateApi server URL to connect.</string>
 
+    <!-- Demo mode offer, shown during first-run setup for people with no TeslaMate server
+         to point the form at (evaluating the app, or reviewing it for a store). -->
+    <string name="settings_demo_title">No server to hand?</string>
+    <string name="settings_demo_description">Look around MateDroid with a year of sample data from a demonstration car. You can connect your own TeslaMate later.</string>
+    <string name="settings_demo_action">Try the demo</string>
+
+    <!-- Shown on the connection screen while the sample data is in use -->
+    <string name="settings_demo_active_title">Demo mode</string>
+    <string name="settings_demo_active_description">You are looking at sample data from a demonstration car, not a real vehicle. Leave the demo to connect your own TeslamateApi server.</string>
+    <string name="settings_demo_exit_action">Leave demo mode</string>
+    <!-- Summary line on the settings hub while demo mode is active -->
+    <string name="settings_demo_summary">Demo mode — sample data</string>
+    <!-- Badge next to the car name while demo mode is active -->
+    <string name="demo_mode_badge">Demo</string>
+
     <!-- Server URL field -->
     <string name="settings_server_url_label">Server URL</string>
     <string name="settings_server_url_placeholder">https://teslamate-api.example.com</string>

--- a/app/src/test/java/com/matedroid/data/demo/DemoDataSetTest.kt
+++ b/app/src/test/java/com/matedroid/data/demo/DemoDataSetTest.kt
@@ -1,0 +1,216 @@
+package com.matedroid.data.demo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * The demo dataset is a simulation, not a fixture, so what is worth testing is that it stays
+ * *coherent*: the odometer only goes up, a drive picks up where the last one left off, and
+ * nothing is dated in the future. Those are the properties every derived screen — mileage,
+ * stats, battery — silently depends on.
+ */
+class DemoDataSetTest {
+
+    private val zone: ZoneId = ZoneId.of("Europe/Madrid")
+    private val anchor: Instant = OffsetDateTime.of(2026, 6, 15, 14, 30, 0, 0, java.time.ZoneOffset.ofHours(2))
+        .toInstant()
+    private val data = DemoDataSet(anchor, zone)
+
+    // Oldest first, which is the order the simulation produced them in.
+    private val chronological = data.drives.sortedBy { it.startDate }
+
+    @Test
+    fun `there is a year of history to look at`() {
+        assertTrue("expected a few hundred drives, got ${data.drives.size}", data.drives.size > 150)
+        assertTrue("expected a good number of charges, got ${data.charges(anchor).size}",
+            data.charges(anchor).size > 40)
+        assertTrue(data.updates.size >= 5)
+    }
+
+    @Test
+    fun `nothing is dated in the future`() {
+        data.drives.forEach { drive ->
+            val end = OffsetDateTime.parse(drive.endDate).toInstant()
+            assertTrue("drive ${drive.driveId} ends after now", end.isBefore(anchor))
+        }
+        data.charges(anchor).forEach { charge ->
+            val end = OffsetDateTime.parse(charge.endDate).toInstant()
+            assertTrue("charge ${charge.chargeId} ends after now", !end.isAfter(anchor))
+        }
+    }
+
+    @Test
+    fun `history spans two calendar years so the year filter has a choice`() {
+        val years = data.drives.map { OffsetDateTime.parse(it.startDate).year }.toSet()
+        assertEquals(setOf(2025, 2026), years)
+    }
+
+    @Test
+    fun `the odometer only ever moves forward, and each drive resumes where the last stopped`() {
+        chronological.zipWithNext { previous, next ->
+            val previousEnd = previous.odometerDetails?.odometerEnd ?: 0.0
+            val nextStart = next.odometerDetails?.odometerStart ?: 0.0
+            assertEquals(
+                "drive ${next.driveId} does not resume from drive ${previous.driveId}",
+                previousEnd, nextStart, 0.05
+            )
+        }
+    }
+
+    @Test
+    fun `every drive spends charge and stays inside a plausible battery range`() {
+        data.drives.forEach { drive ->
+            val start = drive.startBatteryLevel ?: 0
+            val end = drive.endBatteryLevel ?: 0
+            assertTrue("drive ${drive.driveId} gained charge", end < start)
+            assertTrue("drive ${drive.driveId} battery out of range", end in 1..100 && start in 1..100)
+            assertTrue("drive ${drive.driveId} has no distance", (drive.distance ?: 0.0) > 0.0)
+            assertTrue("drive ${drive.driveId} consumption implausible",
+                (drive.consumptionNet ?: 0.0) in 100.0..320.0)
+        }
+    }
+
+    @Test
+    fun `every charge adds energy and its cost follows from it`() {
+        data.charges(anchor).forEach { charge ->
+            val start = charge.startBatteryLevel ?: 0
+            val end = charge.endBatteryLevel ?: 0
+            assertTrue("charge ${charge.chargeId} did not add charge", end > start)
+            val added = charge.chargeEnergyAdded ?: 0.0
+            val used = charge.chargeEnergyUsed ?: 0.0
+            assertTrue("charge ${charge.chargeId} added no energy", added > 0.0)
+            assertTrue("charge ${charge.chargeId} used less than it added", used >= added)
+            assertTrue("charge ${charge.chargeId} has a negative cost", (charge.cost ?: 0.0) >= 0.0)
+            assertTrue("charge ${charge.chargeId} takes no time", (charge.durationMin ?: 0) > 0)
+        }
+    }
+
+    @Test
+    fun `the car leaves the country, so Visited Countries has something to show`() {
+        val addresses = data.drives.mapNotNull { it.startAddress }.toSet() +
+            data.drives.mapNotNull { it.endAddress }.toSet()
+        assertTrue("no French leg", addresses.any { it.contains("Perpignan") })
+        assertTrue("no Andorran leg", addresses.any { it.contains("Andorra") })
+    }
+
+    @Test
+    fun `both AC and DC charging appear in the history`() {
+        val addresses = data.charges(anchor).mapNotNull { it.address }.toSet()
+        assertTrue("no home AC charging", addresses.any { it == "Home" })
+        assertTrue("no Supercharger sessions", addresses.any { it.contains("Supercharger") })
+    }
+
+    @Test
+    fun `a drive detail traces the route it claims to`() {
+        val drive = data.drives.first { (it.distance ?: 0.0) > 50 }
+        val detail = data.driveDetail(drive.driveId)
+        assertNotNull(detail)
+        val positions = detail!!.positions.orEmpty()
+        assertTrue("too few positions to draw", positions.size > 20)
+
+        // The trace must cover the whole distance the summary reports, or the map line
+        // stops short of the destination.
+        val traced = positions.zipWithNext { a, b ->
+            haversineKm(
+                DemoPoint(a.latitude!!, a.longitude!!, 0),
+                DemoPoint(b.latitude!!, b.longitude!!, 0)
+            )
+        }.sum()
+        assertEquals("traced route does not match reported distance", drive.distance!!, traced, 1.0)
+
+        assertEquals(drive.startBatteryLevel, positions.first().batteryLevel)
+        assertEquals(drive.endBatteryLevel, positions.last().batteryLevel)
+        assertTrue("no regen anywhere in the trace", positions.any { (it.power ?: 0) < 0 })
+    }
+
+    @Test
+    fun `a charge detail tapers and lands on the level the summary reports`() {
+        val dc = data.charges(anchor).first { it.address.orEmpty().contains("Supercharger") }
+        val detail = data.chargeDetail(dc.chargeId, anchor)
+        assertNotNull(detail)
+        val points = detail!!.chargePoints.orEmpty()
+        assertTrue(points.size >= 12)
+        assertEquals(dc.startBatteryLevel, points.first().batteryLevel)
+        assertEquals(dc.endBatteryLevel, points.last().batteryLevel)
+        assertTrue("DC power should taper as the battery fills",
+            points.first().chargerPower!! > points.last().chargerPower!!)
+        assertTrue("DC session should report itself as fast charging",
+            points.all { it.chargerDetails?.chargerPhases == 0 })
+    }
+
+    @Test
+    fun `the live session charges for part of the cycle and rests for the other`() {
+        val charging = instantWithCyclePhase(1_000)
+        val resting = instantWithCyclePhase(12_000)
+
+        val active = DemoDataSet(anchor, zone).currentCharge(charging)
+        assertNotNull("expected a charge in progress", active)
+        assertTrue(active!!.isCharging == true)
+        assertNotNull("a live charge reports its current level", active.currentBatteryLevel)
+
+        assertNull("expected no charge in progress", DemoDataSet(anchor, zone).currentCharge(resting))
+    }
+
+    @Test
+    fun `status agrees with the live session`() {
+        val charging = instantWithCyclePhase(4_000)
+        val chargingStatus = data.status(charging)
+        assertEquals("charging", chargingStatus.state)
+        assertTrue(chargingStatus.isCharging)
+        assertEquals(true, chargingStatus.pluggedIn)
+        assertTrue((chargingStatus.chargerPower ?: 0) > 0)
+        assertEquals(3, chargingStatus.acPhases)
+
+        val restingStatus = data.status(instantWithCyclePhase(13_000))
+        assertEquals("asleep", restingStatus.state)
+        assertEquals(false, restingStatus.pluggedIn)
+        assertEquals(80, restingStatus.batteryLevel)
+    }
+
+    @Test
+    fun `a finished live session joins the charge list exactly once`() {
+        val resting = instantWithCyclePhase(13_000)
+        val charges = data.charges(resting)
+        assertEquals(charges.map { it.chargeId }.distinct().size, charges.size)
+
+        val charging = instantWithCyclePhase(2_000)
+        val liveId = data.currentCharge(charging)!!.chargeId
+        assertTrue("an in-progress charge must not also be listed",
+            data.charges(charging).none { it.chargeId == liveId })
+    }
+
+    @Test
+    fun `software versions are named for the year they were installed`() {
+        data.updates.forEach { update ->
+            val year = OffsetDateTime.parse(update.startDate).year
+            assertTrue(
+                "version ${update.version} does not belong to $year",
+                update.version!!.startsWith("$year.")
+            )
+        }
+        val installs = data.updates.map { OffsetDateTime.parse(it.startDate).toInstant() }
+        assertEquals("updates should be newest first", installs.sortedDescending(), installs)
+    }
+
+    @Test
+    fun `the dataset is metric and says so`() {
+        assertEquals("km", data.units.unitOfLength)
+        assertEquals("bar", data.units.unitOfPressure)
+        assertEquals("C", data.units.unitOfTemperature)
+        assertTrue(data.units.isMetric)
+    }
+
+    /** An instant whose position in the live-charge cycle is exactly [phaseSeconds]. */
+    private fun instantWithCyclePhase(phaseSeconds: Long): Instant {
+        val cycle = 4 * 60 * 60L
+        val base = anchor.truncatedTo(ChronoUnit.DAYS).epochSecond
+        return Instant.ofEpochSecond(base - Math.floorMod(base, cycle) + phaseSeconds)
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -343,6 +343,98 @@ Pre-configured profiles include:
 3. For `/api/v1/cars/*` endpoints, the response JSON is modified to include the overrides from the selected car profile (deep-merged into `car_details` and `car_exterior`)
 4. Other endpoints are passed through unchanged
 
+### Demo Mode
+
+Demo mode runs the whole app against a self-contained sample dataset, with no server of any
+kind. It exists for two audiences: someone deciding whether Teslamate is worth setting up,
+and app-store reviewers, who have no server to point the connection form at and would
+otherwise never get past onboarding — Google Play rejected a release for exactly that.
+
+Entered from **Try the demo** on the first-run connection screen; left from
+Settings → Connection. The offer is shown during onboarding only, so it can never trample a
+configured server.
+
+#### How it is wired
+
+| File | Role |
+|---|---|
+| `data/demo/DemoMode.kt` | The `demo://matedroid` sentinel stored as the server URL, and the demo car id |
+| `data/demo/DemoGeography.kt` | Route polylines through real places, and the charger sites |
+| `data/demo/DemoDataSet.kt` | Generates the history and serves the live status |
+| `data/demo/DemoTeslamateApi.kt` | A `TeslamateApi` implementation answering from the dataset |
+
+Demo mode is a `TeslamateApi` implementation, injected at `TeslamateApiFactory.create()`,
+which every caller already goes through. Nothing downstream knows the server is missing, so
+every screen, worker, widget and notification path runs exactly the code it runs against a
+real server — including query parameters, pagination, and the "no active charge" reply that
+is a 200 with an `error` field rather than a failure.
+
+`AppSettings.isDemoMode` derives from the server URL rather than being stored separately, so
+the two can never disagree. Because the sentinel is a non-blank URL, every existing
+"is the app configured?" gate treats demo mode as configured with no extra condition.
+
+#### The dataset
+
+Generated against the current date rather than shipped as a JSON fixture. A bundled dataset
+would be visibly stale the first time someone opened the demo a year after the release that
+contained it, and every "last 30 days" filter would come back empty. Generating it means the
+newest drive is always yesterday's and the year filters always have two years to choose from.
+
+It is a simulation, not a pile of independent random rows: one running state-of-charge and
+one running odometer are carried through the whole year, drives spend energy and charges put
+it back. That is what keeps the derived screens honest — battery levels line up end to end
+between consecutive drives, the odometer only increases, and charge costs follow from the
+energy actually delivered.
+
+- **Car**: Model Y Juniper, Ultra Red, Crossflow 19" — a colour with a real entry in
+  `CarColorPalettes`, so the palette theming is visible in the demo.
+- **History**: a year of Girona-based driving — the Barcelona commute, the Costa Brava, and
+  trips over the border to Perpignan and up to Andorra. The border runs are the point of
+  those routes: Visited Countries has nothing to show from a dataset that never leaves one
+  country.
+- **Charging**: home AC (11 kW three-phase), Supercharger DC stops with a real taper curve,
+  and a free hotel charger in Andorra.
+- **Live session**: runs on a four-hour wall-clock cycle — charging for the first ~2h20m,
+  then parked at its 80% limit. Both states have to be reachable, or which one you got would
+  depend on when the release was built.
+- **Determinism**: a fixed seed, so the same day produces the same history and drive ids stay
+  stable while the process lives. The dataset is built once per process.
+
+Everything is metric. TeslamateAPI converts server-side and the app never converts (see
+`UnitFormatter`), so the demo does what a metric Teslamate would: it reports km / bar / °C and
+says so in its `units` block. Making it follow the device locale would mean converting every
+distance, speed, temperature, pressure and consumption figure at generation time, and one
+missed field is a wrong number on screen.
+
+Geocoding is *not* faked: the demo's coordinates are real places and go through Nominatim
+like any other data, which is what fills in Visited Countries. Drive start points land on a
+handful of fixed coordinates, so the grid-cell dedup in `GeocodingRepository` collapses them
+to about a dozen lookups.
+
+`DemoDataSetTest` covers the invariants the derived screens depend on: the odometer only
+moves forward, each drive resumes where the last one stopped, nothing is dated in the future,
+and the live session appears in exactly one of `/charges` and `/charges/current`.
+
+#### What to put in Play Console → App access
+
+Google rejected 1.11.0 for not providing "an active demo/guest account", having got stuck on
+the connection screen with nothing to type into it. Demo mode is the answer, but the reviewer
+still has to be told the button exists. Under **App content → App access**, choose
+**All functionality is available without special access** and paste:
+
+> MateDroid reads data from the user's own self-hosted Teslamate server, so there is no
+> account, login or password of any kind — nothing is transmitted to us and there is nothing
+> to sign in to.
+>
+> To review the app without a server, use the built-in demo:
+> 1. Launch the app. The first screen is "Connection".
+> 2. Tap "Try the demo" in the card at the top of that screen.
+>
+> The app then loads a year of sample vehicle data and every feature is reachable. No
+> credentials, network access to a private server, or configuration are required.
+
+Keep that text in step with the button label if it is ever renamed.
+
 ### Debug API Endpoint Switching
 
 In debug builds, the Teslamate API endpoint can be changed via ADB broadcast without opening the app. This is useful for switching between the real server and the mock server during testing.


### PR DESCRIPTION
## Why

Google Play rejected 1.11.0 for not providing "an active demo/guest account". The screenshot
they attached shows the reviewer sitting on the **Connection** onboarding screen with
*Test Connection* and *Save & Continue* greyed out — they had no Teslamate server to type in,
so they could not get past the wall, and no credential we could have sent them would have
changed that.

The original plan was a public fake server on the homelab, but `*.canferalv.xyz` resolves to
`192.168.1.53` (RFC1918) — it is LAN-only, and Traefik gets its certs over DNS-01, so nothing
there is reachable from outside. Google also require the credentials be "accessible at all
times... regardless of user location", which a residential dynamic IP is a poor fit for.

So: no server. The app carries its own sample data.

## What

A **Try the demo** button on the first-run connection screen, backed by an in-process
`TeslamateApi` implementation serving a simulated year of history. Also a real feature —
people can now evaluate the app before deciding whether Teslamate is worth setting up.

| File | Role |
|---|---|
| `data/demo/DemoMode.kt` | The `demo://matedroid` sentinel stored as the server URL |
| `data/demo/DemoGeography.kt` | Route polylines through real places, and the charger sites |
| `data/demo/DemoDataSet.kt` | Generates the history, serves the live status |
| `data/demo/DemoTeslamateApi.kt` | `TeslamateApi` answering from the dataset |

### Design notes

**Injected at `TeslamateApiFactory.create()`**, which every caller already goes through, so
every screen, worker, widget and notification path runs exactly the code it runs against a
real server — including query parameters, pagination, and the "no active charge" reply that
is a 200 with an `error` field rather than a failure.

**`isDemoMode` derives from the server URL** rather than being stored separately, so the two
can never disagree. The sentinel is non-blank, so every existing "is the app configured?"
gate treats demo mode as configured with no extra condition.

**The dataset is generated against the current date, not shipped as a fixture.** A bundled
dataset would be visibly stale the first time someone opened the demo a year after the
release containing it, and every "last 30 days" filter would come back empty.

**It is a simulation, not random rows.** One running state-of-charge and one running odometer
carry through the whole year; drives spend energy that charges put back. That is what keeps
the derived screens honest — battery levels line up end to end between consecutive drives,
the odometer only increases, and charge costs follow from the energy delivered.

A year of Girona-based driving: the Barcelona commute, the Costa Brava, and border runs to
Perpignan and Andorra — those exist so Visited Countries has something to show. Home AC
charging, Supercharger DC stops with a real taper curve, and a live session on a four-hour
wall-clock cycle so both "charging" and "parked at its limit" are reachable.

Metric only, deliberately: TeslamateAPI converts server-side and the app never converts, so
the demo does what a metric Teslamate would. Following the device locale would mean
converting every distance, speed, temperature, pressure and consumption figure at generation
time, and one missed field is a wrong number on screen.

Geocoding is *not* faked — the coordinates are real places and go through Nominatim like any
other data, which is what fills in Visited Countries.

## Verified on device

Installed on the Samsung J3 (Android 9 / **API 28, the minimum supported**), data wiped:

- Demo card renders at the top of the onboarding screen, above the fold, where the reviewer
  was stuck
- Dashboard: Ultra Red Model Y with the matching palette, **Demo** badge beside the car name,
  live AC charge (60%, 11 kW, 3φ, 233 V, +11.2 kWh, 1h20 to full), map on Girona
- Stats for Nerds: 585 drives, 281 driving days, ~30,500 km, 5.0 MWh, year filter offering
  2026 and 2025, and **3 countries visited** — the Nominatim geocoding resolved ES/FR/AD

## Tests

`DemoDataSetTest` (15 cases) covers the invariants the derived screens depend on: monotonic
odometer, each drive resuming where the last stopped, nothing dated in the future, AC and DC
both present, the trace matching the reported distance, and the live session appearing in
exactly one of `/charges` and `/charges/current`.

`./gradlew lintDebug` clean, full suite 154/154 green.

`./gradlew detekt` fails on 11 pre-existing unused imports — identical on `main`, untouched
here.

## Follow-ups (not in this PR)

- `CarColorPalettes.forExteriorColor()` has no entry for Glacier Blue or Marine Blue, so
  Juniper cars in those colours fall through to the default palette.
- Play Console text to paste is in `docs/DEVELOPMENT.md`.
