### PR TITLE
fix(ci): stop the Play upload discarding itself when a review is unresolved

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,3 +114,6 @@ jobs:
           status: completed
           releaseName: ${{ steps.version.outputs.name }}
           whatsNewDirectory: fastlane/metadata/android
+          # Same reason as in release.yml: without this, a commit made while the app has
+          # an unresolved review fails and takes the upload down with it.
+          changesNotSentForReview: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,13 @@ jobs:
           track: ${{ steps.play-track.outputs.track }}
           status: completed
           whatsNewDirectory: fastlane/metadata/android
+          # Google refuses to auto-submit an edit for review while the app has an
+          # unresolved review or policy issue, and answers "Changes cannot be sent for
+          # review automatically" — which fails the commit and *discards the upload*, so
+          # the bundle never lands at all (this is what silently dropped v1.11.1). With
+          # this set, the bundle uploads and sits on the track awaiting a manual
+          # "Send for review" in the Play Console.
+          changesNotSentForReview: true
 
       - name: Assign to track (if bundle already uploaded)
         if: steps.play-upload.outcome == 'failure'
@@ -209,6 +216,8 @@ jobs:
                   'status': 'completed'
               }]}
           ).execute()
-          service.edits().commit(packageName=pkg, editId=edit_id).execute()
+          service.edits().commit(
+              packageName=pkg, editId=edit_id, changesNotSentForReview=True
+          ).execute()
           print(f'Assigned version code {version_code} to {track} track')
           PYEOF


### PR DESCRIPTION
## What happened to v1.11.1

The release built fine and the GitHub release published, but nothing reached Play Console.
From the `publish-play` job log of [run 33305386895](https://github.com/vide/matedroid/actions/runs/33305386895):

```
Uploading release/app-release.aab
Successfully uploaded 1 artifacts
Committing the Edit
##[error]Changes cannot be sent for review automatically. Please set the query parameter
changesNotSentForReview to true.
```

The upload itself worked; the **edit commit** failed, which discards the edit and the upload
with it. The `Assign to track (if bundle already uploaded)` fallback then confirmed the
bundle was gone:

```
HttpError 404 ... "The following APK version codes could not be found: [178808391]."
```

Google refuses to auto-submit an edit for review while the app has an unresolved review or
policy issue — precisely the state the 1.11.0 rejection left the app in. So the release that
was meant to *answer* the rejection was blocked *by* it.

## Fix

Set `changesNotSentForReview: true` on the upload step, and pass the same flag on the
fallback path's own `edits().commit()`. The bundle then uploads and sits on the track
awaiting a manual **Send for review** in the Play Console.

Applied to `nightly.yml` too — the alpha channel has the identical one-line defect and would
break the same silent way.

## Trade-off

Releases are no longer auto-submitted for review; someone has to press **Send for review**
in the console. That is the cost of the upload being durable, and it is the only setting
that works at all while a review is outstanding. Worth keeping permanently rather than
flipping back once the policy issue clears — the failure mode it prevents is silent.

## Note

This does not retroactively publish 1.11.1; that bundle was never persisted. The signed AAB
is still recoverable from the run's `release-outputs` artifact (expires 2026-11-28) and can
be uploaded by hand, or a fresh tag will now go through cleanly.