### PR TITLE
ci: auto-submit releases again, without the silent data loss

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,6 +114,29 @@ jobs:
           status: completed
           releaseName: ${{ steps.version.outputs.name }}
           whatsNewDirectory: fastlane/metadata/android
-          # Same reason as in release.yml: without this, a commit made while the app has
-          # an unresolved review fails and takes the upload down with it.
+          # Auto-submit, so a nightly needs no attention at all.
+          changesNotSentForReview: false
+
+      # Same fallback as release.yml: if Google will not accept the review automatically,
+      # a failed commit discards the upload along with it. Re-upload with the flag set so
+      # the build at least lands on the alpha track.
+      - name: Re-upload without auto-submit (Google blocked the review)
+        id: play-upload-deferred
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        if: env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != '' && steps.play-upload.outcome == 'failure'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.matedroid
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: alpha
+          status: completed
+          releaseName: ${{ steps.version.outputs.name }}
+          whatsNewDirectory: fastlane/metadata/android
           changesNotSentForReview: true
+
+      - name: Warn if the nightly needs a manual "Send for review"
+        if: always() && steps.play-upload-deferred.outcome == 'success'
+        run: |
+          echo "::warning::Nightly uploaded without auto-submit. Press 'Send for review' in Play Console."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,6 @@ jobs:
         run: |
           VERSION_CODE=$(grep 'versionCode' app/build.gradle.kts | sed 's/[^0-9]*//g')
           echo "code=$VERSION_CODE" >> $GITHUB_OUTPUT
-
       - name: Upload to Google Play
         id: play-upload
         continue-on-error: true
@@ -173,28 +172,44 @@ jobs:
           track: ${{ steps.play-track.outputs.track }}
           status: completed
           whatsNewDirectory: fastlane/metadata/android
-          # Google refuses to auto-submit an edit for review while the app has an
-          # unresolved review or policy issue, and answers "Changes cannot be sent for
-          # review automatically" — which fails the commit and *discards the upload*, so
-          # the bundle never lands at all (this is what silently dropped v1.11.1). With
-          # this set, the bundle uploads and sits on the track awaiting a manual
-          # "Send for review" in the Play Console.
+          # The happy path: commit the edit *and* send it for review, so cutting a tag is
+          # the only manual step in a release.
+          changesNotSentForReview: false
+
+      # Google refuses to auto-submit while the app has an unresolved review or policy
+      # issue, answering "Changes cannot be sent for review automatically". That fails the
+      # commit, and a failed commit discards the edit *including the upload* — which is how
+      # v1.11.1 vanished without a trace. Re-uploading with the flag set lands the bundle on
+      # the track, where it waits for a manual "Send for review". Degrading to one manual
+      # click beats losing the release.
+      - name: Re-upload without auto-submit (Google blocked the review)
+        id: play-upload-deferred
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        if: env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != '' && steps.play-upload.outcome == 'failure'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.matedroid
+          releaseFiles: release/app-release.aab
+          track: ${{ steps.play-track.outputs.track }}
+          status: completed
+          whatsNewDirectory: fastlane/metadata/android
           changesNotSentForReview: true
 
-      - name: Assign to track (if bundle already uploaded)
-        if: steps.play-upload.outcome == 'failure'
+      # A green upload step is not proof the bundle is there: the v1.11.1 upload reported
+      # "Successfully uploaded 1 artifacts" and then threw it away on commit. Ask Play what
+      # is actually on the track, and fail loudly if the answer is "nothing".
+      - name: Verify the bundle is on the track
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           TRACK: ${{ steps.play-track.outputs.track }}
           VERSION_CODE: ${{ steps.version.outputs.code }}
+        if: env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != ''
         run: |
