### PR TITLE
docs: correct the Play Console Sign in details guidance

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -415,31 +415,30 @@ to about a dozen lookups.
 moves forward, each drive resumes where the last one stopped, nothing is dated in the future,
 and the live session appears in exactly one of `/charges` and `/charges/current`.
 
-#### What to put in Play Console → App access
+#### What to declare in Play Console → Sign in details
 
 Google rejected 1.11.0 for not providing "an active demo/guest account", having got stuck on
-the connection screen with nothing to type into it. Demo mode is the answer, but the reviewer
-still has to be told the button exists.
+the connection screen with nothing to type into it. Demo mode is the answer.
 
-**Where:** Play Console → the app → **Policy and programmes → App content → App access →
-Manage** (some Console layouts shorten the sidebar entry to **Policy → App content**). This is
-an app-level declaration, set once — it is *not* part of the "Create new release" flow, and
-nothing prompts you for it while publishing.
+**Where:** Play Console → the app → **Policy and programmes → App content → Sign in details**
+(previously called "App access"). This is an app-level declaration, set once — it is *not*
+part of the "Create new release" flow, and nothing prompts you for it while publishing.
 
-**Which option:** the page offers two, and they are mutually exclusive:
+**What to answer: No.**
 
-- *All functionality is available without special access* — accurate now that demo mode
-  exists, and it removes the credential demand at its root. But it gives you **no text field
-  at all**, so the reviewer is told nothing and may get stuck on the connection screen exactly
-  as before.
-- *All or some functionality is restricted* → **Add new instructions** — gives a flow name,
-  username, password and an "Any other instructions" free-text box. The free text is the only
-  durable channel to a reviewer; replying to a rejection only reaches the reviewer handling
-  that one submission.
+The question is "Is any part of your app restricted?", and **Yes** is defined by an explicit
+enumeration — account sign in details, payments, referral or QR codes, one-time PINs or
+2-step verification, biometric authentication, actions carried out on another device.
+MateDroid has none of them. **No** covers "no account sign in required in any country /
+region", which is simply true: there is no login, no account and no backend of ours.
 
-Prefer the **restricted** option, for the durability. The username and password fields are not
-applicable here — say so in them rather than inventing credentials — and put the real content
-in "Any other instructions":
+Do **not** answer Yes in the hope of reaching its free-text instructions box. Yes obliges you
+to supply credentials that must be valid and reusable, and there are none to supply —
+entering "n/a" or similar reads as invalid credentials, which is precisely what got 1.11.0
+rejected.
+
+Answering No means there is no field in which to tell a reviewer about the demo button, so
+that has to travel in the reply to a rejection or appeal. Keep this text to hand for that:
 
 > MateDroid has no login, user accounts or authentication of any kind, so there are no
 > credentials to supply. It is a read-only viewer for Teslamate, an open-source vehicle-data
@@ -452,8 +451,12 @@ in "Any other instructions":
 > A full year of sample vehicle data loads and every feature becomes reachable. No
 > credentials, no access to a private server and no configuration are required.
 
-Keep that text in step with the button label if it is ever renamed — the label is
-`settings_demo_action` in `res/values/strings.xml`.
+This is the reason the demo offer sits directly under the page description on the connection
+screen, above the first field, rather than next to the buttons at the bottom: with no
+reviewer-instructions field anywhere in the Console, being visible without scrolling is the
+only thing that reliably gets a reviewer past onboarding. Keep the text above in step with
+the button label if it is ever renamed — the label is `settings_demo_action` in
+`res/values/strings.xml`.
 
 ### Debug API Endpoint Switching
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -419,21 +419,41 @@ and the live session appears in exactly one of `/charges` and `/charges/current`
 
 Google rejected 1.11.0 for not providing "an active demo/guest account", having got stuck on
 the connection screen with nothing to type into it. Demo mode is the answer, but the reviewer
-still has to be told the button exists. Under **App content → App access**, choose
-**All functionality is available without special access** and paste:
+still has to be told the button exists.
 
-> MateDroid reads data from the user's own self-hosted Teslamate server, so there is no
-> account, login or password of any kind — nothing is transmitted to us and there is nothing
-> to sign in to.
->
-> To review the app without a server, use the built-in demo:
-> 1. Launch the app. The first screen is "Connection".
-> 2. Tap "Try the demo" in the card at the top of that screen.
->
-> The app then loads a year of sample vehicle data and every feature is reachable. No
-> credentials, network access to a private server, or configuration are required.
+**Where:** Play Console → the app → **Policy and programmes → App content → App access →
+Manage** (some Console layouts shorten the sidebar entry to **Policy → App content**). This is
+an app-level declaration, set once — it is *not* part of the "Create new release" flow, and
+nothing prompts you for it while publishing.
 
-Keep that text in step with the button label if it is ever renamed.
+**Which option:** the page offers two, and they are mutually exclusive:
+
+- *All functionality is available without special access* — accurate now that demo mode
+  exists, and it removes the credential demand at its root. But it gives you **no text field
+  at all**, so the reviewer is told nothing and may get stuck on the connection screen exactly
+  as before.
+- *All or some functionality is restricted* → **Add new instructions** — gives a flow name,
+  username, password and an "Any other instructions" free-text box. The free text is the only
+  durable channel to a reviewer; replying to a rejection only reaches the reviewer handling
+  that one submission.
+
+Prefer the **restricted** option, for the durability. The username and password fields are not
+applicable here — say so in them rather than inventing credentials — and put the real content
+in "Any other instructions":
+
+> MateDroid has no login, user accounts or authentication of any kind, so there are no
+> credentials to supply. It is a read-only viewer for Teslamate, an open-source vehicle-data
+> logger that users install on their own hardware, and no data reaches us.
+>
+> To reach the app's full functionality without a server:
+> 1. Launch the app. The first screen is titled "Connection".
+> 2. Tap "Try the demo" in the card near the top of that screen.
+>
+> A full year of sample vehicle data loads and every feature becomes reachable. No
+> credentials, no access to a private server and no configuration are required.
+
+Keep that text in step with the button label if it is ever renamed — the label is
+`settings_demo_action` in `res/values/strings.xml`.
 
 ### Debug API Endpoint Switching
 


### PR DESCRIPTION
The App access guidance added alongside demo mode was wrong twice over, and either error would cost a review cycle.

**First revision** said to choose *All functionality is available without special access* **and** paste reviewer instructions. Choosing that option presents no text field.

**Second revision** (this PR's first commit) then recommended declaring the app *restricted* to reach the free-text box. Also wrong: the section is now called **Sign in details**, and its Yes branch is an explicit enumeration — account sign in details, payments, referral or QR codes, one-time PINs or 2SV, biometric authentication, actions on another device. MateDroid has none of them. Worse, Yes obliges you to supply credentials that must be valid and reusable; entering `n/a` reads as invalid credentials, which is exactly what got 1.11.0 rejected.

Now says **answer No**, with the reasoning.

For the record, `No` was already what the console had set when 1.11.0 was rejected — so this declaration was never the cause. The reviewer simply could not get past the connection screen and fell back to the boilerplate credentials template. That is worth knowing, because it means the Console offers *no* field anywhere for telling a reviewer how to reach the app: the demo steps can only travel in the reply to a rejection, and the demo card's placement above the fold on the connection screen is the only thing that reliably works unprompted. The section now records both.
