### PR TITLE
ci: refresh README screenshots on a hosted emulator

### DIFF
--- a/.github/scripts/capture-screenshots.sh
+++ b/.github/scripts/capture-screenshots.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# CI wrapper around scripts/screenshots.sh for the Screenshots workflow.
+#
+# The emulator-runner action executes its `script` input line by line with /bin/sh, so the
+# retry and the logcat dump live here instead. Environment:
+#   SCREENS           optional comma-separated spec ids (workflow input)
+#   SCREENSHOT_CLOCK  optional ISO-8601 instant (workflow input; empty = script default)
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+args=()
+if [ -n "${SCREENS:-}" ]; then
+    args+=(--screens "$SCREENS")
+fi
+
+if ./scripts/screenshots.sh "${args[@]}"; then
+    exit 0
+fi
+echo "::warning::Capture failed, retrying once"
+if ./scripts/screenshots.sh "${args[@]}"; then
+    exit 0
+fi
+adb logcat -d > logcat.txt || true
+exit 1

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -89,7 +89,9 @@ jobs:
           force-avd-creation: false
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
           disable-animations: false
-          script: echo "AVD snapshot generated"
+          # The cold boot under software rendering tends to raise "isn't responding" dialogs
+          # for the launcher; make sure the saved snapshot will not raise new ones.
+          script: adb shell settings put global hide_error_dialogs 1
 
       # The action runs each script line with /bin/sh, hence the single-line call into a bash
       # helper that holds the retry and the logcat dump.

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -91,9 +91,12 @@ jobs:
           disable-animations: false
           script: echo "AVD snapshot generated"
 
+      # The action runs each script line with /bin/sh, hence the single-line call into a bash
+      # helper that holds the retry and the logcat dump.
       - name: Capture screenshots
         uses: reactivecircus/android-emulator-runner@v2
         env:
+          SCREENS: ${{ inputs.screens }}
           # Empty means the script's default (today 09:00 UTC).
           SCREENSHOT_CLOCK: ${{ inputs.clock }}
         with:
@@ -104,14 +107,7 @@ jobs:
           force-avd-creation: false
           emulator-options: ${{ env.EMULATOR_OPTIONS }} -no-snapshot-save
           disable-animations: true