-          if [ -z "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]; then
-            echo "No Google Play service account JSON found, skipping"
-            exit 0
-          fi
           pip install -q google-auth google-api-python-client
           python3 << 'PYEOF'
-          import json, os
+          import json, os, sys
           from google.oauth2 import service_account
           from googleapiclient.discovery import build
 
@@ -205,19 +220,43 @@ jobs:
           service = build('androidpublisher', 'v3', credentials=creds)
           pkg = 'com.matedroid'
           track = os.environ['TRACK']
-          version_code = os.environ['VERSION_CODE']
+          wanted = os.environ['VERSION_CODE']
 
-          edit = service.edits().insert(packageName=pkg).execute()
-          edit_id = edit['id']
-          service.edits().tracks().update(
-              packageName=pkg, editId=edit_id, track=track,
-              body={'track': track, 'releases': [{
-                  'versionCodes': [version_code],
-                  'status': 'completed'
-              }]}
-          ).execute()
-          service.edits().commit(
-              packageName=pkg, editId=edit_id, changesNotSentForReview=True
-          ).execute()
-          print(f'Assigned version code {version_code} to {track} track')
+          edit = service.edits().insert(packageName=pkg).execute()['id']
+          try:
+              info = service.edits().tracks().get(
+                  packageName=pkg, editId=edit, track=track
+              ).execute()
+          finally:
+              # Read-only check: never commit this edit.
+              service.edits().delete(packageName=pkg, editId=edit).execute()
+
+          found = {c for r in info.get('releases', []) for c in r.get('versionCodes', [])}
+          if wanted not in found:
+              sys.exit(
+                  f"Version code {wanted} is NOT on the '{track}' track "
+                  f"(found: {sorted(found) or 'nothing'}). The upload did not persist."
+              )
+          print(f"Verified: version code {wanted} is on the '{track}' track.")
           PYEOF
+
+      - name: Say whether a manual "Send for review" is needed
+        if: always() && env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != ''
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ "${{ steps.play-upload-deferred.outcome }}" = "success" ]; then
+            {
+              echo "### :warning: Manual step required"
+              echo
+              echo "Google would not accept the release for review automatically, which"
+              echo "normally means an unresolved review or policy issue on the app."
+              echo "The bundle **is** uploaded and on the \`${{ steps.play-track.outputs.track }}\` track,"
+              echo "but it will not go anywhere until you open Play Console and click"
+              echo "**Publishing overview → Send for review**."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Uploaded without auto-submit. Press 'Send for review' in Play Console."
+          elif [ "${{ steps.play-upload.outcome }}" = "success" ]; then
+            echo "### :white_check_mark: Submitted for review automatically" >> "$GITHUB_STEP_SUMMARY"
+            echo "No manual action needed." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -508,6 +508,25 @@ The `-n` flag (explicit component) is required on Android 14+ since implicit bro
 
 Releases are automated via GitHub Actions. When a release is published, the workflow builds the APK and attaches it to the release, and deploys to Google Play.
 
+**Publishing to Play, and the one way it can go wrong.** The upload normally commits the edit
+*and* sends it for review, so cutting a tag is the only manual step. But Google refuses to
+auto-submit while the app has an unresolved review or policy issue — it answers "Changes
+cannot be sent for review automatically", and because a failed commit discards the whole edit,
+the upload goes with it. That is how v1.11.2's predecessor vanished: the job logged
+"Successfully uploaded 1 artifacts" and left nothing behind.
+
+The workflow therefore does three things rather than one:
+
+1. Upload with `changesNotSentForReview: false` — auto-submit, no attention needed.
+2. If that fails, re-upload with `changesNotSentForReview: true`. The bundle lands on the
+   track and waits for **Publishing overview → Send for review** in the Console. Degrading to
+   one click beats losing the release.
+3. Ask the Play API what is actually on the track and fail if the version code isn't there —
+   a green upload step is not by itself proof that anything persisted.
+
+The job summary says which path ran, so "do I need to click anything?" is answered without
+reading logs.
+
 The recommended way to create releases is using the `/release` skill in Claude Code, which automates:
 1. Version bumping in `app/build.gradle.kts` (versionCode and versionName)
 2. Updating `CHANGELOG.md` with the release date


### PR DESCRIPTION
Restores automatic *Send for review* so that cutting a tag on GitHub is the only manual step of a release — nightlies included — without reinstating the failure that made us turn it off.

## The bind

Auto-submit (`changesNotSentForReview: false`) is what we want, but Google refuses it while the app has an unresolved review or policy issue. The refusal fails the *commit*, and a failed commit discards the entire edit — upload included. That is how v1.11.1 disappeared: the job logged `Successfully uploaded 1 artifacts`, went green on the upload step, and left nothing in Play Console.

Turning auto-submit off (#376) fixed the loss but made every release need a manual click, forever, to guard against a state that is rare.

## Instead of choosing

1. **Upload with auto-submit.** Normal case, zero attention.
2. **If that fails, re-upload with `changesNotSentForReview: true`.** The bundle lands on the track and waits for **Publishing overview → Send for review**. Degrading to one click beats losing the release.
3. **Verify.** Ask the Play API what is actually on the track and fail if the version code isn't there.

Step 3 matters independently: a green upload step was never proof the bundle persisted, and that is precisely what misled us for eight days.

The job summary states which path ran, so "do I need to click anything?" is answerable without reading logs.

## Also removed

The old `Assign to track (if bundle already uploaded)` fallback. It was written for a state that cannot occur — a discarded commit leaves no bundle to assign — so its only observed behaviour was a confusing `404 The following APK version codes could not be found`. The verification step replaces it.

## Applies from the next tag

Nothing changes for v1.11.2, which is already uploaded and submitted. Safe to merge now regardless of where that review stands: if a release were cut while an issue is still open, step 1 fails, step 2 lands the bundle, and the summary says so — which is exactly the intended behaviour rather than a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