-          script: |
-            args=()
-            if [ -n "${{ inputs.screens }}" ]; then args+=(--screens "${{ inputs.screens }}"); fi
-            if ./scripts/screenshots.sh "${args[@]}"; then exit 0; fi
-            echo "::warning::Capture failed, retrying once"
-            if ./scripts/screenshots.sh "${args[@]}"; then exit 0; fi
-            adb logcat -d > logcat.txt || true
-            exit 1
+          script: bash .github/scripts/capture-screenshots.sh
 
       # The suite's output directory holds the images and, for failed screens, a hierarchy dump
       # and a raw frame: the first thing to read when a marker stops matching.

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,148 @@
+# Regenerates the README gallery from demo mode on a hosted emulator and opens a pull request
+# with the result. Run it by hand after a UI change; the PR shows the image diffs for review.
+#
+# The capture itself is scripts/screenshots.sh, the same entry point used locally, so this file
+# only provides the emulator and the PR. The google_apis image is rootable, which lets the script
+# pin the device clock and the demo clock together: a same-day re-run produces identical pixels.
+name: Screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      screens:
+        description: Comma-separated spec ids to capture (empty = all, see ScreenshotSpecs.kt)
+        required: false
+        default: ""
+      clock:
+        description: ISO-8601 instant to pin the clocks to (empty = today 09:00 UTC, a charging phase)
+        required: false
+        default: ""
+      dry_run:
+        description: Capture and upload artifacts only, no pull request
+        type: boolean
+        default: false
+  # TEMP: validation runs on the PR branch, removed before merge.
+  push:
+    branches: [feat/screenshots-workflow]
+
+# One refresh at a time; a second dispatch queues behind the first.
+concurrency:
+  group: screenshots
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  API_LEVEL: 35
+  TARGET: google_apis
+  ARCH: x86_64
+  # 1080x2400 at 420 dpi, the same geometry as the local AVD the first gallery came from.
+  PROFILE: pixel_6
+  EMULATOR_OPTIONS: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -timezone Europe/Madrid
+
+jobs:
+  capture:
+    name: Capture demo-mode screenshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Hosted Linux runners have KVM; without this rule the emulator falls back to software
+      # virtualisation and never boots in time.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache AVD
+        id: avd-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}-${{ env.TARGET }}-${{ env.ARCH }}-${{ env.PROFILE }}-v1
+
+      # Cold boot once and save a snapshot; later runs restore it in seconds.
+      - name: Create AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.TARGET }}
+          arch: ${{ env.ARCH }}
+          profile: ${{ env.PROFILE }}
+          force-avd-creation: false
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
+          disable-animations: false
+          script: echo "AVD snapshot generated"
+
+      - name: Capture screenshots
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          # Empty means the script's default (today 09:00 UTC).
+          SCREENSHOT_CLOCK: ${{ inputs.clock }}
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.TARGET }}
+          arch: ${{ env.ARCH }}
+          profile: ${{ env.PROFILE }}
+          force-avd-creation: false
+          emulator-options: ${{ env.EMULATOR_OPTIONS }} -no-snapshot-save
+          disable-animations: true
+          script: |
+            args=()
+            if [ -n "${{ inputs.screens }}" ]; then args+=(--screens "${{ inputs.screens }}"); fi
+            if ./scripts/screenshots.sh "${args[@]}"; then exit 0; fi
+            echo "::warning::Capture failed, retrying once"
+            if ./scripts/screenshots.sh "${args[@]}"; then exit 0; fi
+            adb logcat -d > logcat.txt || true
+            exit 1
+
+      # The suite's output directory holds the images and, for failed screens, a hierarchy dump
+      # and a raw frame: the first thing to read when a marker stops matching.
+      - name: Upload capture output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-output
+          if-no-files-found: ignore
+          path: |
+            app/build/outputs/connected_android_test_additional_output/
+            app/build/reports/androidTests/
+            logcat.txt
+
+      - name: Open pull request
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          branch: chore/refresh-screenshots
+          delete-branch: true
+          add-paths: |
+            docs/screenshots/*.jpg
+            README.md
+          commit-message: |
+            docs: refresh screenshots from demo mode
+
+            Captured by the Screenshots workflow, run ${{ github.run_id }}.
+          title: "docs: refresh screenshots from demo mode"
+          body: |
+            Gallery images regenerated from demo mode on a hosted emulator by
+            [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Review the image diffs and merge if they look right. A run that changed nothing opens no PR.

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -21,9 +21,6 @@ on:
         description: Capture and upload artifacts only, no pull request
         type: boolean
         default: false
-  # TEMP: validation runs on the PR branch, removed before merge.
-  push:
-    branches: [feat/screenshots-workflow]
 
 # One refresh at a time; a second dispatch queues behind the first.
 concurrency:

--- a/app/src/androidTest/java/com/matedroid/screenshots/ScreenshotsTest.kt
+++ b/app/src/androidTest/java/com/matedroid/screenshots/ScreenshotsTest.kt
@@ -9,6 +9,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
@@ -90,6 +91,7 @@ class ScreenshotsTest(private val spec: ScreenshotSpec) {
         device.executeShellCommand("wm dismiss-keyguard")
         device.executeShellCommand("svc power stayon true")
         device.waitForIdle()
+        dismissSystemDialogs()
     }
 
     @Test
@@ -132,6 +134,7 @@ class ScreenshotsTest(private val spec: ScreenshotSpec) {
         val deadline = SystemClock.uptimeMillis() + timeoutMs
         while (SystemClock.uptimeMillis() < deadline) {
             if (selectors.any { device.hasObject(it) }) return
+            dismissSystemDialogs()
             SystemClock.sleep(POLL_MS)
         }
         error("$spec: none of ${selectors.size} ready marker(s) appeared within ${timeoutMs / 1000}s")
@@ -164,6 +167,7 @@ class ScreenshotsTest(private val spec: ScreenshotSpec) {
     private fun tapFirstRow(selector: BySelector) {
         var row: UiObject2? = null
         for (attempt in 0..MAX_SCROLLS) {
+            dismissSystemDialogs()
             device.wait(Until.hasObject(selector), spec.timeoutMs / (MAX_SCROLLS + 1))
             row = device.findObjects(selector).firstOrNull()
             if (row != null) break
@@ -178,6 +182,23 @@ class ScreenshotsTest(private val spec: ScreenshotSpec) {
         val h = device.displayHeight
         device.swipe(w / 2, h * 3 / 4, w / 2, h / 4, SWIPE_STEPS)
         device.waitForIdle()
+    }
+
+    /**
+     * Taps away an "isn't responding" or "keeps stopping" dialog if one is up. A software-rendered
+     * emulator under load raises them for the launcher or System UI, and while such a dialog is
+     * showing the app's window is not in the accessibility tree at all, so no marker can match.
+     * Matched by the system's button ids, which do not depend on the device locale. "Wait" is
+     * preferred so the stalled process is kept; "Close" is the fallback for crash dialogs.
+     */
+    private fun dismissSystemDialogs() {
+        for (id in SYSTEM_DIALOG_BUTTONS) {
+            val button = device.findObject(By.res(id)) ?: continue
+            Log.w(TAG, "$spec: dismissing system error dialog via $id")
+            button.click()
+            device.waitForIdle()
+            return
+        }
     }
 
     /**
@@ -243,6 +264,7 @@ class ScreenshotsTest(private val spec: ScreenshotSpec) {
         private const val DEFAULT_WIDTH = 576
         private const val JPEG_QUALITY = 85
         private const val POLL_MS = 500L
+        private val SYSTEM_DIALOG_BUTTONS = listOf("android:id/aerr_wait", "android:id/aerr_close")
         private const val STABLE_INTERVAL_MS = 5_000L
         private const val MAX_SCROLLS = 3
         private const val SWIPE_STEPS = 20

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -547,7 +547,17 @@ the screen has loaded. List screens hand over to their detail screens with `tapF
 taps the first clickable row; Visited Countries uses `waitStable` because its rows arrive one
 Nominatim answer at a time.
 
-The canonical images come from the CI emulator; a local run against a phone is a preview, and
+**CI.** The `Screenshots` workflow (`.github/workflows/screenshots.yml`, run by hand from the
+Actions tab or with `gh workflow run screenshots.yml`) boots a headless API 35 `google_apis`
+emulator on a hosted runner, runs the same script, and opens a pull request on
+`chore/refresh-screenshots` with the changed images and README. That image is rootable, so both
+clocks are pinned there and a same-day re-run is pixel-identical. Inputs: `screens` (subset),
+`clock` (override the pinned instant), `dry_run` (artifacts only). Every run uploads the suite's
+output directory as an artifact, which on failure contains a hierarchy dump and a raw frame per
+failed screen. The PR is opened with the workflow token, so CI does not run on it, and the
+repository setting *Allow GitHub Actions to create and approve pull requests* must stay on.
+
+The canonical images come from that workflow; a local run against a phone is a preview, and
 its content-area height differs by a few dozen pixels because of the phone's own bars.
 
 ### Remote builds on the homelab cluster


### PR DESCRIPTION
## What this does

PR 2 of the screenshot plan, stacked on #381. Adds the **Screenshots** GitHub Actions workflow: run it by hand after a UI change and it boots a headless emulator on a hosted runner, captures the gallery from demo mode with the suite from #381, and opens a pull request on `chore/refresh-screenshots` with the changed images and README block. No PR is opened when nothing changed.

## How it works

- `workflow_dispatch` with inputs `screens` (subset of spec ids), `clock` (override the pinned instant) and `dry_run` (artifacts only). One run at a time via a concurrency group.
- KVM enabled on the runner, API 35 `google_apis` x86_64 on the `pixel_6` profile (1080×2400 at 420 dpi, the geometry the current gallery came from), software GPU, `Europe/Madrid` timezone, animations off. The AVD snapshot is cached between runs; the first run also sets `hide_error_dialogs` before the snapshot is saved.
- The capture is `scripts/screenshots.sh`, the same entry point as locally, called through `.github/scripts/capture-screenshots.sh` (the emulator-runner action executes each `script` line with `/bin/sh`, so the retry and the logcat dump live in a bash helper). The `google_apis` image is rootable, so the script pins device clock and demo clock together and a same-day re-run is pixel-identical.
- Every run uploads the suite's output directory as an artifact: the images, and for failed screens a hierarchy dump and a raw frame, plus `logcat.txt` when both attempts fail.
- `peter-evans/create-pull-request` opens the PR with the workflow token. That means CI does not run on the refresh PR (only images and README change) and the repository setting *Allow GitHub Actions to create and approve pull requests* must be on. I enabled it.

## Found and fixed while validating on the branch

- The launcher raised an "isn't responding" dialog during the cold boot that produced the AVD snapshot. While such a dialog is up the app's window is absent from the accessibility tree, so every marker timed out. The suite now dismisses ANR and crash dialogs (by the system's button ids, locale-independent) before and during each wait.

## Validation

Three validation runs on this branch (temporary `push` trigger):

| Run | Outcome | Cause |
|---|---|---|
| [1](https://github.com/vide/matedroid/actions/runs/34461795727) | failed in 2 min | bash syntax in a `/bin/sh` script line |
| [2](https://github.com/vide/matedroid/actions/runs/34462144434) | failed in 28 min | launcher ANR dialog hid the app window from UiAutomator |
| [3](https://github.com/vide/matedroid/actions/runs/34465076867) | **green in 8m45s**, 11/11 captured | compile ~5 min, capture 85 s, both clocks pinned |

The images from run 3 are in its `screenshots-output` artifact; they are not committed here because the PR step is skipped on branch runs. The first `workflow_dispatch` after merge will open the refresh PR.

The temporary `push` trigger used for validation has been removed; only `workflow_dispatch` remains. First real dispatch after merge will exercise the PR-opening step, which the branch runs skipped by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
